### PR TITLE
Installing gdb that supports clang-17

### DIFF
--- a/.github/Dockerfile.debuda
+++ b/.github/Dockerfile.debuda
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
 	libboost-all-dev \
 	libhwloc-dev \
 	libzmq3-dev \
+    sudo \
     wget \
 	xxd 
 

--- a/.github/Dockerfile.debuda-ird
+++ b/.github/Dockerfile.debuda-ird
@@ -6,11 +6,22 @@ SHELL ["/bin/bash", "-c"]
 
 # Set environment variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV TT_LENS_INFRA_DIR=/opt/tt_lens_infra
+
+# Create directories for infra
+RUN mkdir -p ${TT_LENS_INFRA_DIR}
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
 	docker \
-	gdb \
     ssh \
-    sudo \
     vim
+
+# Install compatible gdb debugger for clang-17
+RUN cd $TT_LENS_INFRA_DIR \
+    && wget https://ftp.gnu.org/gnu/gdb/gdb-14.2.tar.gz \
+    && tar -xvf gdb-14.2.tar.gz \
+    && cd gdb-14.2 \
+    && ./configure \
+    && make -j$(nproc)
+ENV PATH="$TT_LENS_INFRA_DIR/gdb-14.2/gdb:$PATH"


### PR DESCRIPTION
Current gdb is slow when working with clang-17. Installing new version that works better with clang-17