### PR TITLE
Fix for Debuda --server does not work without debuda context #93

### DIFF
--- a/dbd/debuda_commands/dram-queue-summary.py
+++ b/dbd/debuda_commands/dram-queue-summary.py
@@ -23,7 +23,7 @@ command_metadata = {
     "short": "dq",
     "type": "high-level",
     "description": __doc__,
-    "context": ["limited", "buda", "metal"],
+    "context": ["buda"],
 }
 
 

--- a/debuda.py
+++ b/debuda.py
@@ -481,7 +481,7 @@ def main():
     # Try to start the server. If already running, exit with error.
     if args["--server"]:
         print(f"Starting Debuda server at {args['--port']}")
-        runtime_data_yaml_filename = tt_debuda_init.find_runtime_data_yaml_filename(output_dir)
+        runtime_data_yaml_filename = tt_debuda_init.find_runtime_data_yaml_filename(output_dir) if output_dir else None
         debuda_server = tt_debuda_server.start_server(
             args["--port"],
             runtime_data_yaml_filename,


### PR DESCRIPTION
If runtime_data.yaml file does not exist, find_runtime_data_yaml_filename is throwing exception. Added check whether output dir exists, before calling function. 

Additionally, removed dram_queue_summary.py from metal/limited context