### PR TITLE
Extracting debug bus from device

### DIFF
--- a/test/ttexalens/unit_tests/core_simulator.py
+++ b/test/ttexalens/unit_tests/core_simulator.py
@@ -25,11 +25,13 @@ class RiscvCoreSimulator:
         self.core_loc = self._get_core_location()
 
         # Initialize core components
-        loc = OnChipCoordinate.create(self.core_loc, device=self.context.devices[0])
+        self.device = self.context.devices[0]
+        loc = OnChipCoordinate.create(self.core_loc, device=self.device)
         self.risc_id = get_risc_id(self.risc_name)
         rloc = RiscLoc(loc, 0, self.risc_id)
         self.rdbg = RiscDebug(rloc, self.context)
         self.loader = RiscLoader(self.rdbg, self.context)
+        self.debug_bus_store = self.device.get_debug_bus_signal_store(loc)
 
         # Initialize core in reset state
         self.set_reset(True)
@@ -106,7 +108,7 @@ class RiscvCoreSimulator:
 
     def get_pc_from_debug_bus(self) -> int:
         """Get PC value from debug bus."""
-        return self.context.devices[0].read_debug_bus_signal(self.core_loc, self.risc_name.lower() + "_pc")
+        return self.debug_bus_store.read_signal(self.risc_name.lower() + "_pc")
 
     def is_halted(self) -> bool:
         """Check if core is halted."""

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -17,7 +17,7 @@ from ttexalens import util
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context
 from ttexalens.device import ConfigurationRegisterDescription, DebugRegisterDescription
-from ttexalens.debug_bus_signal import DebugBusSignalDescription
+from ttexalens.debug_bus_signal_store import DebugBusSignalDescription
 from ttexalens.debug_risc import RiscLoader, RiscDebug, RiscLoc, get_risc_name, get_risc_id
 from ttexalens.firmware import ELF
 from ttexalens.object import DataArray

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import struct
 import unittest
+import os
 
 from functools import wraps
 
@@ -15,10 +16,11 @@ from ttexalens import util
 
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context
+from ttexalens.device import ConfigurationRegisterDescription, DebugRegisterDescription
+from ttexalens.debug_bus_signal import DebugBusSignalDescription
 from ttexalens.debug_risc import RiscLoader, RiscDebug, RiscLoc, get_risc_name, get_risc_id
 from ttexalens.firmware import ELF
 from ttexalens.object import DataArray
-import os
 
 from ttexalens.hw.arc.arc import load_arc_fw
 from ttexalens.hw.arc.arc_dbg_fw import arc_dbg_fw_check_msg_loop_running, arc_dbg_fw_command, NUM_LOG_CALLS_OFFSET
@@ -238,8 +240,6 @@ class TestReadWrite(unittest.TestCase):
         """Test invalid inputs for write function."""
         with self.assertRaises((util.TTException, ValueError)):
             lib.write_to_device(core_loc, address, data, device_id)
-
-    from ttexalens.device import ConfigurationRegisterDescription, DebugRegisterDescription, DebugBusSignalDescription
 
     @parameterized.expand(
         [

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -68,6 +68,7 @@ class TestDebugging(unittest.TestCase):
         self.rdbg = RiscDebug(rloc, self.context)
         loader = RiscLoader(self.rdbg, self.context)
         self.program_base_address = loader.get_risc_start_address()
+        self.debug_bus_store = self.context.devices[0].get_debug_bus_signal_store(loc)
 
         # If address wasn't set before, we want to set it to something that is not 0 for testing purposes
         if self.program_base_address == None:
@@ -124,7 +125,7 @@ class TestDebugging(unittest.TestCase):
             )
 
     def get_pc_from_debug_bus(self):
-        return self.context.devices[0].read_debug_bus_signal(self.core_loc, self.risc_name.lower() + "_pc")
+        return self.debug_bus_store.read_signal(self.risc_name.lower() + "_pc")
 
     def assertPcLess(self, expected):
         """Assert PC register is less than expected value."""

--- a/ttexalens/debug_bus_signal_store.py
+++ b/ttexalens/debug_bus_signal_store.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Dict, Iterable, TYPE_CHECKING
+
+from ttexalens.tt_exalens_lib import read_word_from_device, write_words_to_device
+
+if TYPE_CHECKING:
+    from ttexalens.coordinate import OnChipCoordinate
+    from ttexalens.device import Device
+
+
+@dataclass
+class DebugBusSignalDescription:
+    rd_sel: int = 0
+    daisy_sel: int = 0
+    sig_sel: int = 0
+    mask: int = 0xFFFFFFFF
+
+
+class DebugBusSignalStore:
+    def __init__(
+        self, signals: Dict[str, DebugBusSignalDescription], location: OnChipCoordinate, neo_id: int | None = None
+    ):
+        self.signals = signals
+        self.location = location
+        self.neo_id = neo_id
+
+    @property
+    def device(self) -> Device:
+        return self.location._device
+
+    @cached_property
+    def _control_register_address(self) -> int:
+        # TODO: This should be read from register store (once we have it). Register store should be argument to the constructor.
+        return self.device.get_tensix_register_address("RISCV_DEBUG_REG_DBG_BUS_CNTL_REG")
+
+    @cached_property
+    def _data_register_address(self) -> int:
+        # TODO: This should be read from register store (once we have it). Register store should be argument to the constructor.
+        return self.device.get_tensix_register_address("RISCV_DEBUG_REG_DBG_RD_DATA")
+
+    def get_signal_names(self) -> Iterable[str]:
+        return self.signals.keys()
+
+    def get_signal_description(self, signal_name: str) -> DebugBusSignalDescription:
+        if signal_name in self.signals:
+            return self.signals[signal_name]
+        elif self.neo_id is None:
+            raise ValueError(
+                f"Unknown signal name '{signal_name}' on {self.location.to_user_str()} for device {self.device._id}."
+            )
+        else:
+            raise ValueError(
+                f"Unknown signal name '{signal_name}' on {self.location.to_user_str()} [NEO {self.neo_id}] for device {self.device._id}."
+            )
+
+    def read_signal(self, signal: DebugBusSignalDescription | str) -> int:
+        if isinstance(signal, str):
+            signal = self.get_signal_description(signal)
+        else:
+            if not (0 <= signal.rd_sel <= 3):  # Example range, update if needed
+                raise ValueError(f"rd_sel must be between 0 and 3, got {signal.rd_sel}")
+
+            if not (0 <= signal.daisy_sel <= 255):  # Example range, update if needed
+                raise ValueError(f"daisy_sel must be between 0 and 255, got {signal.daisy_sel}")
+
+            if not (0 <= signal.sig_sel <= 65535):  # Example range, update if needed
+                raise ValueError(f"sig_sel must be between 0 and 65535, got {signal.sig_sel}")
+
+            if not (0 <= signal.mask <= 0xFFFFFFFF):  # Mask should be a valid 32-bit value
+                raise ValueError(f"mask must be a valid 32-bit integer, got {signal.mask}")
+
+        # Write the configuration
+        en = 1
+        config = (en << 29) | (signal.rd_sel << 25) | (signal.daisy_sel << 16) | (signal.sig_sel << 0)
+        write_words_to_device(
+            self.location, self._control_register_address, config, self.device._id, self.device._context
+        )
+
+        # Read the data
+        data = read_word_from_device(self.location, self._data_register_address, self.device._id, self.device._context)
+
+        # Disable the signal
+        write_words_to_device(self.location, self._control_register_address, 0, self.device._id, self.device._context)
+
+        return data if signal.mask is None else data & signal.mask

--- a/ttexalens/hw/tensix/blackhole/blackhole.py
+++ b/ttexalens/hw/tensix/blackhole/blackhole.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+from ttexalens.coordinate import OnChipCoordinate
 import ttexalens.util as util
 from ttexalens.debug_tensix import TensixDebug
 from ttexalens.util import DATA_TYPE
@@ -14,8 +15,8 @@ from ttexalens.device import (
     NocStatusRegisterDescription,
     NocConfigurationRegisterDescription,
     NocControlRegisterDescription,
-    DebugBusSignalDescription,
 )
+from ttexalens.debug_bus_signal_store import DebugBusSignalDescription, DebugBusSignalStore
 
 
 class BlackholeInstructions(TensixInstructions):
@@ -679,11 +680,11 @@ class BlackholeDevice(Device):
         "PORT2_FLIT_COUNTER_UPPER": NocControlRegisterDescription(address=0x5C0),  # 16 instances
     }
 
-    def _get_debug_bus_signal_description(self, name):
-        """Overrides the base class method to provide debug bus signal descriptions for Wormhole device."""
-        if name in BlackholeDevice.__debug_bus_signal_map:
-            return BlackholeDevice.__debug_bus_signal_map[name]
-        return None
+    def get_debug_bus_signal_store(self, location: OnChipCoordinate) -> DebugBusSignalStore:
+        block_type = self.get_block_type(location)
+        if block_type == "functional_workers":
+            return DebugBusSignalStore(self.__debug_bus_signal_map, location)
+        raise ValueError(f"Debug bus signal store not available for block type {block_type} at location {location}")
 
     __debug_bus_signal_map = {
         # For the other signals applying the pc_mask.
@@ -3854,9 +3855,6 @@ class BlackholeDevice(Device):
             rd_sel=2, daisy_sel=14, sig_sel=4, mask=0x1
         ),
     }
-
-    def get_debug_bus_signal_names(self) -> List[str]:
-        return list(self.__debug_bus_signal_map.keys())
 
     def get_alu_config(self) -> List[dict]:
         return [


### PR DESCRIPTION
This will enable us to have different signals for different noc locations. Currently, only functional_workers have debug bus signal store.