### PR TITLE
Move old IO calls to the new api that uses CoreCoordinates

### DIFF
--- a/ttexalens/server/lib/src/open_implementation.cpp
+++ b/ttexalens/server/lib/src/open_implementation.cpp
@@ -448,9 +448,8 @@ std::unique_ptr<open_implementation<umd_implementation>> open_implementation<umd
 
     for (const auto &worker : soc_descriptor.get_cores(CoreType::TENSIX)) {
         uint32_t data = 0x6f;  // while (true);
-        tt::umd::cxy_pair cxy(0, worker.x, worker.y);
 
-        device->write_to_device(&data, sizeof(data), cxy, 0, {});
+        device->write_to_device(&data, sizeof(data), 0, worker, 0, {});
     }
 
     device->deassert_risc_reset();

--- a/ttexalens/server/lib/src/read_tile.cpp
+++ b/ttexalens/server/lib/src/read_tile.cpp
@@ -381,7 +381,7 @@ std::optional<std::string> read_tile_implementation(uint8_t chip_id, uint8_t noc
     std::vector<std::uint32_t> mem_vector;
 
     if (df != TileDataFormat::Invalid) {
-        tt_cxy_pair target(chip_id, noc_x, noc_y);
+        tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::VIRTUAL);
         bool small_access = false;
         bool register_txn = true;  // FIX: This should not be register access, actually
 
@@ -394,11 +394,11 @@ std::optional<std::string> read_tile_implementation(uint8_t chip_id, uint8_t noc
         if (mmio_targets.find(chip_id) == mmio_targets.end()) {
             for (uint32_t done = 0; done < size;) {
                 uint32_t block = std::min(size - done, 1024u);
-                device->read_from_device(mem_vector.data() + done, target, address + done, block, tlb_to_use);
+                device->read_from_device(mem_vector.data() + done, chip_id, target, address + done, block, tlb_to_use);
                 done += block;
             }
         } else {
-            device->read_from_device(mem_vector.data(), target, address, size, tlb_to_use);
+            device->read_from_device(mem_vector.data(), chip_id, target, address, size, tlb_to_use);
         }
 
         return dump_tile(mem_vector, df);

--- a/ttexalens/server/lib/src/read_tile.cpp
+++ b/ttexalens/server/lib/src/read_tile.cpp
@@ -381,7 +381,8 @@ std::optional<std::string> read_tile_implementation(uint8_t chip_id, uint8_t noc
     std::vector<std::uint32_t> mem_vector;
 
     if (df != TileDataFormat::Invalid) {
-        tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::VIRTUAL);
+        tt::umd::CoreCoord target =
+            device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::VIRTUAL);
         bool small_access = false;
         bool register_txn = true;  // FIX: This should not be register access, actually
 


### PR DESCRIPTION
This was done a while back for tt_metal.
And we removed the old API in https://github.com/tenstorrent/tt-umd/pull/675

Unblocks https://github.com/tenstorrent/tt-exalens/pull/314