### PR TITLE
Add support for displaying all and specific NOC registers

### DIFF
--- a/ttexalens/cli_commands/noc.py
+++ b/ttexalens/cli_commands/noc.py
@@ -4,12 +4,16 @@
 """
 Usage:
     noc status [-d <device>] [--noc <noc-id>] [-l <loc>] [-s]
-    noc dump [-d <device>] [-l <loc>] [-s]
+    noc all [-d <device>] [-l <loc>] [-s]
+    noc register <reg-names> [-d <device>] [--noc <noc-id>] [-l <loc>] [-s]
+
 
 Arguments:
     device-id         ID of the device [default: current active]
     noc-id            Identifier for the NOC (e.g. 0, 1) [default: both noc0 and noc1]
     loc               Location identifier (e.g. 0-0) [default: current active]
+    reg-names         Name of specific NOC register(s) to display, can be comma-separated
+
 
 Options:
     -s, --simple     Print simple output
@@ -17,10 +21,15 @@ Options:
 Description:
     Displays NOC (Network on Chip) registers.
         • "noc status" prints status registers for transaction counters.
+        • "noc all" prints all registers.
+        • "noc register <reg-names>" prints specific register(s) by name.
+
 
 Examples:
     noc status -d 0 -l 0,0                      # Prints status registers for device 0 on 0,0
     noc status -s                               # Prints status registers with simple output
+    noc register NIU_MST_RD_REQ_SENT            # Prints a specific register value
+    noc register NIU_MST_RD_REQ_SENT,NIU_MST_RD_DATA_WORD_RECEIVED  # Prints multiple registers
 """
 
 # Standard imports first
@@ -117,12 +126,31 @@ def get_noc_status_registers(loc: OnChipCoordinate, device, noc_id: int) -> Dict
     return noc_registers
 
 
+def get_all_noc_registers(loc: OnChipCoordinate, device) -> Dict[str, Dict[str, int]]:
+    """
+    Get all NOC registers for both NOC0 and NOC1.
+
+    Args:
+        loc: On-chip coordinate
+        device: Device object
+
+    Returns:
+        Dictionary of all register values for both NOCs
+    """
+    noc_registers = {"Noc0 Registers": {}, "Noc1 Registers": {}}
+    register_names = device.get_noc_register_names()
+    for reg_name in register_names:
+        noc_registers["Noc0 Registers"][reg_name] = read_noc_register(loc, device, 0, reg_name)
+        noc_registers["Noc1 Registers"][reg_name] = read_noc_register(loc, device, 1, reg_name)
+    return noc_registers
+
+
 ###############################################################################
 # NOC Register Display Functions
 ###############################################################################
-def display_noc_registers(loc: OnChipCoordinate, device, noc_id: int, simple_print: bool = False) -> None:
+def display_noc_status_registers(loc: OnChipCoordinate, device, noc_id: int, simple_print: bool = False) -> None:
     """
-    Display registers for a specific NOC.
+    Display status registers for a specific NOC.
 
     Args:
         loc: On-chip coordinate
@@ -130,7 +158,7 @@ def display_noc_registers(loc: OnChipCoordinate, device, noc_id: int, simple_pri
         noc_id: NOC identifier (0 or 1)
         simple_print: Whether to use simplified output format
     """
-    formatter.print_header(f"NOC{noc_id} Registers", "bold")
+    formatter.print_header(f"NOC{noc_id} Status Registers", "bold")
     noc_registers = get_noc_status_registers(loc, device, noc_id)
     grouping = [
         ["Transaction Counters (Sent)", "Transaction Counters (Received)"],
@@ -142,15 +170,85 @@ def display_noc_registers(loc: OnChipCoordinate, device, noc_id: int, simple_pri
 
 def display_all_noc_registers(loc: OnChipCoordinate, device, simple_print: bool = False) -> None:
     """
-    Display registers for both NOCs.
+    Display all registers for both NOCs.
 
     Args:
         loc: On-chip coordinate
         device: Device object
         simple_print: Whether to use simplified output format
     """
-    display_noc_registers(loc, device, 0, simple_print)
-    display_noc_registers(loc, device, 1, simple_print)
+    formatter.print_header("All NOC Registers", "bold")
+    noc_registers = get_all_noc_registers(loc, device)
+
+    # Get all register group names for grouping
+    group_names = list(noc_registers.keys())
+    grouping = [group_names]
+
+    # Use the shared formatter API
+    formatter.display_grouped_data(noc_registers, grouping, simple_print)
+
+
+def display_all_noc_status_registers(loc: OnChipCoordinate, device, simple_print: bool = False) -> None:
+    """
+    Display status registers for both NOCs.
+
+    Args:
+        loc: On-chip coordinate
+        device: Device object
+        simple_print: Whether to use simplified output format
+    """
+    display_noc_status_registers(loc, device, 0, simple_print)
+    display_noc_status_registers(loc, device, 1, simple_print)
+
+
+def display_specific_noc_registers(
+    loc: OnChipCoordinate, device, reg_names: List[str], noc_id: int, simple_print: bool = False
+) -> None:
+    """
+    Display one or more specific NOC registers by name.
+
+    Args:
+        loc: On-chip coordinate
+        device: Device object
+        reg_names: List of register names to display
+        noc_id: NOC identifier (0 or 1)
+        simple_print: Whether to use simplified output format
+    """
+    # Get the list of valid register names
+    valid_register_names = device.get_noc_register_names()
+
+    # Create a data structure to hold register values
+    register_data = {f"NOC{noc_id} Registers": {}}
+
+    # Check if we have valid registers to display
+    valid_registers_found = False
+    invalid_registers = []
+
+    # Process each requested register
+    for reg_name in reg_names:
+        reg_name = reg_name.strip()  # Remove any whitespace
+        if not reg_name:  # Skip empty names
+            continue
+
+        if reg_name in valid_register_names:
+            valid_registers_found = True
+            # Read the register value
+            value = read_noc_register(loc, device, noc_id, reg_name)
+            register_data[f"NOC{noc_id} Registers"][reg_name] = value
+        else:
+            invalid_registers.append(reg_name)
+
+    # Report any invalid register names
+    if invalid_registers:
+        util.ERROR(f"The following register names are invalid for NOC{noc_id}: {', '.join(invalid_registers)}")
+
+    # Only display if we found at least one valid register
+    if valid_registers_found:
+        # Display the registers
+        formatter.display_grouped_data(register_data, [[f"NOC{noc_id} Registers"]], simple_print)
+    elif not invalid_registers:
+        # If no registers were found but none were invalid, it's likely an empty list
+        util.ERROR(f"No register names provided for NOC{noc_id}")
 
 
 ###############################################################################
@@ -177,13 +275,13 @@ def run(cmd_text: str, context: Dict, ui_state: Optional[UIState] = None) -> Lis
     # Parse and validate NOC ID
     if dopt.args["--noc"]:
         try:
-            noc_id = int(dopt.args["--noc"])
+            noc_id = int(dopt.args["<noc-id>"])
             if noc_id not in [0, 1]:
                 util.ERROR(f"Invalid NOC identifier: {noc_id}. Must be 0 or 1.")
                 return []
             noc_ids = [noc_id]
         except ValueError:
-            util.ERROR(f"Invalid NOC identifier: {dopt.args['--noc']}. Must be 0 or 1.")
+            util.ERROR(f"Invalid NOC identifier: {dopt.args['<noc-id>']}. Must be 0 or 1.")
             return []
     else:
         noc_ids = [0, 1]
@@ -196,7 +294,29 @@ def run(cmd_text: str, context: Dict, ui_state: Optional[UIState] = None) -> Lis
             formatter.print_device_header(device, loc)
 
             if dopt.args["status"]:
-                for noc_id in noc_ids:
-                    display_noc_registers(loc, device, noc_id, simple_print)
+                if dopt.args["--noc"]:
+                    # If a specific NOC ID was specified, only display that one
+                    display_noc_status_registers(loc, device, noc_ids[0], simple_print)
+                else:
+                    # Otherwise, display status for both NOCs
+                    display_all_noc_status_registers(loc, device, simple_print)
+            elif dopt.args["all"]:
+                # Display all registers for both NOCs
+                display_all_noc_registers(loc, device, simple_print)
+            elif dopt.args["register"]:
+                # Parse the comma-separated register names
+                reg_names_str = dopt.args["<reg-names>"]
+                reg_names = [name.strip() for name in reg_names_str.split(",")]
+
+                if dopt.args["--noc"]:
+                    # If a specific NOC ID was specified, only display for that one
+                    print(f"Displaying registers for NOC{noc_ids[0]}: {', '.join(reg_names)}")
+                    display_specific_noc_registers(loc, device, reg_names, noc_ids[0], simple_print)
+                else:
+                    # Otherwise, display for both NOCs
+                    for noc_id in [0, 1]:
+                        display_specific_noc_registers(loc, device, reg_names, noc_id, simple_print)
+
+    return []
 
     return []


### PR DESCRIPTION
#249 

- Added 'noc all' and 'noc register <reg-names>' CLI commands
- Implemented retrieval and display of all NOC registers
- Added validation and error reporting for unknown register names
- Refactored status display logic to differentiate status from all registers
- Extended Device class with get_noc_register_names() for NOC register filtering