### PR TITLE
Add repeat option to wxy command for multiple writes

### DIFF
--- a/ttexalens/cli_commands/write-xy.py
+++ b/ttexalens/cli_commands/write-xy.py
@@ -18,6 +18,7 @@ Options:
 
 Examples:
   wxy 0,0 0x0 0x1234
+  wxy 0,0 0x0 0x1234 --repeat 10
 """
 
 command_metadata = {
@@ -30,6 +31,7 @@ command_metadata = {
 from docopt import docopt
 
 from ttexalens.uistate import UIState
+import ttexalens.util as util
 
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.tt_exalens_lib import write_words_to_device
@@ -48,6 +50,9 @@ def run(cmd_text, context, ui_state: UIState = None):
     addr = int(args["<addr>"], 0)
     data = int(args["<data>"], 0)
     repeat = int(args["--repeat"]) if args["--repeat"] else 1
+    if repeat <= 0:
+        util.WARN("Repeat count must be a positive integer, defaulting to 1")
+        repeat = 1
 
     current_device_id = ui_state.current_device_id
     current_device = context.devices[current_device_id]

--- a/ttexalens/cli_commands/write-xy.py
+++ b/ttexalens/cli_commands/write-xy.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Usage:
-  wxy <core-loc> <addr> <data>
+  wxy <core-loc> <addr> <data> [--repeat <repeat>]
 
 Description:
   Writes data word to address 'addr' at noc0 location x-y of the current chip.
@@ -12,6 +12,9 @@ Arguments:
   core-loc    Either X-Y or R,C location of a core, or dram channel (e.g. ch3)
   addr        Address to write to
   data        Data to write
+
+Options:
+  --repeat <repeat>  Number of times to repeat the write. Default: 1
 
 Examples:
   wxy 0,0 0x0 0x1234
@@ -34,6 +37,7 @@ from ttexalens.tt_exalens_lib import write_words_to_device
 
 # A helper to print the result of a single PCI read
 def print_a_pci_write(core_loc_str, addr, val, comment=""):
+    core_loc_str = f"{core_loc_str} (L1) :" if not core_loc_str.startswith("ch") else f"{core_loc_str} (DRAM): "
     print(f"{core_loc_str} 0x{addr:08x} ({addr}) <= 0x{val:08x} ({val:d})")
 
 
@@ -43,14 +47,16 @@ def run(cmd_text, context, ui_state: UIState = None):
     core_loc_str = args["<core-loc>"]
     addr = int(args["<addr>"], 0)
     data = int(args["<data>"], 0)
+    repeat = int(args["--repeat"]) if args["--repeat"] else 1
 
     current_device_id = ui_state.current_device_id
     current_device = context.devices[current_device_id]
     core_loc = OnChipCoordinate.create(core_loc_str, device=current_device)
 
-    write_words_to_device(core_loc, addr, data, ui_state.current_device_id, context)
+    for _ in range(repeat):
+        write_words_to_device(core_loc, addr, data, ui_state.current_device_id, context)
 
-    core_loc_str = f"{core_loc_str} (L1) :" if not core_loc_str.startswith("ch") else f"{core_loc_str} (DRAM): "
-    print_a_pci_write(core_loc_str, addr, data)
+        print_a_pci_write(core_loc_str, addr, data)
+        addr += 4
 
     return None


### PR DESCRIPTION
`wxy` command now has optional argument `[--repeat <repeat>]`. Here is how output looks like:
```
gdb:None device:0 loc:1-1 (0,0) > wxy 0,0 0 0xdeadbeef
0,0 (L1) : 0x00000000 (0) <= 0xdeadbeef (3735928559)
gdb:None device:0 loc:1-1 (0,0) > wxy 0,0 0 0xdeadbeef --repeat 10
0,0 (L1) : 0x00000000 (0) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000004 (4) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000008 (8) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x0000000c (12) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000010 (16) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000014 (20) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000018 (24) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x0000001c (28) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000020 (32) <= 0xdeadbeef (3735928559)
0,0 (L1) : 0x00000024 (36) <= 0xdeadbeef (3735928559)
gdb:None device:0 loc:1-1 (0,0) >
```