### PR TITLE
Updating SFPI to 6.6.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,14 +82,6 @@ jobs:
       - uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build
-          path: build
-
-      - name: Debug list
-        shell: bash
-        run: |
-          ls -la
-          ls -la build
-          ls -la build/build
 
       - name: Set reusable strings
         id: strings
@@ -169,7 +161,6 @@ jobs:
       - uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build
-          path: build
       - name: Install wheel
         run: |
           pip install build/ttexalens_wheel/*.whl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,7 +81,7 @@ jobs:
           submodules: recursive
           lfs: true
 
-      - uses: actions/download-artifact@v4
+      - uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build
           path: build
@@ -105,13 +105,6 @@ jobs:
           echo "Current job id: $JOB_ID"
           echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
           echo "test_report_path=report_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
-
-      - name: Update permissions for downloaded binaries
-        shell: bash
-        run: |
-          chmod +x build/bin/ttexalens-server-standalone
-          chmod +x build/bin/ttexalens_server_unit_tests
-          ls -la build/lib # Debug reomve
 
       - name: Run C++ tests
         run: |
@@ -169,14 +162,10 @@ jobs:
         with:
           submodules: recursive
           lfs: true
-      - uses: actions/download-artifact@v4
+      - uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build
           path: build
-      - name: Update permissions for downloaded binaries
-        run: |
-          chmod +x build/bin/ttexalens-server-standalone
-          chmod +x build/bin/ttexalens_server_unit_tests
       - name: Install wheel
         run: |
           pip install build/ttexalens_wheel/*.whl

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,6 +84,13 @@ jobs:
           name: ttexalens-build
           path: build
 
+      - name: Debug list
+        shell: bash
+        run: |
+          ls -la
+          ls -la build
+          ls -la build/build
+
       - name: Set reusable strings
         id: strings
         shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -79,7 +78,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
 
       - uses: pyTooling/download-artifact@v4
         with:
@@ -161,7 +159,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
       - uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build

--- a/.github/workflows/build-ttexalens.yml
+++ b/.github/workflows/build-ttexalens.yml
@@ -33,7 +33,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
       - name: Git safe dir
         run: git config --global --add safe.directory $(pwd)
       - name: ccache

--- a/.github/workflows/build-ttexalens.yml
+++ b/.github/workflows/build-ttexalens.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           make wheel
       - name: Upload libraries as artifacts
-        uses: actions/upload-artifact@v4
+        uses: pyTooling/upload-artifact@v4
         with:
           name: ttexalens-build
           path: build

--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          lfs: true
       - uses: ./.github/actions/install-ttexalens-deps
       - uses: actions/setup-python@v5
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ core
 
 .cpmcache
 /build
-/sfpi
 
 __pycache__
 .venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ set(UMD_HOME "${PROJECT_SOURCE_DIR}/third_party/umd")
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/pybind11)
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/umd)
 
+# Check for SFPI release
+include(${PROJECT_SOURCE_DIR}/cmake/sfpi_release.cmake)
+
 # Check for ZeroMQ
 include(${PROJECT_SOURCE_DIR}/cmake/ZeroMQ.cmake)
 

--- a/cmake/sfpi_release.cmake
+++ b/cmake/sfpi_release.cmake
@@ -1,0 +1,18 @@
+set(SFPI_RELEASE_PATH "${TTEXALENS_HOME}/build/sfpi")
+
+if(NOT EXISTS "${SFPI_RELEASE_PATH}")
+    message(STATUS "Downloading sfpi release")
+
+    include(FetchContent)
+    FetchContent_Declare(
+        sfpi
+        URL
+            https://github.com/tenstorrent/sfpi/releases/download/v6.6.0/sfpi-release.tgz
+        URL_HASH MD5=8eed4d1128809e2fb2df00e04b5a51ea
+        SOURCE_DIR
+        ${SFPI_RELEASE_PATH}
+    )
+    FetchContent_MakeAvailable(sfpi)
+else()
+    message(STATUS "Using sfpi release from ${SFPI_RELEASE_PATH}")
+endif()

--- a/test/ttexalens/unit_tests/test_parse_elf.py
+++ b/test/ttexalens/unit_tests/test_parse_elf.py
@@ -21,7 +21,7 @@ def compile_test_cpp_program(program_path, program_text):
     Just compile a program to get an ELF file
     """
     print(f"\nCompiling {program_path}...")
-    # Run ./sfpi/compiler/bin/riscv32-unknown-elf-g++ -g ./test-elf.c -o test-elf on the program_text
+    # Run ./build/sfpi/compiler/bin/riscv32-unknown-elf-g++ -g ./test-elf.c -o test-elf on the program_text
     import os
 
     elf_file_name = f"{program_path}.elf"
@@ -30,7 +30,7 @@ def compile_test_cpp_program(program_path, program_text):
     with open(f"{src_file_name}", "w") as f:
         f.write(program_text)
     # Compile the program
-    os.system(f"./sfpi/compiler/bin/riscv32-unknown-elf-g++ -g {src_file_name} -o {program_path}.elf")
+    os.system(f"./build/sfpi/compiler/bin/riscv32-unknown-elf-g++ -g {src_file_name} -o {program_path}.elf")
     if not os.path.exists(elf_file_name):
         util.ERROR(f"ERROR: Failed to compile {src_file_name}")
         exit(1)

--- a/ttexalens/riscv-src/CMakeLists.txt
+++ b/ttexalens/riscv-src/CMakeLists.txt
@@ -8,21 +8,8 @@ if(NOT TTEXALENS_HOME)
     set(TTEXALENS_HOME "${CMAKE_CURRENT_LIST_DIR}/../..")
 endif()
 
-message(STATUS "Downloading sfpi release")
-
-include(FetchContent)
-FetchContent_Declare(
-    sfpi
-    URL
-        https://github.com/tenstorrent/sfpi/releases/download/v5.0.0/sfpi-release.tgz
-    URL_HASH MD5=10cacabe92846076cb4d7596e46d06be
-    SOURCE_DIR
-    ${TTEXALENS_HOME}/sfpi
-)
-FetchContent_MakeAvailable(sfpi)
-
 # Set toolchain and tools
-set(TOOL_PATH "${TTEXALENS_HOME}/sfpi/compiler/bin")
+set(TOOL_PATH "${SFPI_RELEASE_PATH}/compiler/bin")
 set(GXX "${TOOL_PATH}/riscv32-unknown-elf-g++")
 set(OBJDUMP "${TOOL_PATH}/riscv32-unknown-elf-objdump")
 set(OBJCOPY "${TOOL_PATH}/riscv32-unknown-elf-objcopy")
@@ -34,7 +21,7 @@ set(OPTIMIZED_OPTIONS_COMPILE -fno-use-cxa-atexit -Wall -fno-exceptions -fno-rtt
 set(OPTIMIZED_OPTIONS_LINK -fno-exceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles -Lttexalens/riscv-src)
 
 # Compiler options
-set(OPTIONS_ALL -O0 -march=rv32imw -mtune=rvtt-b1 -mabi=ilp32 -std=c++17 -g -flto -ffast-math)
+set(OPTIONS_ALL -O0 -mtune=rvtt-b1 -mabi=ilp32 -std=c++17 -g -flto -ffast-math)
 set(OPTIONS_COMPILE -fno-use-cxa-atexit -fno-exceptions -Wall -Werror -Wno-unknown-pragmas -Wno-error=multistatement-macros -Wno-error=parentheses -Wno-error=unused-but-set-variable -Wno-unused-variable)
 set(OPTIONS_LINK -fno-exceptions -Wl,-z,max-page-size=16 -Wl,-z,common-page-size=16 -nostartfiles -Lttexalens/riscv-src)
 


### PR DESCRIPTION
Updating to new SFPI release since it brings GDB.
Moving sfpi directory to build directory to avoid download on CMake files update and allow it to be cleaned with `make clean`.

Fixing workflow to use `pyTooling/download-artifact@v4` instead of `actions/download-artifact@v4` because it preserves file attributes. Removed `Update permissions for downloaded binaries`.  Removed `lfs: true` for checkout since we don't use it.