### PR TITLE
Fixed getting libjtag in non-interactive way

### DIFF
--- a/docs/ttlens-jtag-tutorial.md
+++ b/docs/ttlens-jtag-tutorial.md
@@ -7,7 +7,17 @@ The JTAG library is proprietary and subject to licensing restrictions. Access is
 ## Setup
 #### Downloading
 If you have access, the library should be downloaded by default from a private GitLab repository and placed in `third_party/jtag_access_library/` on the first `make` run.
-If JTAG was not setup, you need to add yor SSH key to private GitLab instance hosted on yyz-gitlab.local.tenstorrent.com.
+
+If you see error "JTAG support not available.", you either:
+1. Are not on company's VPN
+2. Haven't added your ssh key to GitLab (yyz-gitlab.local.tenstorrent.com)
+3. Have ssh key with password
+
+Third one can be solved easily:
+```
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_rsa
+```
 
 #### Permissions
 Your user will need to have permission to use the SEGGER J-Link adapter.

--- a/scripts/get_jtag_access_library.sh
+++ b/scripts/get_jtag_access_library.sh
@@ -9,6 +9,7 @@ if [ -z "$CMAKE_BINARY_DIR" ]; then
 fi
 
 REPO=jtag-access-library
+REPO_URL=git@yyz-gitlab.local.tenstorrent.com
 REPO_PATH="$TT_HOME/third_party/$REPO"
 LIBJTAG="$CMAKE_BINARY_DIR/lib/libjtag.so"
 LIBJTAG_SOURCE="$REPO_PATH/out/libjtag.so"
@@ -16,11 +17,13 @@ LIBJTAG_DEP="$CMAKE_BINARY_DIR/lib/libjlinkarm.so"
 LIBJTAG_DEP_SOURCE="$REPO_PATH/lib/libjlinkarm.so"
 
 if [ ! -d "$REPO_PATH" ]; then
-	timeout 60 git clone "git@yyz-gitlab.local.tenstorrent.com:tenstorrent/$REPO" "$REPO_PATH" 2>/dev/null
+	ssh -o BatchMode=yes -o ConnectTimeout=1 "$REPO_URL" > /dev/null 2>&1
 	if [ ! $? -eq 0 ]; then
-		echo "JTAG support not available"
+		echo "JTAG support not available. See docs/ttlens-jtag-tutorial."
 		exit
 	fi
+
+	git clone "$REPO_URL:tenstorrent/$REPO" "$REPO_PATH" 2>/dev/null
 fi
 
 cd "$REPO_PATH"


### PR DESCRIPTION
Our build system does not support interactive, like typing out ssh password when prompted.
This change fixes issue for users with password protected ssh keys.