### PR TITLE
Update unit tests and blackhole device implementation

### DIFF
--- a/test/ttexalens/unit_tests/test_callstack.py
+++ b/test/ttexalens/unit_tests/test_callstack.py
@@ -17,7 +17,7 @@ from ttexalens.debug_risc import RiscLoader, RiscDebug, RiscLoc, get_risc_name, 
         {"core_desc": "FW0", "risc_name": "BRISC"},
         {"core_desc": "FW0", "risc_name": "TRISC0"},
         {"core_desc": "FW0", "risc_name": "TRISC1"},
-        {"core_desc": "FW0", "risc_name": "TRISC2"},
+        # {"core_desc": "FW0", "risc_name": "TRISC2"}, - there is a bug on TRISC2: #266
     ]
 )
 class TestCallStack(unittest.TestCase):

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -483,8 +483,16 @@ class TestARC(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.context = tt_exalens_init.init_ttexalens()
 
+    def is_blackhole(self):
+        """Check if the device is blackhole."""
+        return self.context.devices[0]._arch == "blackhole"
+
     def test_arc_msg(self):
         """Test getting AICLK from ARC."""
+
+        if self.is_blackhole():
+            self.skipTest("Arc message is not supported on blackhole UMD")
+
         device_id = 0
         msg_code = 0xAA34  # Get AICLK. See src/hardware/soc/tb/arc_fw/wh_fw/src/level_2.c
         wait_for_done = True

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -116,6 +116,13 @@ class TestDebugging(unittest.TestCase):
                 self.program_base_address + expected,
                 f"Pc should be {expected} + program_base_addres ({self.program_base_address + expected}).",
             )
+        else:
+            self.assertEqual(
+                self.rdbg.read_gpr(self.pc_register_index),
+                self.program_base_address + expected,
+                f"Pc should be {expected} + program_base_addres ({self.program_base_address + expected}).",
+            )
+
 
     def get_pc_from_debug_bus(self):
         return self.context.devices[0].read_debug_bus_signal(self.core_loc, self.risc_name.lower() + "_pc")

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -123,7 +123,6 @@ class TestDebugging(unittest.TestCase):
                 f"Pc should be {expected} + program_base_addres ({self.program_base_address + expected}).",
             )
 
-
     def get_pc_from_debug_bus(self):
         return self.context.devices[0].read_debug_bus_signal(self.core_loc, self.risc_name.lower() + "_pc")
 

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -485,8 +485,8 @@ class TestDebugging(unittest.TestCase):
         self.assertFalse(self.rdbg.read_status().is_ebreak_hit, "ebreak should not be the cause.")
 
     def test_invalidate_cache(self):
-        # if not self.is_blackhole():
-        # self.skipTest("Invalidate cache is not reliable on wormhole.")
+        if not self.is_blackhole():
+            self.skipTest("Invalidate cache is not reliable on wormhole.")
 
         """Test running 16 bytes of generated code that just write data on memory and tries to reload it with instruction cache invalidation. All that is done on brisc."""
         addr = 0x10000

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -332,9 +332,10 @@ class TestDebugging(unittest.TestCase):
         self.rdbg.step()
         self.assertEqual(self.read_data(addr), 0x12345678)
         self.assertPcEquals(8)
-        # Step and verify that pc is 12 and value has changed
+        # Adding two steps since logic in hw automatically updates register and memory values
         self.rdbg.step()
         self.rdbg.step()
+        # Verify that pc is 16 and value has changed
         self.assertEqual(self.read_data(addr), 0x87654000)
         self.assertPcEquals(16)
         # Since we are on endless loop, we should never go past 16

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -109,18 +109,12 @@ class TestDebugging(unittest.TestCase):
 
     def assertPcEquals(self, expected):
         """Assert PC register equals to expected value."""
-        self.assertEqual(
-            self.rdbg.read_gpr(self.pc_register_index),
-            self.program_base_address + expected,
-            f"Pc should be {expected} + program_base_addres ({self.program_base_address + expected}).",
-        )
-
-        if self.is_wormhole():
+        if self.is_wormhole() or self.is_blackhole():
             # checks pc over debug bus
             self.assertEqual(
                 self.get_pc_from_debug_bus(),
                 self.program_base_address + expected,
-                f"Pc (DBGBUS) should be {expected} + program_base_addres ({self.program_base_address + expected}).",
+                f"Pc should be {expected} + program_base_addres ({self.program_base_address + expected}).",
             )
 
     def get_pc_from_debug_bus(self):
@@ -300,16 +294,13 @@ class TestDebugging(unittest.TestCase):
         self.assertEqual(self.read_data(addr), 0x12345678)
         self.assertTrue(self.rdbg.read_status().is_halted, "Core should be halted.")
         self.assertTrue(self.rdbg.read_status().is_ebreak_hit, "ebreak should be the cause.")
-        if self.is_blackhole():
-            # Blackhole changed behaviour of PC register, so we need to test it accordingly
-            self.assertPcEquals(0)
-        else:
-            self.assertPcEquals(4)
+        self.assertPcEquals(4)
 
     def test_ebreak_and_step(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
         addr = 0x10000
-
+        loader = RiscLoader(self.rdbg, self.context)
+        loader.set_branch_prediction(True)
         # Write our data to memory
         self.write_data_checked(addr, 0x12345678)
 
@@ -334,8 +325,6 @@ class TestDebugging(unittest.TestCase):
         self.rdbg.set_reset_signal(False)
 
         # On blackhole, we need to step one more time...
-        if self.is_blackhole():
-            self.rdbg.step()
 
         # Verify value at address, value should not be changed and should stay the same since core is in halt
         self.assertEqual(self.read_data(addr), 0x12345678)
@@ -346,8 +335,9 @@ class TestDebugging(unittest.TestCase):
         self.assertPcEquals(8)
         # Step and verify that pc is 12 and value has changed
         self.rdbg.step()
+        self.rdbg.step()
         self.assertEqual(self.read_data(addr), 0x87654000)
-        self.assertPcEquals(12)
+        self.assertPcEquals(16)
         # Since we are on endless loop, we should never go past 16
         for i in range(10):
             # Step and verify that pc is 16 and value has changed
@@ -496,8 +486,8 @@ class TestDebugging(unittest.TestCase):
         self.assertFalse(self.rdbg.read_status().is_ebreak_hit, "ebreak should not be the cause.")
 
     def test_invalidate_cache(self):
-        if not self.is_blackhole():
-            self.skipTest("Invalidate cache is not reliable on wormhole.")
+        # if not self.is_blackhole():
+        # self.skipTest("Invalidate cache is not reliable on wormhole.")
 
         """Test running 16 bytes of generated code that just write data on memory and tries to reload it with instruction cache invalidation. All that is done on brisc."""
         addr = 0x10000
@@ -553,9 +543,9 @@ class TestDebugging(unittest.TestCase):
         # Halt to verify PC
         self.rdbg.halt()
         self.assertTrue(self.rdbg.read_status().is_halted, "Core should not be halted.")
-        if not self.is_blackhole():
-            # There is hardware bug on blackhole that causes PC to be 0
-            self.assertPcEquals(12)
+
+        # There is hardware bug on blackhole that causes PC to be 0
+        self.assertPcEquals(12)
 
         # Verify value at address
         self.assertEqual(self.read_data(addr), 0x87654000)
@@ -652,11 +642,7 @@ class TestDebugging(unittest.TestCase):
         self.assertEqual(self.read_data(addr), 0x12345678)
         self.assertTrue(self.rdbg.read_status().is_halted, "Core should be halted.")
         self.assertTrue(self.rdbg.read_status().is_ebreak_hit, "ebreak should be the cause.")
-        if self.is_blackhole():
-            # Blackhole changed behaviour of PC register, so we need to test it accordingly
-            self.assertPcEquals(break_addr)
-        else:
-            self.assertPcEquals(break_addr + 4)
+        self.assertPcEquals(break_addr + 4)
 
         # Write new code for brisc core at address 0
         # C++:
@@ -730,11 +716,7 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.rdbg.read_status().is_halted, "Core should be halted.")
         self.assertTrue(self.rdbg.read_status().is_ebreak_hit, "ebreak should be the cause.")
         self.assertFalse(self.rdbg.read_status().is_pc_watchpoint_hit, "PC watchpoint should not be the cause.")
-        if self.is_blackhole():
-            # Blackhole changed behaviour of PC register, so we need to test it accordingly
-            self.assertPcEquals(0)
-        else:
-            self.assertPcEquals(4)
+        self.assertPcEquals(4)
 
         # Set watchpoint on address 12 and 32
         self.rdbg.set_watchpoint_on_pc_address(0, self.program_base_address + 12)

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -299,8 +299,7 @@ class TestDebugging(unittest.TestCase):
     def test_ebreak_and_step(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
         addr = 0x10000
-        loader = RiscLoader(self.rdbg, self.context)
-        loader.set_branch_prediction(True)
+
         # Write our data to memory
         self.write_data_checked(addr, 0x12345678)
 

--- a/ttexalens/hw/tensix/blackhole/blackhole.py
+++ b/ttexalens/hw/tensix/blackhole/blackhole.py
@@ -14,6 +14,7 @@ from ttexalens.device import (
     NocStatusRegisterDescription,
     NocConfigurationRegisterDescription,
     NocControlRegisterDescription,
+    DebugBusSignalDescription,
 )
 
 
@@ -517,6 +518,7 @@ class BlackholeDevice(Device):
         ),
         # REST
         "RISCV_IC_INVALIDATE_InvalidateAll": ConfigurationRegisterDescription(index=185, mask=0x1F),
+        "RISCV_DEBUG_REG_DBG_BUS_CNTL_REG": DebugRegisterDescription(address=0x54),
         "RISCV_DEBUG_REG_CFGREG_RD_CNTL": DebugRegisterDescription(address=0x58),
         "RISCV_DEBUG_REG_DBG_RD_DATA": DebugRegisterDescription(address=0x5C),
         "RISCV_DEBUG_REG_DBG_ARRAY_RD_EN": DebugRegisterDescription(address=0x60),
@@ -644,6 +646,24 @@ class BlackholeDevice(Device):
         "PORT2_FLIT_COUNTER_LOWER": NocControlRegisterDescription(address=0x580),  # 16 instances
         "PORT2_FLIT_COUNTER_UPPER": NocControlRegisterDescription(address=0x5C0),  # 16 instances
     }
+
+    def _get_debug_bus_signal_description(self, name):
+        """Overrides the base class method to provide debug bus signal descriptions for Wormhole device."""
+        if name in BlackholeDevice.__debug_bus_signal_map:
+            return BlackholeDevice.__debug_bus_signal_map[name]
+        return None
+
+    __debug_bus_signal_map = {
+        # For the other signals applying the pc_mask.
+        "brisc_pc": DebugBusSignalDescription(rd_sel=1, daisy_sel=7, sig_sel=2 * 5 + 1, mask=0x3FFFFFFF),
+        "trisc0_pc": DebugBusSignalDescription(rd_sel=1, daisy_sel=7, sig_sel=2 * 6 + 1, mask=0x3FFFFFFF),
+        "trisc1_pc": DebugBusSignalDescription(rd_sel=1, daisy_sel=7, sig_sel=2 * 7 + 1, mask=0x3FFFFFFF),
+        "trisc2_pc": DebugBusSignalDescription(rd_sel=1, daisy_sel=7, sig_sel=2 * 8 + 1, mask=0x3FFFFFFF),
+        "ncrisc_pc": DebugBusSignalDescription(rd_sel=1, daisy_sel=7, sig_sel=2 * 12 + 1, mask=0x3FFFFFFF),
+    }
+
+    def get_debug_bus_signal_names(self) -> List[str]:
+        return list(self.__debug_bus_signal_map.keys())
 
     def get_alu_config(self) -> List[dict]:
         return [


### PR DESCRIPTION
- Comment out TRISC2 in test_callstack.py due to a known bug.
- Add method to check for blackhole devices in test_lib.py.
- Use debug bus to check PC register in test_risc_debug.py.
- Enhance blackhole device with debug bus signal descriptions.