### PR TITLE
Fixing JTAG harvesting

### DIFF
--- a/ttlens/server/lib/inc/ttlensserver/jtag_device.h
+++ b/ttlens/server/lib/inc/ttlensserver/jtag_device.h
@@ -18,7 +18,6 @@ class JtagDevice {
 
     std::optional<uint32_t> get_device_cnt() const;
     std::optional<uint32_t> get_efuse_harvesting(uint8_t chip_id) const;
-    std::optional<uint32_t> get_device_harvesting(uint8_t chip_id) const;
 
     std::optional<tt::ARCH> get_jtag_arch(uint8_t chip_id);
 
@@ -47,7 +46,6 @@ class JtagDevice {
     std::unique_ptr<Jtag> jtag;
     std::vector<uint32_t> jlink_devices;
     std::vector<uint32_t> efuse_harvesting;
-    std::vector<uint32_t> device_harvesting;
     uint8_t curr_device_idx = -1;
 };
 

--- a/ttlens/server/lib/src/jtag_device.cpp
+++ b/ttlens/server/lib/src/jtag_device.cpp
@@ -49,19 +49,6 @@ JtagDevice::JtagDevice(std::unique_ptr<Jtag> jtag_device) : jtag(std::move(jtag_
          * format */
         efuse_harvesting.push_back(bad_row_bits);
 
-        uint32_t mapping_idx[ROW_LEN] = {0, 2, 4, 6, 8, 10, 11, 9, 7, 5, 3, 1};
-        uint32_t x = 0;
-        for (int i = 0; i < ROW_LEN; i++) {
-            if ((bad_row_bits << 1) & (1 << mapping_idx[i])) {
-                x |= (1 << i);
-            }
-        }
-
-        /* device_harvesting is the remapped harvesting value, where the bits are
-         * remapped to the sequential order of rows, and it is used for
-         * harvesting info passed as CEM output */
-        device_harvesting.push_back(x);
-
         jtag->close_jlink();
     }
     if (jlink_devices.empty()) {
@@ -86,14 +73,6 @@ std::optional<uint32_t> JtagDevice::get_efuse_harvesting(uint8_t chip_id) const 
     }
 
     return efuse_harvesting[chip_id];
-}
-
-std::optional<uint32_t> JtagDevice::get_device_harvesting(uint8_t chip_id) const {
-    if (chip_id >= get_device_cnt()) {
-        return {};
-    }
-
-    return device_harvesting[chip_id];
 }
 
 bool JtagDevice::select_device(uint8_t chip_id) {

--- a/ttlens/server/lib/src/open_implementation.cpp
+++ b/ttlens/server/lib/src/open_implementation.cpp
@@ -370,7 +370,7 @@ std::unique_ptr<open_implementation<jtag_implementation>> open_implementation<jt
 
     for (size_t device_id = 0; device_id < jtag_device->get_device_cnt(); device_id++) {
         tt::ARCH arch = *jtag_device->get_jtag_arch(device_id);
-        uint32_t harvesting = *jtag_device->get_device_harvesting(device_id);
+        uint32_t harvesting = *jtag_device->get_efuse_harvesting(device_id);
         soc_descriptors[device_id] = tt_SocDescriptor(device_configuration_path, harvesting);
         device_soc_descriptors_yamls[device_id] =
             jtag_create_device_soc_descriptor(soc_descriptors[device_id], device_id);


### PR DESCRIPTION
UMD's new coordinate manager API uses efuse harvessting instead of translated device harvesting