### PR TITLE
GDB file server remote file patch

### DIFF
--- a/dbd/tt_gdb_file_server.py
+++ b/dbd/tt_gdb_file_server.py
@@ -1,64 +1,59 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+import io
 import os
 from typing import Set
 
 class GdbFileServer:
     def __init__(self, context):
-        self.opened_files: Set[int] = set()
+        self.opened_files: dict[int, io.BytesIO] = dict()
         self._context = context
+        self.count = 0
 
     def __del__(self):
         self.close_all()
 
     def close_all(self):
         # Close all opened files
-        for fd in self.opened_files:
-            try:
-                os.close(fd)
-            except:
-                # Ignore exceptions
-                pass
         self.opened_files.clear()
+        self.count = 0
 
     def open(self, filename: str, flags: int, mode: int):
         try:
-            if not os.path.exists(filename):
-                content = self._context.server_ifc.get_binary(filename)
-                filename = self._context.server_ifc.save_tmp_file(filename, content)
-            fd = os.open(filename, flags, mode)
-            self.opened_files.add(fd)
-            return fd
+            content = self._context.server_ifc.get_binary(filename)
+            id = self.count
+
+            self.opened_files[id] = io.BytesIO(content)
+            self.count += 1
+            return id
         except OSError as e:
             return f"-1,{e.errno}"
 
     def close(self, fd: int):
-        if fd in self.opened_files:
-            try:
-                os.close(fd)
-                self.opened_files.remove(fd)
-                return True
-            except:
-                pass
+        if fd in self.opened_files.keys():
+            del self.opened_files[fd]
+            return True
         return False
 
     def pread(self, fd: int, count: int, offset: int):
         if fd in self.opened_files:
+            stream = self.opened_files[fd]
             try:
-                os.lseek(fd, offset, os.SEEK_SET)
-                return os.read(fd, count)
-            except OSError as e:
-                return f"-1,{e.errno}"
+                stream.seek(offset, os.SEEK_SET)
+                return stream.read(count)
+            except:
+                return "-2, Exception while reading."
         else:
             return "-1"
 
     def pwrite(self, fd: int, offset: int, data: bytes):
         if fd in self.opened_files:
+            stream = self.opened_files[fd]
             try:
-                os.lseek(fd, offset, os.SEEK_SET)
-                return os.write(fd, data)
-            except OSError as e:
-                return f"-1,{e.errno}"
+                stream.seek(offset, os.SEEK_SET)
+                return stream.write(data)
+            except:
+                return "-2,Error while writing."
         else:
             return "-1"


### PR DESCRIPTION
- gdb file server now uses debuda_ifc class to obtain files
- instead of file handle, an in-memory cache store is used, with integer keys serving the role of OS handles

