### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM to build configuration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ build:
 	@echo "Building"
 	@if [ ! -f build/build.ninja ] || ! grep -iq "CMAKE_BUILD_TYPE:STRING=$(CONFIG)" build/CMakeCache.txt; then \
 		if which ccache > /dev/null; then \
-			cmake -B build -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG); \
+			cmake -B build -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
 		else \
-			cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG); \
+			cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
 		fi \
 	fi
 	@ninja -C build


### PR DESCRIPTION
Fixing build error:
```
-- CPM: Adding package yaml-cpp@0.8.0 (0.8.0 to /localdev/abhullar/tt-exalens/.cpmcache/yaml-cpp/905940a232aea3437e2fb77334461b1fe343318b)
CMake Error at .cpmcache/yaml-cpp/905940a232aea3437e2fb77334461b1fe343318b/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```