### PR TITLE
Added option to run release latest workflow manually

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -1,6 +1,7 @@
 name: Release Latest
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"


### PR DESCRIPTION
Currently release latest workflow can only be triggered by pushing something on main. Added option to run this workflow manually for testing purposes.