### PR TITLE
Extending test verify_device to support for more devices

### DIFF
--- a/test/app/test_umd_debuda.py
+++ b/test/app/test_umd_debuda.py
@@ -52,6 +52,8 @@ class UmdDbdOutputVerifier(DbdOutputVerifier):
 
         for line in lines:
             # Check if the line matches the current test regex
+            # Last test regex is a special case, as there may be multiple lines that match it
+            # depending on number of devices
             if re.search(test_regex[id], line):
                 if id < num_test_regex - 1:
                     id += 1


### PR DESCRIPTION
If we have more than one device, startup output will have multiple lines 'Opened device:' which will trigger out of bounds error when accessing test_regex list.