### PR TITLE
Removed job that uses ubuntu-20.04

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         build-info: [
-          {py-version: "3.8", os: "ubuntu-20.04"},
           {py-version: "3.10", os: "ubuntu-22.04"},
         ]
     name: "Latest Release"


### PR DESCRIPTION
Since ubuntu-20.04 is now retired, job that uses it is removed.