### PR TITLE
Trim comments from user input in CLI main loop

### DIFF
--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -326,6 +326,9 @@ def main_loop(args, context):
                 my_prompt += f"{ui_state.current_prompt}> "
                 cmd_raw = context.prompt_session.prompt(HTML(my_prompt))
 
+            # Trim comments
+            cmd_raw = cmd_raw.split("#")[0].strip()
+
             cmd_int = try_int(cmd_raw)
             if type(cmd_int) == int:
                 if navigation_suggestions and cmd_int >= 0 and cmd_int < len(navigation_suggestions):


### PR DESCRIPTION
Everything after first `#` is ignored which allows user to use comments in commands (copy/paste from documentation/scripts/etc).