### PR TITLE
Log error reason if create-ethernet-map fails

### DIFF
--- a/dbd/server/lib/src/umd_with_open_implementation.cpp
+++ b/dbd/server/lib/src/umd_with_open_implementation.cpp
@@ -123,7 +123,7 @@ static std::string create_temp_network_descriptor_file(tt::ARCH arch, std::files
 
             // Try calling create-ethernet-map
             if (!std::system(
-                    (create_ethernet_map + " " + cluster_descriptor_path +" >" + create_ethernet_map_log + " 2>&1")
+                    (create_ethernet_map + " " + cluster_descriptor_path + " >" + create_ethernet_map_log + " 2>&1")
                         .c_str())) {
                 return cluster_descriptor_path;
             }


### PR DESCRIPTION
Logging all create-ethernet-map error massages to temporary error log file. If create-ethernet-map fails, instead of just calling 
```throw std::runtime_error("Call to create-ethernet-map failed. Fallback not implemented...");```, additional error information is  added to exception.