### PR TITLE
Adding -ldl when compiling ttlens_server_lib

### DIFF
--- a/ttlens/server/lib/CMakeLists.txt
+++ b/ttlens/server/lib/CMakeLists.txt
@@ -38,7 +38,7 @@ file(GLOB TTLENS_SERVER_LIB_SRCS "src/*.cpp")
 add_library(ttlens_server_lib STATIC ${TTLENS_SERVER_LIB_SRCS})
 add_dependencies(ttlens_server_lib generate_embed_files)
 target_link_libraries(ttlens_server_lib 
-    PUBLIC umd::device fmt cppzmq-static
+    PUBLIC umd::device fmt cppzmq-static dl
 )
 target_include_directories(ttlens_server_lib PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/inc


### PR DESCRIPTION
New version of UMD made nng and uv link statically and it somehow triggered problem with our build on Ubuntu 20.04. Hopefully this fix the problem...