### PR TITLE
Handle DocoptExit in CLI to improve error reporting instead of application exit

### DIFF
--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -382,6 +382,12 @@ def main_loop(args, context):
             if have_non_interactive_commands or type(e) == util.TTFatalException:
                 # In non-interactive mode and on fatal excepions, we re-raise to exit the program
                 raise
+        except DocoptExit as e:
+            if args["--test"]:  # Always raise in test mode
+                util.ERROR("CLI option --test is set. Raising exception to exit.")
+                raise
+            else:
+                print(e.usage)
 
 
 def main():


### PR DESCRIPTION
Previously, `DocoptExit` exception would close CLI application, but now we will just print usage and continue the main loop.