### PR TITLE
Fixing default for device summary to be all devices.

### DIFF
--- a/ttlens/ttlens_commands/device-summary.py
+++ b/ttlens/ttlens_commands/device-summary.py
@@ -63,6 +63,9 @@ def run(cmd_text, context, ui_state=None):
         util.ERROR(f"Invalid axis coordinate type: {axis_coordinate}. Valid types: {valid_axis_types}")
         return []
 
+    if not dopt.args["-d"]:
+        dopt.args["-d"] = "all"
+
     cell_contents = ""
     if dopt.args["<cell-contents>"]:
         cell_contents = dopt.args["<cell-contents>"]


### PR DESCRIPTION
With changes to device-summary syntax, default wasn't all devices, but currently selected device in go command. Now we return default to all devices.