### PR TITLE
Expose noc_id in read/write API

### DIFF
--- a/test/ttexalens/pybind/test_bindings.cpp
+++ b/test/ttexalens/pybind/test_bindings.cpp
@@ -6,41 +6,42 @@
 
 class bindings_implementation : public tt::exalens::ttexalens_implementation {
    private:
-    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> read_write_4;
-    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint64_t, uint32_t>, std::vector<uint8_t>> read_write;
+    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> read_write_4;
+    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint8_t, uint64_t, uint32_t>, std::vector<uint8_t>> read_write;
     std::map<std::tuple<uint8_t, uint64_t>, uint32_t> read_write_4_raw;
 
    public:
-    std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override {
-        auto it = read_write_4.find(std::make_tuple(chip_id, noc_x, noc_y, address));
+    std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                       uint64_t address) override {
+        auto it = read_write_4.find(std::make_tuple(noc_id, chip_id, noc_x, noc_y, address));
         if (it != read_write_4.end()) {
             return it->second;
         }
         return {};
     }
 
-    std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                         uint32_t data) override {
-        read_write_4[std::make_tuple(chip_id, noc_x, noc_y, address)] = data;
+        read_write_4[std::make_tuple(noc_id, chip_id, noc_x, noc_y, address)] = data;
         return data;
     }
 
-    std::optional<std::vector<uint8_t>> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                 uint32_t size) override {
-        auto it = read_write.find(std::make_tuple(chip_id, noc_x, noc_y, address, size));
+    std::optional<std::vector<uint8_t>> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                 uint64_t address, uint32_t size) override {
+        auto it = read_write.find(std::make_tuple(noc_id, chip_id, noc_x, noc_y, address, size));
         if (it != read_write.end()) {
             return it->second;
         }
         return {};
     }
 
-    std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                       const uint8_t *data, uint32_t size) override {
         std::vector<uint8_t> data_vector(size);
         for (size_t i = 0; i < size; i++) {
             data_vector[i] = data[i];
         }
-        read_write[std::make_tuple(chip_id, noc_x, noc_y, address, size)] = data_vector;
+        read_write[std::make_tuple(noc_id, chip_id, noc_x, noc_y, address, size)] = data_vector;
         return size;
     }
 
@@ -65,11 +66,11 @@ class bindings_implementation : public tt::exalens::ttexalens_implementation {
         return {};
     }
 
-    std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                             uint32_t size, uint8_t data_format) override {
-        return "pci_read_tile(" + std::to_string(chip_id) + ", " + std::to_string(noc_x) + ", " +
-               std::to_string(noc_y) + ", " + std::to_string(address) + ", " + std::to_string(size) + ", " +
-               std::to_string(data_format) + ")";
+    std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                             uint64_t address, uint32_t size, uint8_t data_format) override {
+        return "pci_read_tile(" + std::to_string(noc_id) + ", " + std::to_string(chip_id) + ", " +
+               std::to_string(noc_x) + ", " + std::to_string(noc_y) + ", " + std::to_string(address) + ", " +
+               std::to_string(size) + ", " + std::to_string(data_format) + ")";
     }
     std::optional<std::string> get_cluster_description() override { return "get_cluster_description()"; }
     std::optional<std::vector<uint8_t>> get_device_ids() override { return std::vector<uint8_t>{0, 1}; }

--- a/test/ttexalens/pybind/test_bindings.py
+++ b/test/ttexalens/pybind/test_bindings.py
@@ -32,9 +32,9 @@ class TestBindings(unittest.TestCase):
         self,
         data: int = 2,
     ):
-        assert pb.pci_read32(0, 1, 0, 0) is None, "Error: pci_read32 should return None before writing."
-        assert pb.pci_write32(0, 1, 0, 0, data) == data, "Error: pci_write32 should return the data written."
-        assert pb.pci_read32(0, 1, 0, 0) == data, "Error: pci_read32 should return the data written."
+        assert pb.pci_read32(0, 0, 1, 0, 0) is None, "Error: pci_read32 should return None before writing."
+        assert pb.pci_write32(0, 0, 1, 0, 0, data) == data, "Error: pci_write32 should return the data written."
+        assert pb.pci_read32(0, 0, 1, 0, 0) == data, "Error: pci_read32 should return the data written."
 
     def test_pci_read_write32_raw(
         self,
@@ -45,19 +45,21 @@ class TestBindings(unittest.TestCase):
         assert pb.pci_read32_raw(1, 1) == data, "Error: pci_read32_raw should return the data written."
 
     def test_pci_read_write(self, data: Union[bytes, bytearray] = bytearray([1, 5, 3]), size=3):
-        assert pb.pci_read(3, 3, 3, 3, size) is None, "Error: pci_read should return None before writing."
-        assert pb.pci_write(3, 3, 3, 3, data, 3) == size, "Error: pci_write should return the size of the data written."
+        assert pb.pci_read(0, 3, 3, 3, 3, size) is None, "Error: pci_read should return None before writing."
+        assert (
+            pb.pci_write(0, 3, 3, 3, 3, data, 3) == size
+        ), "Error: pci_write should return the size of the data written."
 
-        rlist = pb.pci_read(3, 3, 3, 3, 3)
+        rlist = pb.pci_read(0, 3, 3, 3, 3, 3)
         for x, y in zip(data, rlist):
             assert x == y, "Error: pci_read should return the data written."
 
     def pci_write_negative(self, data: list = [1, 2, -3], size=3):
         assert (
-            pb.pci_write(5, 5, 5, 5, data, 3) is None
+            pb.pci_write(0, 5, 5, 5, 5, data, 3) is None
         ), "Error: pci_write should return None if any of the data is negative."
-        pb.pci_write(5, 5, 5, 5, [4, 5, 6], 3)
-        rlist = pb.pci_read(5, 5, 5, 5, 3)
+        pb.pci_write(0, 5, 5, 5, 5, [4, 5, 6], 3)
+        rlist = pb.pci_read(0, 5, 5, 5, 5, 3)
         for x, y in zip(data, rlist):
             assert x == y, "Error: pci_read should return the data written."
 
@@ -72,8 +74,8 @@ class TestBindings(unittest.TestCase):
 
     def test_pci_read_tile(self):
         assert (
-            pb.pci_read_tile(1, 2, 3, 4, 5, 6) == "pci_read_tile(1, 2, 3, 4, 5, 6)"
-        ), "Error: pci_read_tile(1, 2, 3, 4, 5, 6) should return 'pci_read_tile(1, 2, 3, 4, 5, 6)'."
+            pb.pci_read_tile(0, 1, 2, 3, 4, 5, 6) == "pci_read_tile(0, 1, 2, 3, 4, 5, 6)"
+        ), "Error: pci_read_tile(0, 1, 2, 3, 4, 5, 6) should return 'pci_read_tile(0, 1, 2, 3, 4, 5, 6)'."
 
     def test_get_cluster_description(self):
         assert (

--- a/test/ttexalens/server/test_communication.cpp
+++ b/test/ttexalens/server/test_communication.cpp
@@ -78,18 +78,19 @@ TEST(ttexalens_communication, get_device_ids) {
 }
 
 TEST(ttexalens_communication, pci_read32) {
-    test_yaml_request(tt::exalens::pci_read32_request{tt::exalens::request_type::pci_read32, 1, 2, 3, 123456},
-                      "- type: 10\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
+    test_yaml_request(tt::exalens::pci_read32_request{tt::exalens::request_type::pci_read32, 0, 1, 2, 3, 123456},
+                      "- type: 10\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
 }
 
 TEST(ttexalens_communication, pci_write32) {
-    test_yaml_request(tt::exalens::pci_write32_request{tt::exalens::request_type::pci_write32, 1, 2, 3, 123456, 987654},
-                      "- type: 11\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
+    test_yaml_request(
+        tt::exalens::pci_write32_request{tt::exalens::request_type::pci_write32, 0, 1, 2, 3, 123456, 987654},
+        "- type: 11\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
 }
 
 TEST(ttexalens_communication, pci_read) {
-    test_yaml_request(tt::exalens::pci_read_request{tt::exalens::request_type::pci_read, 1, 2, 3, 123456, 1024},
-                      "- type: 12\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024");
+    test_yaml_request(tt::exalens::pci_read_request{tt::exalens::request_type::pci_read, 0, 1, 2, 3, 123456, 1024},
+                      "- type: 12\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024");
 }
 
 TEST(ttexalens_communication, pci_read32_raw) {
@@ -111,8 +112,9 @@ TEST(ttexalens_communication, dma_buffer_read32) {
 
 TEST(ttexalens_communication, pci_read_tile) {
     test_yaml_request(
-        tt::exalens::pci_read_tile_request{tt::exalens::request_type::pci_read_tile, 1, 2, 3, 123456, 1024, 14},
-        "- type: 100\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  data_format: 14");
+        tt::exalens::pci_read_tile_request{tt::exalens::request_type::pci_read_tile, 0, 1, 2, 3, 123456, 1024, 14},
+        "- type: 100\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  "
+        "data_format: 14");
 }
 
 TEST(ttexalens_communication, get_device_arch) {
@@ -129,12 +131,14 @@ TEST(ttexalens_communication, get_device_soc_description) {
 TEST(ttexalens_communication, pci_write) {
     // This test is different because we are trying to send request that has dynamic structure size
     std::string expected_response =
-        "- type: 13\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, 12, 13, 14, "
+        "- type: 13\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, "
+        "12, 13, 14, "
         "15, 16, 17]";
     constexpr size_t data_size = 8;
     std::array<uint8_t, data_size + sizeof(tt::exalens::pci_write_request)> request_data = {0};
     auto request = reinterpret_cast<tt::exalens::pci_write_request*>(&request_data[0]);
     request->type = tt::exalens::request_type::pci_write;
+    request->noc_id = 0;
     request->chip_id = 1;
     request->noc_x = 2;
     request->noc_y = 3;
@@ -189,22 +193,24 @@ TEST(ttexalens_communication, convert_from_noc0) {
 }
 
 TEST(ttexalens_communication, arc_msg) {
-    auto req = tt::exalens::arc_msg_request{tt::exalens::request_type::arc_msg, 1, 2, true, 3, 4, 5};
+    auto req = tt::exalens::arc_msg_request{tt::exalens::request_type::arc_msg, 0, 1, 2, true, 3, 4, 5};
 
-    test_yaml_request(req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::arc_msg)) +
-                               "\n  chip_id: 1\n  msg_code: 2\n  wait_for_done: 1\n  arg0: 3\n  arg1: 4\n  timeout: 5");
+    test_yaml_request(
+        req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::arc_msg)) +
+                 "\n  noc_id: 0\n  chip_id: 1\n  msg_code: 2\n  wait_for_done: 1\n  arg0: 3\n  arg1: 4\n  timeout: 5");
 }
 
 TEST(ttexalens_communication, jtag_read32) {
-    auto req = tt::exalens::jtag_read32_request{tt::exalens::request_type::jtag_read32, 1, 2, 3, 123456};
+    auto req = tt::exalens::jtag_read32_request{tt::exalens::request_type::jtag_read32, 0, 1, 2, 3, 123456};
     test_yaml_request(req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::jtag_read32)) +
-                               "\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
+                               "\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
 }
 
 TEST(ttexalens_communication, jtag_write32) {
-    auto req = tt::exalens::jtag_write32_request{tt::exalens::request_type::jtag_write32, 1, 2, 3, 123456, 987654};
-    test_yaml_request(req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::jtag_write32)) +
-                               "\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
+    auto req = tt::exalens::jtag_write32_request{tt::exalens::request_type::jtag_write32, 0, 1, 2, 3, 123456, 987654};
+    test_yaml_request(req,
+                      "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::jtag_write32)) +
+                          "\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
 }
 
 TEST(ttexalens_communication, jtag_read32_axi) {

--- a/test/ttexalens/server/test_communication.py
+++ b/test/ttexalens/server/test_communication.py
@@ -37,24 +37,24 @@ def get_device_ids():
 def pci_read32():
     global server_communication
     check_response(
-        server_communication.pci_read32(1, 2, 3, 123456),
-        "- type: 10\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456",
+        server_communication.pci_read32(0, 1, 2, 3, 123456),
+        "- type: 10\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456",
     )
 
 
 def pci_write32():
     global server_communication
     check_response(
-        server_communication.pci_write32(1, 2, 3, 123456, 987654),
-        "- type: 11\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654",
+        server_communication.pci_write32(0, 1, 2, 3, 123456, 987654),
+        "- type: 11\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654",
     )
 
 
 def pci_read():
     global server_communication
     check_response(
-        server_communication.pci_read(1, 2, 3, 123456, 1024),
-        "- type: 12\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024",
+        server_communication.pci_read(0, 1, 2, 3, 123456, 1024),
+        "- type: 12\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024",
     )
 
 
@@ -85,8 +85,8 @@ def dma_buffer_read32():
 def pci_read_tile():
     global server_communication
     check_response(
-        server_communication.pci_read_tile(1, 2, 3, 123456, 1024, 14),
-        "- type: 100\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  data_format: 14",
+        server_communication.pci_read_tile(0, 1, 2, 3, 123456, 1024, 14),
+        "- type: 100\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  data_format: 14",
     )
 
 
@@ -117,8 +117,8 @@ def convert_from_noc0():
 def pci_write():
     global server_communication
     check_response(
-        server_communication.pci_write(1, 2, 3, 123456, bytes([10, 11, 12, 13, 14, 15, 16, 17])),
-        "- type: 13\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, 12, 13, 14, 15, 16, 17]",
+        server_communication.pci_write(0, 1, 2, 3, 123456, bytes([10, 11, 12, 13, 14, 15, 16, 17])),
+        "- type: 13\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, 12, 13, 14, 15, 16, 17]",
     )
 
 
@@ -133,16 +133,16 @@ def get_file():
 def jtag_read32():
     global server_communication
     check_response(
-        server_communication.jtag_read32(1, 2, 3, 123456),
-        "- type: 50\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456",
+        server_communication.jtag_read32(0, 1, 2, 3, 123456),
+        "- type: 50\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456",
     )
 
 
 def jtag_write32():
     global server_communication
     check_response(
-        server_communication.jtag_write32(1, 2, 3, 123456, 987654),
-        "- type: 51\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654",
+        server_communication.jtag_write32(0, 1, 2, 3, 123456, 987654),
+        "- type: 51\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654",
     )
 
 

--- a/test/ttexalens/server/test_python_communication.cpp
+++ b/test/ttexalens/server/test_python_communication.cpp
@@ -60,15 +60,17 @@ TEST(ttexalens_python_communication, get_cluster_description) {
 TEST(ttexalens_python_communication, get_device_ids) { call_python("get_device_ids", "- type: 18\n"); }
 
 TEST(ttexalens_python_communication, pci_read32) {
-    call_python("pci_read32", "- type: 10\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n");
+    call_python("pci_read32", "- type: 10\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n");
 }
 
 TEST(ttexalens_python_communication, pci_write32) {
-    call_python("pci_write32", "- type: 11\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654\n");
+    call_python("pci_write32",
+                "- type: 11\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654\n");
 }
 
 TEST(ttexalens_python_communication, pci_read) {
-    call_python("pci_read", "- type: 12\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n");
+    call_python("pci_read",
+                "- type: 12\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n");
 }
 
 TEST(ttexalens_python_communication, pci_read32_raw) {
@@ -84,9 +86,9 @@ TEST(ttexalens_python_communication, dma_buffer_read32) {
 }
 
 TEST(ttexalens_python_communication, pci_read_tile) {
-    call_python(
-        "pci_read_tile",
-        "- type: 100\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  data_format: 14\n");
+    call_python("pci_read_tile",
+                "- type: 100\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  "
+                "data_format: 14\n");
 }
 
 TEST(ttexalens_python_communication, get_device_arch) { call_python("get_device_arch", "- type: 19\n  chip_id: 1\n"); }
@@ -102,10 +104,10 @@ TEST(ttexalens_python_communication, convert_from_noc0) {
 }
 
 TEST(ttexalens_python_communication, pci_write) {
-    call_python(
-        "pci_write",
-        "- type: 13\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, 12, 13, 14, "
-        "15, 16, 17]\n");
+    call_python("pci_write",
+                "- type: 13\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: "
+                "[10, 11, 12, 13, 14, "
+                "15, 16, 17]\n");
 }
 
 TEST(ttexalens_python_communication, get_file) {
@@ -113,12 +115,12 @@ TEST(ttexalens_python_communication, get_file) {
 }
 
 TEST(ttexalens_python_communication, jtag_read32) {
-    call_python("jtag_read32", "- type: 50\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n");
+    call_python("jtag_read32", "- type: 50\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n");
 }
 
 TEST(ttexalens_python_communication, jtag_write32) {
     call_python("jtag_write32",
-                "- type: 51\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654\n");
+                "- type: 51\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654\n");
 }
 
 TEST(ttexalens_python_communication, jtag_read32_axi) {

--- a/test/ttexalens/server/test_python_server.cpp
+++ b/test/ttexalens/server/test_python_server.cpp
@@ -28,40 +28,41 @@ class simulation_server : public tt::exalens::server {
 // For every write combination, read of the same communication will return that result.
 class simulation_implementation : public tt::exalens::ttexalens_implementation {
    private:
-    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> read_write_4;
-    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint64_t, uint32_t>, std::vector<uint8_t>> read_write;
+    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> read_write_4;
+    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint8_t, uint64_t, uint32_t>, std::vector<uint8_t>> read_write;
     std::map<std::tuple<uint8_t, uint64_t>, uint32_t> read_write_4_raw;
-    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> jtag_read_write_4;
-    std::map<uint32_t, uint32_t> jtag_read_write_2;
+    std::map<std::tuple<uint8_t, uint8_t, uint8_t, uint8_t, uint64_t>, uint32_t> jtag_read_write_4;
+    std::map<uint32_t, uint32_t> jtag_read_write_4_axi;
 
    protected:
-    std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override {
-        auto it = read_write_4.find(std::make_tuple(chip_id, noc_x, noc_y, address));
+    std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                       uint64_t address) override {
+        auto it = read_write_4.find(std::make_tuple(noc_id, chip_id, noc_x, noc_y, address));
         if (it != read_write_4.end()) {
             return it->second;
         }
         return {};
     }
-    std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                         uint32_t data) override {
-        read_write_4[std::make_tuple(chip_id, noc_x, noc_y, address)] = data;
+        read_write_4[std::make_tuple(noc_id, chip_id, noc_x, noc_y, address)] = data;
         return 4;
     }
-    std::optional<std::vector<uint8_t>> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                 uint32_t size) override {
-        auto it = read_write.find(std::make_tuple(chip_id, noc_x, noc_y, address, size));
+    std::optional<std::vector<uint8_t>> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                 uint64_t address, uint32_t size) override {
+        auto it = read_write.find(std::make_tuple(noc_id, chip_id, noc_x, noc_y, address, size));
         if (it != read_write.end()) {
             return it->second;
         }
         return {};
     }
-    std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                       const uint8_t* data, uint32_t size) override {
         std::vector<uint8_t> data_vector(size);
         for (size_t i = 0; i < size; i++) {
             data_vector[i] = data[i];
         }
-        read_write[std::make_tuple(chip_id, noc_x, noc_y, address, size)] = data_vector;
+        read_write[std::make_tuple(noc_id, chip_id, noc_x, noc_y, address, size)] = data_vector;
         return size;
     }
     std::optional<uint32_t> pci_read32_raw(uint8_t chip_id, uint64_t address) override {
@@ -83,36 +84,37 @@ class simulation_implementation : public tt::exalens::ttexalens_implementation {
         return {};
     }
 
-    std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override {
-        auto it = jtag_read_write_4.find(std::make_tuple(chip_id, noc_x, noc_y, address));
+    std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                        uint64_t address) override {
+        auto it = jtag_read_write_4.find(std::make_tuple(noc_id, chip_id, noc_x, noc_y, address));
         if (it != jtag_read_write_4.end()) {
             return it->second;
         }
         return {};
     }
-    std::optional<int> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                     uint32_t data) override {
-        jtag_read_write_4[std::make_tuple(chip_id, noc_x, noc_y, address)] = data;
+        jtag_read_write_4[std::make_tuple(noc_id, chip_id, noc_x, noc_y, address)] = data;
         return 4;
     }
 
     std::optional<uint32_t> jtag_read32_axi(uint8_t chip_id, uint32_t address) override {
-        auto it = jtag_read_write_2.find(address);
-        if (it != jtag_read_write_2.end()) {
+        auto it = jtag_read_write_4_axi.find(address);
+        if (it != jtag_read_write_4_axi.end()) {
             return it->second;
         }
         return {};
     }
     std::optional<int> jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) override {
-        jtag_read_write_2[address] = data;
+        jtag_read_write_4_axi[address] = data;
         return 4;
     }
 
-    std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                             uint32_t size, uint8_t data_format) override {
-        return "pci_read_tile(" + std::to_string(chip_id) + ", " + std::to_string(noc_x) + ", " +
-               std::to_string(noc_y) + ", " + std::to_string(address) + ", " + std::to_string(size) + ", " +
-               std::to_string(data_format) + ")";
+    std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                             uint64_t address, uint32_t size, uint8_t data_format) override {
+        return "pci_read_tile(" + std::to_string(noc_id) + ", " + std::to_string(chip_id) + ", " +
+               std::to_string(noc_x) + ", " + std::to_string(noc_y) + ", " + std::to_string(address) + ", " +
+               std::to_string(size) + ", " + std::to_string(data_format) + ")";
     }
     std::optional<std::string> get_cluster_description() override { return "get_cluster_description()"; }
     std::optional<std::vector<uint8_t>> get_device_ids() override { return std::vector<uint8_t>{0, 1}; }

--- a/test/ttexalens/server/test_server.cpp
+++ b/test/ttexalens/server/test_server.cpp
@@ -54,34 +54,37 @@ class yaml_not_implemented_implementation : public ttexalens_implementation {
    public:
     yaml_not_implemented_implementation(yaml_not_implemented_server *server) : server(server) {}
 
-    std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override {
+    std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                       uint64_t address) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::pci_read32)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address));
         return {};
     }
-    std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                         uint32_t data) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::pci_write32)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address) +
-                          "\n  data: " + std::to_string(data));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address) + "\n  data: " + std::to_string(data));
         return {};
     }
-    std::optional<std::vector<uint8_t>> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                 uint32_t size) override {
+    std::optional<std::vector<uint8_t>> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                 uint64_t address, uint32_t size) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::pci_read)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address) +
-                          "\n  size: " + std::to_string(size));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address) + "\n  size: " + std::to_string(size));
         return {};
     }
-    std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                       const uint8_t *data, uint32_t size) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::pci_write)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address) +
-                          "\n  size: " + std::to_string(size) + "\n  data: " + serialize_bytes(data, size));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address) + "\n  size: " + std::to_string(size) +
+                          "\n  data: " + serialize_bytes(data, size));
         return {};
     }
     std::optional<uint32_t> pci_read32_raw(uint8_t chip_id, uint64_t address) override {
@@ -102,12 +105,13 @@ class yaml_not_implemented_implementation : public ttexalens_implementation {
         return {};
     }
 
-    std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                             uint32_t size, uint8_t data_format) override {
+    std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                             uint64_t address, uint32_t size, uint8_t data_format) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::pci_read_tile)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address) +
-                          "\n  size: " + std::to_string(size) + "\n  data_format: " + std::to_string(data_format));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address) + "\n  size: " + std::to_string(size) +
+                          "\n  data_format: " + std::to_string(data_format));
         return {};
     }
 
@@ -140,27 +144,31 @@ class yaml_not_implemented_implementation : public ttexalens_implementation {
         return {};
     }
 
-    std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t chip_id, uint32_t msg_code, bool wait_for_done,
-                                                               uint32_t arg0, uint32_t arg1, int timeout) override {
+    std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id, uint32_t msg_code,
+                                                               bool wait_for_done, uint32_t arg0, uint32_t arg1,
+                                                               int timeout) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::arc_msg)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  msg_code: " + std::to_string(msg_code) +
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  msg_code: " + std::to_string(msg_code) +
                           "\n  wait_for_done: " + std::to_string(wait_for_done) + "\n  arg0: " + std::to_string(arg0) +
                           "\n  arg1: " + std::to_string(arg1) + "\n  timeout: " + std::to_string(timeout));
         return {};
     }
 
-    std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override {
+    std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                        uint64_t address) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::jtag_read32)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address));
         return {};
     }
-    std::optional<int> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                     uint32_t data) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::jtag_write32)) +
-                          "\n  chip_id: " + std::to_string(chip_id) + "\n  noc_x: " + std::to_string(noc_x) +
-                          "\n  noc_y: " + std::to_string(noc_y) + "\n  address: " + std::to_string(address) +
-                          "\n  data: " + std::to_string(data));
+                          "\n  noc_id: " + std::to_string(noc_id) + "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  noc_x: " + std::to_string(noc_x) + "\n  noc_y: " + std::to_string(noc_y) +
+                          "\n  address: " + std::to_string(address) + "\n  data: " + std::to_string(data));
         return {};
     }
 
@@ -254,20 +262,20 @@ TEST(ttexalens_server, get_device_ids) {
 
 TEST(ttexalens_server, pci_read32) {
     test_not_implemented_request(
-        tt::exalens::pci_read32_request{tt::exalens::request_type::pci_read32, 1, 2, 3, 123456},
-        "- type: 10\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
+        tt::exalens::pci_read32_request{tt::exalens::request_type::pci_read32, 0, 1, 2, 3, 123456},
+        "- type: 10\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
 }
 
 TEST(ttexalens_server, pci_write32) {
     test_not_implemented_request(
-        tt::exalens::pci_write32_request{tt::exalens::request_type::pci_write32, 1, 2, 3, 123456, 987654},
-        "- type: 11\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
+        tt::exalens::pci_write32_request{tt::exalens::request_type::pci_write32, 0, 1, 2, 3, 123456, 987654},
+        "- type: 11\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
 }
 
 TEST(ttexalens_server, pci_read) {
     test_not_implemented_request(
-        tt::exalens::pci_read_request{tt::exalens::request_type::pci_read, 1, 2, 3, 123456, 1024},
-        "- type: 12\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024");
+        tt::exalens::pci_read_request{tt::exalens::request_type::pci_read, 0, 1, 2, 3, 123456, 1024},
+        "- type: 12\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024");
 }
 
 TEST(ttexalens_server, pci_read32_raw) {
@@ -290,8 +298,9 @@ TEST(ttexalens_server, dma_buffer_read32) {
 
 TEST(ttexalens_server, pci_read_tile) {
     test_not_implemented_request(
-        tt::exalens::pci_read_tile_request{tt::exalens::request_type::pci_read_tile, 1, 2, 3, 123456, 1024, 14},
-        "- type: 100\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  data_format: 14");
+        tt::exalens::pci_read_tile_request{tt::exalens::request_type::pci_read_tile, 0, 1, 2, 3, 123456, 1024, 14},
+        "- type: 100\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 1024\n  "
+        "data_format: 14");
 }
 
 TEST(ttexalens_server, get_device_arch) {
@@ -307,14 +316,14 @@ TEST(ttexalens_server, get_device_soc_description) {
 
 TEST(ttexalens_server, jtag_read32) {
     test_not_implemented_request(
-        tt::exalens::jtag_read32_request{tt::exalens::request_type::jtag_read32, 1, 2, 3, 123456},
-        "- type: 50\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
+        tt::exalens::jtag_read32_request{tt::exalens::request_type::jtag_read32, 0, 1, 2, 3, 123456},
+        "- type: 50\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456");
 }
 
 TEST(ttexalens_server, jtag_write32) {
     test_not_implemented_request(
-        tt::exalens::jtag_write32_request{tt::exalens::request_type::jtag_write32, 1, 2, 3, 123456, 987654},
-        "- type: 51\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
+        tt::exalens::jtag_write32_request{tt::exalens::request_type::jtag_write32, 0, 1, 2, 3, 123456, 987654},
+        "- type: 51\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  data: 987654");
 }
 
 TEST(ttexalens_server, jtag_read32_axi) {
@@ -332,12 +341,14 @@ TEST(ttexalens_server, jtag_write32_axi) {
 TEST(ttexalens_server, pci_write) {
     // This test is different because we are trying to send request that has dynamic structure size
     std::string expected_response =
-        "- type: 13\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, 12, 13, 14, "
+        "- type: 13\n  noc_id: 0\n  chip_id: 1\n  noc_x: 2\n  noc_y: 3\n  address: 123456\n  size: 8\n  data: [10, 11, "
+        "12, 13, 14, "
         "15, 16, 17]";
     constexpr size_t data_size = 8;
     std::array<uint8_t, data_size + sizeof(tt::exalens::pci_write_request)> request_data = {0};
     auto request = reinterpret_cast<tt::exalens::pci_write_request *>(&request_data[0]);
     request->type = tt::exalens::request_type::pci_write;
+    request->noc_id = 0;
     request->chip_id = 1;
     request->noc_x = 2;
     request->noc_y = 3;

--- a/test/ttexalens/server/test_server.py
+++ b/test/ttexalens/server/test_server.py
@@ -30,17 +30,17 @@ def empty_convert_from_noc0():
 
 def empty_pci_read32():
     global server
-    check_not_implemented_response(lambda: server.pci_read32(1, 2, 3, 123456))
+    check_not_implemented_response(lambda: server.pci_read32(0, 1, 2, 3, 123456))
 
 
 def empty_pci_write32():
     global server
-    check_not_implemented_response(lambda: server.pci_write32(1, 2, 3, 123456, 987654))
+    check_not_implemented_response(lambda: server.pci_write32(0, 1, 2, 3, 123456, 987654))
 
 
 def empty_pci_read():
     global server
-    check_not_implemented_response(lambda: server.pci_read(1, 2, 3, 123456, 1024))
+    check_not_implemented_response(lambda: server.pci_read(0, 1, 2, 3, 123456, 1024))
 
 
 def empty_pci_read32_raw():
@@ -60,22 +60,24 @@ def empty_dma_buffer_read32():
 
 def empty_pci_read_tile():
     global server
-    check_not_implemented_response(lambda: server.pci_read_tile(1, 2, 3, 123456, 1024, 14))
+    check_not_implemented_response(lambda: server.pci_read_tile(0, 1, 2, 3, 123456, 1024, 14))
 
 
 def empty_pci_write():
     global server
-    check_not_implemented_response(lambda: server.pci_write(1, 2, 3, 123456, bytes([10, 11, 12, 13, 14, 15, 16, 17])))
+    check_not_implemented_response(
+        lambda: server.pci_write(0, 1, 2, 3, 123456, bytes([10, 11, 12, 13, 14, 15, 16, 17]))
+    )
 
 
 def empty_jtag_read32():
     global server
-    check_not_implemented_response(lambda: server.jtag_read32(1, 2, 3, 123456))
+    check_not_implemented_response(lambda: server.jtag_read32(0, 1, 2, 3, 123456))
 
 
 def empty_jtag_write32():
     global server
-    check_not_implemented_response(lambda: server.jtag_write32(1, 2, 3, 123456, 987654))
+    check_not_implemented_response(lambda: server.jtag_write32(0, 1, 2, 3, 123456, 987654))
 
 
 def empty_jtag_read32_axi():
@@ -95,15 +97,15 @@ def empty_get_file():
 
 def pci_write32_pci_read32():
     global server
-    server.pci_write32(1, 2, 3, 123456, 987654)
-    read = server.pci_read32(1, 2, 3, 123456)
+    server.pci_write32(0, 1, 2, 3, 123456, 987654)
+    read = server.pci_read32(0, 1, 2, 3, 123456)
     print("pass" if read == 987654 else "fail")
 
 
 def pci_write_pci_read():
     global server
-    server.pci_write(1, 2, 3, 123456, b"987654")
-    read = server.pci_read(1, 2, 3, 123456, 6)
+    server.pci_write(0, 1, 2, 3, 123456, b"987654")
+    read = server.pci_read(0, 1, 2, 3, 123456, 6)
     print("pass" if read == b"987654" else "fail")
 
 
@@ -123,14 +125,14 @@ def dma_buffer_read32():
 
 def pci_read_tile():
     global server
-    read = server.pci_read_tile(1, 2, 3, 123456, 1024, 14)
-    print("pass" if read == "pci_read_tile(1, 2, 3, 123456, 1024, 14)" else "fail")
+    read = server.pci_read_tile(0, 1, 2, 3, 123456, 1024, 14)
+    print("pass" if read == "pci_read_tile(0, 1, 2, 3, 123456, 1024, 14)" else "fail")
 
 
 def jtag_write32_jtag_read32():
     global server
-    server.jtag_write32(1, 2, 3, 123456, 987654)
-    read = server.jtag_read32(1, 2, 3, 123456)
+    server.jtag_write32(0, 1, 2, 3, 123456, 987654)
+    read = server.jtag_read32(0, 1, 2, 3, 123456)
     print("pass" if read == 987654 else "fail")
 
 

--- a/test/ttexalens/server/yaml_communication.cpp
+++ b/test/ttexalens/server/yaml_communication.cpp
@@ -78,29 +78,31 @@ std::string yaml_communication::serialize(const tt::exalens::request& request) {
 
 std::string yaml_communication::serialize(const tt::exalens::pci_read32_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::pci_write32_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address) +
-           "\n  data: " + std::to_string(request.data);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address) + "\n  data: " + std::to_string(request.data);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::pci_read_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address) +
-           "\n  size: " + std::to_string(request.size);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address) + "\n  size: " + std::to_string(request.size);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::pci_write_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address) +
-           "\n  size: " + std::to_string(request.size) + "\n  data: " + serialize_bytes(request.data, request.size);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address) + "\n  size: " + std::to_string(request.size) +
+           "\n  data: " + serialize_bytes(request.data, request.size);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::pci_read32_raw_request& request) {
@@ -122,9 +124,10 @@ std::string yaml_communication::serialize(const tt::exalens::dma_buffer_read32_r
 
 std::string yaml_communication::serialize(const tt::exalens::pci_read_tile_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address) +
-           "\n  size: " + std::to_string(request.size) + "\n  data_format: " + std::to_string(request.data_format);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address) + "\n  size: " + std::to_string(request.size) +
+           "\n  data_format: " + std::to_string(request.data_format);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::convert_from_noc0_request& request) {
@@ -153,22 +156,24 @@ std::string yaml_communication::serialize(const tt::exalens::get_file_request& r
 
 std::string yaml_communication::serialize(const tt::exalens::arc_msg_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  msg_code: " + std::to_string(request.msg_code) +
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  msg_code: " + std::to_string(request.msg_code) +
            "\n  wait_for_done: " + std::to_string(request.wait_for_done) + "\n  arg0: " + std::to_string(request.arg0) +
            "\n  arg1: " + std::to_string(request.arg1) + "\n  timeout: " + std::to_string(request.timeout);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::jtag_read32_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::jtag_write32_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  noc_x: " + std::to_string(request.noc_x) +
-           "\n  noc_y: " + std::to_string(request.noc_y) + "\n  address: " + std::to_string(request.address) +
-           "\n  data: " + std::to_string(request.data);
+           "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  noc_x: " + std::to_string(request.noc_x) + "\n  noc_y: " + std::to_string(request.noc_y) +
+           "\n  address: " + std::to_string(request.address) + "\n  data: " + std::to_string(request.data);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::jtag_read32_axi_request& request) {

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -5,7 +5,7 @@
 """
 Usage:
   tt-exalens [--commands=<cmds>] [--write-cache] [--cache-path=<path>] [--start-gdb=<gdb_port>] [--devices=<devices>] [--verbosity=<verbosity>] [--test] [--jtag] [--use-noc1]
-  tt-exalens --server [--port=<port>] [--devices=<devices>] [--test] [--jtag] [-s=<simulation_directory>] [--background] [--use-noc1]
+  tt-exalens --server [--port=<port>] [--devices=<devices>] [--test] [--jtag] [-s=<simulation_directory>] [--background] [--initialize-with-noc1]
   tt-exalens --remote [--remote-address=<ip:port>] [--commands=<cmds>] [--write-cache] [--cache-path=<path>] [--start-gdb=<gdb_port>] [--verbosity=<verbosity>] [--test]
   tt-exalens --cached [--cache-path=<path>] [--commands=<cmds>] [--verbosity=<verbosity>] [--test]
   tt-exalens -h | --help
@@ -23,6 +23,7 @@ Options:
   --cache-path=<path>             If running in --cached mode, this is the path to the cache file. If writing cache, this is the path for output. [default: ttexalens_cache.pkl]
   --devices=<devices>             Comma-separated list of devices to load. If not supplied, all devices will be loaded.
   --background                    Start the server in the background detached from console (doesn't require ENTER button for exit, but exit.server file to be created).
+  --initialize-with-noc1          Initialize the device with NOC1.
   -s=<simulation_directory>       Specifies build output directory of the simulator.
   --verbosity=<verbosity>         Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
   --test                          Exits with non-zero exit code on any exception.
@@ -420,7 +421,7 @@ def main():
             args["--port"],
             wanted_devices,
             init_jtag=args["--jtag"],
-            use_noc1=args["--use-noc1"],
+            initialize_with_noc1=args["--initialize-with-noc1"],
             simulation_directory=args["-s"],
             background=args["--background"],
         )

--- a/ttexalens/pybind/inc/bindings.h
+++ b/ttexalens/pybind/inc/bindings.h
@@ -12,23 +12,24 @@
 #include <memory>
 
 bool open_device(const std::string& binary_directory, const std::vector<uint8_t>& wanted_devices = {},
-                 bool init_jtag = false, bool use_noc1 = false);
+                 bool init_jtag = false, bool initialize_with_noc1 = false);
 void set_ttexalens_implementation(std::unique_ptr<tt::exalens::ttexalens_implementation> imp);
 
-std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
-std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data);
+std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
+std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+                                    uint32_t data);
 
-std::optional<pybind11::object> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                         uint32_t size);
-std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+std::optional<pybind11::object> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                         uint64_t address, uint32_t size);
+std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                   pybind11::buffer data, uint32_t size);
 
 std::optional<uint32_t> pci_read32_raw(uint8_t chip_id, uint64_t address);
 std::optional<uint32_t> pci_write32_raw(uint8_t chip_id, uint64_t address, uint32_t data);
 
 std::optional<uint32_t> dma_buffer_read32(uint8_t chip_id, uint64_t address, uint32_t channel);
-std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t size,
-                                         uint8_t data_format);
+std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                         uint64_t address, uint32_t size, uint8_t data_format);
 
 std::optional<std::string> get_cluster_description();
 std::optional<std::tuple<uint8_t, uint8_t>> convert_from_noc0(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
@@ -38,7 +39,8 @@ std::optional<std::vector<uint8_t>> get_device_ids();
 std::optional<std::string> get_device_arch(uint8_t chip_id);
 std::optional<std::string> get_device_soc_description(uint8_t chip_id);
 
-std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
-std::optional<uint32_t> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data);
+std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
+std::optional<uint32_t> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+                                     uint32_t data);
 std::optional<uint32_t> jtag_read32_axi(uint8_t chip_id, uint32_t address);
 std::optional<uint32_t> jtag_write32_axi(uint8_t chip_id, uint64_t address, uint32_t data);

--- a/ttexalens/pybind/src/bindings.cpp
+++ b/ttexalens/pybind/src/bindings.cpp
@@ -33,17 +33,17 @@ void set_ttexalens_implementation(std::unique_ptr<tt::exalens::ttexalens_impleme
 }
 
 bool open_device(const std::string &binary_directory, const std::vector<uint8_t> &wanted_devices, bool init_jtag,
-                 bool use_noc1) {
+                 bool initialize_with_noc1) {
     try {
         // Since tt::umd::Cluster is printing some output and we don't want to see it in python, we disable std::cout
         scoped_null_stdout null_stdout;
 
         if (init_jtag) {
             ttexalens_implementation = tt::exalens::open_implementation<tt::exalens::jtag_implementation>::open(
-                binary_directory, wanted_devices, use_noc1);
+                binary_directory, wanted_devices, initialize_with_noc1);
         } else {
             ttexalens_implementation = tt::exalens::open_implementation<tt::exalens::umd_implementation>::open(
-                binary_directory, wanted_devices, use_noc1);
+                binary_directory, wanted_devices, initialize_with_noc1);
         }
         if (!ttexalens_implementation) {
             return false;
@@ -55,24 +55,25 @@ bool open_device(const std::string &binary_directory, const std::vector<uint8_t>
     return true;
 }
 
-std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
+std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->pci_read32(chip_id, noc_x, noc_y, address);
+        return ttexalens_implementation->pci_read32(noc_id, chip_id, noc_x, noc_y, address);
     }
     return {};
 }
 
-std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data) {
+std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+                                    uint32_t data) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->pci_write32(chip_id, noc_x, noc_y, address, data);
+        return ttexalens_implementation->pci_write32(noc_id, chip_id, noc_x, noc_y, address, data);
     }
     return {};
 }
 
-std::optional<pybind11::object> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                         uint32_t size) {
+std::optional<pybind11::object> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                         uint64_t address, uint32_t size) {
     if (ttexalens_implementation) {
-        auto data = ttexalens_implementation->pci_read(chip_id, noc_x, noc_y, address, size);
+        auto data = ttexalens_implementation->pci_read(noc_id, chip_id, noc_x, noc_y, address, size);
 
         if (data) {
             // This is a hacky way to create a bytes object for Python so that we avoid multiple
@@ -97,13 +98,13 @@ std::optional<pybind11::object> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t
     return {};
 }
 
-std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                   pybind11::buffer data, uint32_t size) {
     if (ttexalens_implementation) {
         pybind11::buffer_info info = data.request();
         uint8_t *data_ptr = static_cast<uint8_t *>(info.ptr);
 
-        return ttexalens_implementation->pci_write(chip_id, noc_x, noc_y, address, data_ptr, size);
+        return ttexalens_implementation->pci_write(noc_id, chip_id, noc_x, noc_y, address, data_ptr, size);
     }
     return {};
 }
@@ -129,24 +130,25 @@ std::optional<uint32_t> dma_buffer_read32(uint8_t chip_id, uint64_t address, uin
     return {};
 }
 
-std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t size,
-                                         uint8_t data_format) {
+std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                         uint64_t address, uint32_t size, uint8_t data_format) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->pci_read_tile(chip_id, noc_x, noc_y, address, size, data_format);
+        return ttexalens_implementation->pci_read_tile(noc_id, chip_id, noc_x, noc_y, address, size, data_format);
     }
     return {};
 }
 
-std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
+std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->jtag_read32(chip_id, noc_x, noc_y, address);
+        return ttexalens_implementation->jtag_read32(noc_id, chip_id, noc_x, noc_y, address);
     }
     return {};
 }
 
-std::optional<uint32_t> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address, uint32_t data) {
+std::optional<uint32_t> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+                                     uint32_t data) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->jtag_write32(chip_id, noc_x, noc_y, address, data);
+        return ttexalens_implementation->jtag_write32(noc_id, chip_id, noc_x, noc_y, address, data);
     }
     return {};
 }
@@ -202,10 +204,11 @@ std::optional<std::string> get_device_soc_description(uint8_t chip_id) {
     return {};
 }
 
-std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t chip_id, uint32_t msg_code, bool wait_for_done,
-                                                           uint32_t arg0, uint32_t arg1, int timeout) {
+std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id, uint32_t msg_code,
+                                                           bool wait_for_done, uint32_t arg0, uint32_t arg1,
+                                                           int timeout) {
     if (ttexalens_implementation) {
-        return ttexalens_implementation->arc_msg(chip_id, msg_code, wait_for_done, arg0, arg1, timeout);
+        return ttexalens_implementation->arc_msg(noc_id, chip_id, msg_code, wait_for_done, arg0, arg1, timeout);
     }
     return {};
 }
@@ -213,24 +216,26 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t chip_id, uint
 PYBIND11_MODULE(ttexalens_pybind, m) {
     m.def("open_device", &open_device, "Opens tt device. Prints error message if failed.",
           pybind11::arg("binary_directory"), pybind11::arg_v("wanted_devices", std::vector<uint8_t>(), "[]"),
-          pybind11::arg("init_jtag"), pybind11::arg("use_noc1"));
-    m.def("pci_read32", &pci_read32, "Reads 4 bytes from PCI address", pybind11::arg("chip_id"), pybind11::arg("noc_x"),
-          pybind11::arg("noc_y"), pybind11::arg("address"));
-    m.def("pci_write32", &pci_write32, "Writes 4 bytes to PCI address", pybind11::arg("chip_id"),
-          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("data"));
-    m.def("pci_read", &pci_read, "Reads data from PCI address", pybind11::arg("chip_id"), pybind11::arg("noc_x"),
-          pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("size"));
-    m.def("pci_write", &pci_write, "Writes data to PCI address", pybind11::arg("chip_id"), pybind11::arg("noc_x"),
-          pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("data"), pybind11::arg("size"));
+          pybind11::arg("init_jtag"), pybind11::arg("initialize_with_noc1"));
+    m.def("pci_read32", &pci_read32, "Reads 4 bytes from PCI address", pybind11::arg("noc_id"),
+          pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"));
+    m.def("pci_write32", &pci_write32, "Writes 4 bytes to PCI address", pybind11::arg("noc_id"),
+          pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"),
+          pybind11::arg("data"));
+    m.def("pci_read", &pci_read, "Reads data from PCI address", pybind11::arg("noc_id"), pybind11::arg("chip_id"),
+          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("size"));
+    m.def("pci_write", &pci_write, "Writes data to PCI address", pybind11::arg("noc_id"), pybind11::arg("chip_id"),
+          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("data"),
+          pybind11::arg("size"));
     m.def("pci_read32_raw", &pci_read32_raw, "Reads 4 bytes from PCI address", pybind11::arg("chip_id"),
           pybind11::arg("address"));
     m.def("pci_write32_raw", &pci_write32_raw, "Writes 4 bytes to PCI address", pybind11::arg("chip_id"),
           pybind11::arg("address"), pybind11::arg("data"));
     m.def("dma_buffer_read32", &dma_buffer_read32, "Reads 4 bytes from DMA buffer", pybind11::arg("chip_id"),
           pybind11::arg("address"), pybind11::arg("channel"));
-    m.def("pci_read_tile", &pci_read_tile, "Reads tile from PCI address", pybind11::arg("chip_id"),
-          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("size"),
-          pybind11::arg("data_format"));
+    m.def("pci_read_tile", &pci_read_tile, "Reads tile from PCI address", pybind11::arg("noc_id"),
+          pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"),
+          pybind11::arg("size"), pybind11::arg("data_format"));
     m.def("get_cluster_description", &get_cluster_description, "Returns cluster description");
     m.def("convert_from_noc0", &convert_from_noc0, "Convert noc0 coordinate into specified coordinate system",
           pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("core_type"),
@@ -239,16 +244,18 @@ PYBIND11_MODULE(ttexalens_pybind, m) {
     m.def("get_device_arch", &get_device_arch, "Returns device architecture", pybind11::arg("chip_id"));
     m.def("get_device_soc_description", &get_device_soc_description, "Returns device SoC description",
           pybind11::arg("chip_id"));
-    m.def("jtag_read32", &jtag_read32, "Reads 4 bytes from NOC address using JTAG", pybind11::arg("chip_id"),
-          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"));
-    m.def("jtag_write32", &jtag_write32, "Writes 4 bytes to NOC address using JTAG", pybind11::arg("chip_id"),
-          pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"), pybind11::arg("data"));
+    m.def("jtag_read32", &jtag_read32, "Reads 4 bytes from NOC address using JTAG", pybind11::arg("noc_id"),
+          pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"));
+    m.def("jtag_write32", &jtag_write32, "Writes 4 bytes to NOC address using JTAG", pybind11::arg("noc_id"),
+          pybind11::arg("chip_id"), pybind11::arg("noc_x"), pybind11::arg("noc_y"), pybind11::arg("address"),
+          pybind11::arg("data"));
     m.def("jtag_read32_axi", &jtag_read32_axi, "Reads 4 bytes from AXI address using JTAG", pybind11::arg("chip_id"),
           pybind11::arg("address"));
     m.def("jtag_write32_axi", &jtag_write32_axi, "Writes 4 bytes to AXI address using JTAG", pybind11::arg("chip_id"),
           pybind11::arg("address"), pybind11::arg("data"));
 
     // Bind arc_msg with explicit lambda to ensure type resolution
-    m.def("arc_msg", &arc_msg, "Send ARC message", pybind11::arg("chip_id"), pybind11::arg("msg_code"),
-          pybind11::arg("wait_for_done"), pybind11::arg("arg0"), pybind11::arg("arg1"), pybind11::arg("timeout"));
+    m.def("arc_msg", &arc_msg, "Send ARC message", pybind11::arg("noc_id"), pybind11::arg("chip_id"),
+          pybind11::arg("msg_code"), pybind11::arg("wait_for_done"), pybind11::arg("arg0"), pybind11::arg("arg1"),
+          pybind11::arg("timeout"));
 }

--- a/ttexalens/server/app/ttexalens-server-standalone.cpp
+++ b/ttexalens/server/app/ttexalens-server-standalone.cpp
@@ -20,7 +20,7 @@ struct server_config {
     std::filesystem::path simulation_directory;
     std::vector<uint8_t> wanted_devices;
     bool init_jtag;
-    bool use_noc1;
+    bool initialize_with_noc1;
 };
 
 // Make sure that the directory exists
@@ -44,10 +44,10 @@ int run_ttexalens_server(const server_config& config) {
             if (config.simulation_directory.empty()) {
                 if (config.init_jtag) {
                     implementation = tt::exalens::open_implementation<tt::exalens::jtag_implementation>::open(
-                        {}, config.wanted_devices, config.use_noc1);
+                        {}, config.wanted_devices, config.initialize_with_noc1);
                 } else {
                     implementation = tt::exalens::open_implementation<tt::exalens::umd_implementation>::open(
-                        {}, config.wanted_devices, config.use_noc1);
+                        {}, config.wanted_devices, config.initialize_with_noc1);
                 }
             } else {
                 ensure_directory("VCS binary", config.simulation_directory);
@@ -105,7 +105,7 @@ server_config parse_args(int argc, char** argv) {
     server_config config = server_config();
     config.port = atoi(argv[1]);
     config.init_jtag = false;
-    config.use_noc1 = false;
+    config.initialize_with_noc1 = false;
 
     int i = 2;
     while (i < argc) {
@@ -141,8 +141,8 @@ server_config parse_args(int argc, char** argv) {
         } else if (strcmp(argv[i], "--jtag") == 0) {
             config.init_jtag = true;
             i++;
-        } else if (strcmp(argv[i], "--use-noc1") == 0) {
-            config.use_noc1 = true;
+        } else if (strcmp(argv[i], "--initialize-with-noc1") == 0) {
+            config.initialize_with_noc1 = true;
             i++;
         } else {
             log_error("Unknown argument: {}", argv[i]);
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
     if (argc < 2) {
         log_error(
             "Need arguments: <port> [-s <simulation_directory>] [-d <device_id1> [<device_id2> ... "
-            "<device_idN>]] [--jtag] [--background] [--use-noc1]");
+            "<device_idN>]] [--jtag] [--background] [--initialize-with-noc1]");
         return 1;
     }
 

--- a/ttexalens/server/lib/inc/ttexalensserver/jtag_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/jtag_implementation.h
@@ -19,10 +19,11 @@ class jtag_implementation : public ttexalens_implementation {
     std::optional<std::string> get_device_arch(uint8_t chip_id) override;
 
     std::optional<int> jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) override;
-    std::optional<int> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                     uint32_t data) override;
     std::optional<uint32_t> jtag_read32_axi(uint8_t chip_id, uint32_t address) override;
-    std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override;
+    std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                        uint64_t address) override;
 
    private:
     JtagDevice* jtag_device = nullptr;

--- a/ttexalens/server/lib/inc/ttexalensserver/open_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/open_implementation.h
@@ -30,7 +30,7 @@ class open_implementation : public BaseClass {
    public:
     static std::unique_ptr<open_implementation<BaseClass>> open(const std::filesystem::path& binary_directory = {},
                                                                 const std::vector<uint8_t>& wanted_devices = {},
-                                                                bool use_noc1 = false);
+                                                                bool initialize_with_noc1 = false);
     static std::unique_ptr<open_implementation<BaseClass>> open_simulation(
         const std::filesystem::path& simulation_directory);
 

--- a/ttexalens/server/lib/inc/ttexalensserver/read_tile.hpp
+++ b/ttexalens/server/lib/inc/ttexalensserver/read_tile.hpp
@@ -45,8 +45,9 @@ enum class TileDataFormat : uint8_t {
 };
 TileDataFormat to_data_format(uint8_t i);
 
-std::optional<std::string> read_tile_implementation(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                    uint32_t size, uint8_t data_format, tt_device* device);
+std::optional<std::string> read_tile_implementation(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                    uint64_t address, uint32_t size, uint8_t data_format,
+                                                    tt_device* device);
 std::optional<std::string> dump_tile(const std::vector<uint32_t>& mem_vector, TileDataFormat df);
 
 TileDataFormat to_data_format(uint8_t i);

--- a/ttexalens/server/lib/inc/ttexalensserver/requests.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/requests.h
@@ -53,6 +53,7 @@ struct request {
 } __attribute__((packed));
 
 struct pci_read32_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -60,6 +61,7 @@ struct pci_read32_request : request {
 } __attribute__((packed));
 
 struct pci_write32_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -68,6 +70,7 @@ struct pci_write32_request : request {
 } __attribute__((packed));
 
 struct pci_read_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -76,6 +79,7 @@ struct pci_read_request : request {
 } __attribute__((packed));
 
 struct pci_write_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -102,6 +106,7 @@ struct dma_buffer_read32_request : request {
 } __attribute__((packed));
 
 struct pci_read_tile_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -133,6 +138,7 @@ struct convert_from_noc0_request : request {
 } __attribute__((packed));
 
 struct arc_msg_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint32_t msg_code;
     bool wait_for_done;
@@ -142,6 +148,7 @@ struct arc_msg_request : request {
 } __attribute__((packed));
 
 struct jtag_read32_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;
@@ -149,6 +156,7 @@ struct jtag_read32_request : request {
 } __attribute__((packed));
 
 struct jtag_write32_request : request {
+    uint8_t noc_id;
     uint8_t chip_id;
     uint8_t noc_x;
     uint8_t noc_y;

--- a/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
@@ -16,19 +16,20 @@ class ttexalens_implementation {
    public:
     virtual ~ttexalens_implementation() = default;
 
-    virtual std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
+    virtual std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                               uint64_t address) {
         return {};
     }
-    virtual std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                uint32_t data) {
+    virtual std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                uint64_t address, uint32_t data) {
         return {};
     }
-    virtual std::optional<std::vector<uint8_t>> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+    virtual std::optional<std::vector<uint8_t>> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
                                                          uint64_t address, uint32_t size) {
         return {};
     }
-    virtual std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                              const uint8_t* data, uint32_t size) {
+    virtual std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                              uint64_t address, const uint8_t* data, uint32_t size) {
         return {};
     }
     virtual std::optional<uint32_t> pci_read32_raw(uint8_t chip_id, uint64_t address) { return {}; }
@@ -37,8 +38,8 @@ class ttexalens_implementation {
         return {};
     }
 
-    virtual std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                     uint32_t size, uint8_t data_format) {
+    virtual std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                     uint64_t address, uint32_t size, uint8_t data_format) {
         return {};
     }
     virtual std::optional<std::string> get_cluster_description() { return {}; }
@@ -51,18 +52,19 @@ class ttexalens_implementation {
         return {};
     }
 
-    virtual std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t chip_id, uint32_t msg_code,
-                                                                       bool wait_for_done, uint32_t arg0, uint32_t arg1,
-                                                                       int timeout) {
+    virtual std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id,
+                                                                       uint32_t msg_code, bool wait_for_done,
+                                                                       uint32_t arg0, uint32_t arg1, int timeout) {
         return {};
     }
     virtual std::optional<int> jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) { return {}; }
-    virtual std::optional<int> jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                            uint32_t data) {
+    virtual std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                            uint64_t address, uint32_t data) {
         return {};
     }
     virtual std::optional<uint32_t> jtag_read32_axi(uint8_t chip_id, uint32_t address) { return {}; }
-    virtual std::optional<uint32_t> jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) {
+    virtual std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                uint64_t address) {
         return {};
     }
 };

--- a/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
@@ -16,24 +16,26 @@ class umd_implementation : public ttexalens_implementation {
     umd_implementation(tt_device* device);
 
    protected:
-    std::optional<uint32_t> pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address) override;
-    std::optional<uint32_t> pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<uint32_t> pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                       uint64_t address) override;
+    std::optional<uint32_t> pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                         uint32_t data) override;
-    std::optional<std::vector<uint8_t>> pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                 uint32_t size) override;
-    std::optional<uint32_t> pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
+    std::optional<std::vector<uint8_t>> pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                 uint64_t address, uint32_t size) override;
+    std::optional<uint32_t> pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                       const uint8_t* data, uint32_t size) override;
     std::optional<uint32_t> pci_read32_raw(uint8_t chip_id, uint64_t address) override;
     std::optional<uint32_t> pci_write32_raw(uint8_t chip_id, uint64_t address, uint32_t data) override;
     std::optional<uint32_t> dma_buffer_read32(uint8_t chip_id, uint64_t address, uint32_t channel) override;
 
-    std::optional<std::string> pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                             uint32_t size, uint8_t data_format) override;
+    std::optional<std::string> pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                             uint64_t address, uint32_t size, uint8_t data_format) override;
 
     std::optional<std::string> get_device_arch(uint8_t chip_id) override;
 
-    virtual std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t chip_id, uint32_t msg_code,
-                                                                       bool wait_for_done, uint32_t arg0, uint32_t arg1,
+    virtual std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id,
+                                                                       uint32_t msg_code, bool wait_for_done,
+                                                                       uint32_t arg0, uint32_t arg1,
                                                                        int timeout) override;
 
    private:

--- a/ttexalens/server/lib/src/jtag_implementation.cpp
+++ b/ttexalens/server/lib/src/jtag_implementation.cpp
@@ -22,15 +22,17 @@ std::optional<std::string> jtag_implementation::get_device_arch(uint8_t chip_id)
 std::optional<int> jtag_implementation::jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) {
     return jtag_device->write32_axi(chip_id, address, data);
 }
-std::optional<int> jtag_implementation::jtag_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                     uint32_t data) {
+std::optional<int> jtag_implementation::jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                     uint64_t address, uint32_t data) {
+    // TODO: Update JTAG library to use noc_id
     return jtag_device->write32(chip_id, noc_x, noc_y, address, data);
 }
 std::optional<uint32_t> jtag_implementation::jtag_read32_axi(uint8_t chip_id, uint32_t address) {
     return jtag_device->read32_axi(chip_id, address);
 }
-std::optional<uint32_t> jtag_implementation::jtag_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+std::optional<uint32_t> jtag_implementation::jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
                                                          uint64_t address) {
+    // TODO: Update JTAG library to use noc_id
     return jtag_device->read32(chip_id, noc_x, noc_y, address);
 }
 

--- a/ttexalens/server/lib/src/open_implementation.cpp
+++ b/ttexalens/server/lib/src/open_implementation.cpp
@@ -317,8 +317,9 @@ open_implementation<BaseClass>::open_implementation(std::unique_ptr<DeviceType> 
 
 template <>
 std::unique_ptr<open_implementation<jtag_implementation>> open_implementation<jtag_implementation>::open(
-    const std::filesystem::path &binary_directory, const std::vector<uint8_t> &wanted_devices, bool use_noc1) {
-    // TODO: Use noc1 in JTAG
+    const std::filesystem::path &binary_directory, const std::vector<uint8_t> &wanted_devices,
+    bool initialize_with_noc1) {
+    // TODO: initialize with noc1 in JTAG
 
     std::vector<uint8_t> device_ids;
     std::unique_ptr<tt::umd::Cluster> device;
@@ -363,9 +364,11 @@ std::unique_ptr<open_implementation<jtag_implementation>> open_implementation<jt
 
 template <>
 std::unique_ptr<open_implementation<umd_implementation>> open_implementation<umd_implementation>::open(
-    const std::filesystem::path &binary_directory, const std::vector<uint8_t> &wanted_devices, bool use_noc1) {
-    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1
-    umd::TTDevice::use_noc1(use_noc1);
+    const std::filesystem::path &binary_directory, const std::vector<uint8_t> &wanted_devices,
+    bool initialize_with_noc1) {
+    // TODO: Hack on UMD on how to use/initialize with noc1. This should be removed once we have a proper way to use
+    // noc1
+    umd::TTDevice::use_noc1(initialize_with_noc1);
 
     auto cluster_descriptor = tt::umd::Cluster::create_cluster_descriptor();
 

--- a/ttexalens/server/lib/src/read_tile.cpp
+++ b/ttexalens/server/lib/src/read_tile.cpp
@@ -375,8 +375,12 @@ std::optional<std::string> dump_tile(const std::vector<uint32_t>& mem_vector, Ti
     return ss.str();
 }
 
-std::optional<std::string> read_tile_implementation(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                    uint32_t size, uint8_t data_format, tt_device* device) {
+std::optional<std::string> read_tile_implementation(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                    uint64_t address, uint32_t size, uint8_t data_format,
+                                                    tt_device* device) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     TileDataFormat df = to_data_format(data_format);
     std::vector<std::uint32_t> mem_vector;
 

--- a/ttexalens/server/lib/src/server.cpp
+++ b/ttexalens/server/lib/src/server.cpp
@@ -18,25 +18,26 @@ void tt::exalens::server::process(const tt::exalens::request& base_request) {
 
         case tt::exalens::request_type::pci_read32: {
             auto& request = static_cast<const tt::exalens::pci_read32_request&>(base_request);
-            respond(implementation->pci_read32(request.chip_id, request.noc_x, request.noc_y, request.address));
+            respond(implementation->pci_read32(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                               request.address));
             break;
         }
         case tt::exalens::request_type::pci_write32: {
             auto& request = static_cast<const tt::exalens::pci_write32_request&>(base_request);
-            respond(implementation->pci_write32(request.chip_id, request.noc_x, request.noc_y, request.address,
-                                                request.data));
+            respond(implementation->pci_write32(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                                request.address, request.data));
             break;
         }
         case tt::exalens::request_type::pci_read: {
             auto& request = static_cast<const tt::exalens::pci_read_request&>(base_request);
-            respond(
-                implementation->pci_read(request.chip_id, request.noc_x, request.noc_y, request.address, request.size));
+            respond(implementation->pci_read(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                             request.address, request.size));
             break;
         }
         case tt::exalens::request_type::pci_write: {
             auto& request = static_cast<const tt::exalens::pci_write_request&>(base_request);
-            respond(implementation->pci_write(request.chip_id, request.noc_x, request.noc_y, request.address,
-                                              request.data, request.size));
+            respond(implementation->pci_write(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                              request.address, request.data, request.size));
             break;
         }
         case tt::exalens::request_type::pci_read32_raw: {
@@ -57,8 +58,8 @@ void tt::exalens::server::process(const tt::exalens::request& base_request) {
 
         case tt::exalens::request_type::pci_read_tile: {
             auto& request = static_cast<const tt::exalens::pci_read_tile_request&>(base_request);
-            respond(implementation->pci_read_tile(request.chip_id, request.noc_x, request.noc_y, request.address,
-                                                  request.size, request.data_format));
+            respond(implementation->pci_read_tile(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                                  request.address, request.size, request.data_format));
             break;
         }
         case tt::exalens::request_type::get_cluster_description:
@@ -95,21 +96,22 @@ void tt::exalens::server::process(const tt::exalens::request& base_request) {
         }
         case tt::exalens::request_type::arc_msg: {
             auto& request = static_cast<const tt::exalens::arc_msg_request&>(base_request);
-            respond(implementation->arc_msg(request.chip_id, request.msg_code, request.wait_for_done, request.arg0,
-                                            request.arg1, request.timeout));
+            respond(implementation->arc_msg(request.noc_id, request.chip_id, request.msg_code, request.wait_for_done,
+                                            request.arg0, request.arg1, request.timeout));
             break;
         }
 
         case tt::exalens::request_type::jtag_read32: {
             auto& request = static_cast<const tt::exalens::jtag_read32_request&>(base_request);
-            respond(implementation->jtag_read32(request.chip_id, request.noc_x, request.noc_y, request.address));
+            respond(implementation->jtag_read32(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                                request.address));
             break;
         }
 
         case tt::exalens::request_type::jtag_write32: {
             auto& request = static_cast<const tt::exalens::jtag_write32_request&>(base_request);
-            respond(implementation->jtag_write32(request.chip_id, request.noc_x, request.noc_y, request.address,
-                                                 request.data));
+            respond(implementation->jtag_write32(request.noc_id, request.chip_id, request.noc_x, request.noc_y,
+                                                 request.address, request.data));
             break;
         }
 

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -13,8 +13,11 @@ namespace tt::exalens {
 
 umd_implementation::umd_implementation(tt_device* device) : device(device) {}
 
-std::optional<uint32_t> umd_implementation::pci_read32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+std::optional<uint32_t> umd_implementation::pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
                                                        uint64_t address) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     uint32_t result;
     tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
@@ -22,16 +25,22 @@ std::optional<uint32_t> umd_implementation::pci_read32(uint8_t chip_id, uint8_t 
     return result;
 }
 
-std::optional<uint32_t> umd_implementation::pci_write32(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                        uint32_t data) {
+std::optional<uint32_t> umd_implementation::pci_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                        uint64_t address, uint32_t data) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
     device->write_to_device_reg(&data, sizeof(data), chip_id, target, address);
     return 4;
 }
 
-std::optional<std::vector<uint8_t>> umd_implementation::pci_read(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
-                                                                 uint64_t address, uint32_t size) {
+std::optional<std::vector<uint8_t>> umd_implementation::pci_read(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x,
+                                                                 uint8_t noc_y, uint64_t address, uint32_t size) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     std::vector<uint8_t> result(size);
     tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
@@ -49,8 +58,11 @@ std::optional<std::vector<uint8_t>> umd_implementation::pci_read(uint8_t chip_id
     return result;
 }
 
-std::optional<uint32_t> umd_implementation::pci_write(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
-                                                      const uint8_t* data, uint32_t size) {
+std::optional<uint32_t> umd_implementation::pci_write(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
+                                                      uint64_t address, const uint8_t* data, uint32_t size) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     tt::umd::CoreCoord target = device->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
     // TODO #124: Mitigation for UMD bug #77
@@ -111,9 +123,11 @@ std::optional<uint32_t> umd_implementation::dma_buffer_read32(uint8_t chip_id, u
     return result;
 }
 
-std::optional<std::string> umd_implementation::pci_read_tile(uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
-                                                             uint64_t address, uint32_t size, uint8_t data_format) {
-    return tt::exalens::tile::read_tile_implementation(chip_id, noc_x, noc_y, address, size, data_format, device);
+std::optional<std::string> umd_implementation::pci_read_tile(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x,
+                                                             uint8_t noc_y, uint64_t address, uint32_t size,
+                                                             uint8_t data_format) {
+    return tt::exalens::tile::read_tile_implementation(noc_id, chip_id, noc_x, noc_y, address, size, data_format,
+                                                       device);
 }
 
 std::optional<std::string> umd_implementation::get_device_arch(uint8_t chip_id) {
@@ -126,9 +140,13 @@ std::optional<std::string> umd_implementation::get_device_arch(uint8_t chip_id) 
     }
 }
 
-std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(uint8_t chip_id, uint32_t msg_code,
-                                                                               bool wait_for_done, uint32_t arg0,
-                                                                               uint32_t arg1, int timeout) {
+std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(uint8_t noc_id, uint8_t chip_id,
+                                                                               uint32_t msg_code, bool wait_for_done,
+                                                                               uint32_t arg0, uint32_t arg1,
+                                                                               int timeout) {
+    // TODO: Hack on UMD on how to use noc1. This should be removed once we have a proper way to use noc1.
+    umd::TTDevice::use_noc1(noc_id == 1);
+
     tt_device* d = static_cast<tt_device*>(device);
 
     uint32_t return_3 = 0;

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -80,11 +80,12 @@ class ttexalens_server_communication:
         self._socket.send(bytes([ttexalens_server_request_type.ping.value]))
         return self._check(self._socket.recv())
 
-    def pci_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
+    def pci_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         self._socket.send(
             struct.pack(
-                "<BBBBQ",
+                "<BBBBBQ",
                 ttexalens_server_request_type.pci_read32.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -93,11 +94,12 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def pci_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+    def pci_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
         self._socket.send(
             struct.pack(
-                "<BBBBQI",
+                "<BBBBBQI",
                 ttexalens_server_request_type.pci_write32.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -107,11 +109,12 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def pci_read(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
+    def pci_read(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
         self._socket.send(
             struct.pack(
-                "<BBBBQI",
+                "<BBBBBQI",
                 ttexalens_server_request_type.pci_read.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -121,11 +124,12 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
         self._socket.send(
             struct.pack(
-                f"<BBBBQI{len(data)}s",
+                f"<BBBBBQI{len(data)}s",
                 ttexalens_server_request_type.pci_write.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -166,6 +170,7 @@ class ttexalens_server_communication:
 
     def pci_read_tile(
         self,
+        noc_id: int,
         chip_id: int,
         noc_x: int,
         noc_y: int,
@@ -175,8 +180,9 @@ class ttexalens_server_communication:
     ):
         self._socket.send(
             struct.pack(
-                "<BBBBQIB",
+                "<BBBBBQIB",
                 ttexalens_server_request_type.pci_read_tile.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -248,11 +254,14 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
+    def arc_msg(
+        self, noc_id: int, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int
+    ):
         self._socket.send(
             struct.pack(
-                "<BBBIIIIB",
+                "<BBBBIIIIB",
                 ttexalens_server_request_type.arc_msg.value,
+                noc_id,
                 device_id,
                 msg_code,
                 wait_for_done,
@@ -263,11 +272,12 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         self._socket.send(
             struct.pack(
-                "<BBBBQ",
+                "<BBBBBQ",
                 ttexalens_server_request_type.jtag_read32.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -276,11 +286,12 @@ class ttexalens_server_communication:
         )
         return self._check(self._socket.recv())
 
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
         self._socket.send(
             struct.pack(
-                "<BBBBQI",
+                "<BBBBBQI",
                 ttexalens_server_request_type.jtag_write32.value,
+                noc_id,
                 chip_id,
                 noc_x,
                 noc_y,
@@ -332,24 +343,24 @@ class ttexalens_client(TTExaLensCommunicator):
     def parse_string(self, buffer: bytes):
         return buffer.decode()
 
-    def pci_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self.parse_uint32_t(self._communication.pci_read32(chip_id, noc_x, noc_y, address))
+    def pci_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self.parse_uint32_t(self._communication.pci_read32(noc_id, chip_id, noc_x, noc_y, address))
 
-    def pci_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
-        buffer = self._communication.pci_write32(chip_id, noc_x, noc_y, address, data)
+    def pci_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+        buffer = self._communication.pci_write32(noc_id, chip_id, noc_x, noc_y, address, data)
         bytes_written = self.parse_uint32_t(buffer)
         if bytes_written != 4:
             raise ValueError(f"Expected 4 bytes written, but {bytes_written} were written")
         return bytes_written
 
-    def pci_read(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
-        buffer = self._communication.pci_read(chip_id, noc_x, noc_y, address, size)
+    def pci_read(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
+        buffer = self._communication.pci_read(noc_id, chip_id, noc_x, noc_y, address, size)
         if len(buffer) != size:
             raise ValueError(f"Expected {size} bytes read, but {len(buffer)} were read")
         return buffer
 
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
-        bytes_written = self.parse_uint32_t(self._communication.pci_write(chip_id, noc_x, noc_y, address, data))
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+        bytes_written = self.parse_uint32_t(self._communication.pci_write(noc_id, chip_id, noc_x, noc_y, address, data))
         if bytes_written != len(data):
             raise ValueError(f"Expected {len(data)} bytes written, but {bytes_written} were written")
         return bytes_written
@@ -368,6 +379,7 @@ class ttexalens_client(TTExaLensCommunicator):
 
     def pci_read_tile(
         self,
+        noc_id: int,
         chip_id: int,
         noc_x: int,
         noc_y: int,
@@ -375,7 +387,9 @@ class ttexalens_client(TTExaLensCommunicator):
         size: int,
         data_format: int,
     ):
-        return self.parse_string(self._communication.pci_read_tile(chip_id, noc_x, noc_y, address, size, data_format))
+        return self.parse_string(
+            self._communication.pci_read_tile(noc_id, chip_id, noc_x, noc_y, address, size, data_format)
+        )
 
     def get_cluster_description(self):
         return self.parse_string(self._communication.get_cluster_description())
@@ -399,14 +413,18 @@ class ttexalens_client(TTExaLensCommunicator):
         binary_content = self._communication.get_file(binary_path)
         return io.BytesIO(binary_content)
 
-    def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
-        return self.parse_uint32_t(self._communication.arc_msg(device_id, msg_code, wait_for_done, arg0, arg1, timeout))
+    def arc_msg(
+        self, noc_id: int, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int
+    ):
+        return self.parse_uint32_t(
+            self._communication.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
+        )
 
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self.parse_uint32_t(self._communication.jtag_read32(chip_id, noc_x, noc_y, address))
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self.parse_uint32_t(self._communication.jtag_read32(noc_id, chip_id, noc_x, noc_y, address))
 
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
-        return self.parse_uint32_t(self._communication.jtag_write32(chip_id, noc_x, noc_y, address, data))
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+        return self.parse_uint32_t(self._communication.jtag_write32(noc_id, chip_id, noc_x, noc_y, address, data))
 
     def jtag_read32_axi(self, chip_id: int, address: int):
         return self.parse_uint32_t(self._communication.jtag_read32_axi(chip_id, address))
@@ -428,9 +446,9 @@ import ttexalens_pybind
 
 
 class TTExaLensPybind(TTExaLensCommunicator):
-    def __init__(self, wanted_devices: list = [], init_jtag=False, use_noc1=False):
+    def __init__(self, wanted_devices: list = [], init_jtag=False, initialize_with_noc1=False):
         super().__init__()
-        if not ttexalens_pybind.open_device(binary_path, wanted_devices, init_jtag, use_noc1):
+        if not ttexalens_pybind.open_device(binary_path, wanted_devices, init_jtag, initialize_with_noc1):
             raise Exception("Failed to open device using pybind library")
 
     def _check_result(self, result):
@@ -438,17 +456,17 @@ class TTExaLensPybind(TTExaLensCommunicator):
             raise ttexalens_server_not_supported()
         return result
 
-    def pci_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self._check_result(ttexalens_pybind.pci_read32(chip_id, noc_x, noc_y, address))
+    def pci_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self._check_result(ttexalens_pybind.pci_read32(noc_id, chip_id, noc_x, noc_y, address))
 
-    def pci_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
-        return self._check_result(ttexalens_pybind.pci_write32(chip_id, noc_x, noc_y, address, data))
+    def pci_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+        return self._check_result(ttexalens_pybind.pci_write32(noc_id, chip_id, noc_x, noc_y, address, data))
 
-    def pci_read(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
-        return self._check_result(ttexalens_pybind.pci_read(chip_id, noc_x, noc_y, address, size))
+    def pci_read(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
+        return self._check_result(ttexalens_pybind.pci_read(noc_id, chip_id, noc_x, noc_y, address, size))
 
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
-        return self._check_result(ttexalens_pybind.pci_write(chip_id, noc_x, noc_y, address, data, len(data)))
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+        return self._check_result(ttexalens_pybind.pci_write(noc_id, chip_id, noc_x, noc_y, address, data, len(data)))
 
     def pci_read32_raw(self, chip_id: int, address: int):
         return self._check_result(ttexalens_pybind.pci_read32_raw(chip_id, address))
@@ -461,6 +479,7 @@ class TTExaLensPybind(TTExaLensCommunicator):
 
     def pci_read_tile(
         self,
+        noc_id: int,
         chip_id: int,
         noc_x: int,
         noc_y: int,
@@ -468,7 +487,9 @@ class TTExaLensPybind(TTExaLensCommunicator):
         size: int,
         data_format: int,
     ):
-        return self._check_result(ttexalens_pybind.pci_read_tile(chip_id, noc_x, noc_y, address, size, data_format))
+        return self._check_result(
+            ttexalens_pybind.pci_read_tile(noc_id, chip_id, noc_x, noc_y, address, size, data_format)
+        )
 
     def get_cluster_description(self):
         return self._check_result(ttexalens_pybind.get_cluster_description())
@@ -485,15 +506,15 @@ class TTExaLensPybind(TTExaLensCommunicator):
     def get_device_soc_description(self, chip_id: int):
         return self._check_result(ttexalens_pybind.get_device_soc_description(chip_id))
 
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         if address % 4 != 0:
             raise Exception("Unaligned access in jtag_read32")
-        return self._check_result(ttexalens_pybind.jtag_read32(chip_id, noc_x, noc_y, address))
+        return self._check_result(ttexalens_pybind.jtag_read32(noc_id, chip_id, noc_x, noc_y, address))
 
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
         if address % 4 != 0:
             raise Exception("Unaligned access in jtag_write32")
-        return self._check_result(ttexalens_pybind.jtag_write32(chip_id, noc_x, noc_y, address, data))
+        return self._check_result(ttexalens_pybind.jtag_write32(noc_id, chip_id, noc_x, noc_y, address, data))
 
     def jtag_read32_axi(self, chip_id: int, address: int):
         if address % 4 != 0:
@@ -514,15 +535,19 @@ class TTExaLensPybind(TTExaLensCommunicator):
     def get_binary(self, binary_path: str) -> io.BufferedIOBase:
         return open(binary_path, "rb")
 
-    def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
-        return self._check_result(ttexalens_pybind.arc_msg(device_id, msg_code, wait_for_done, arg0, arg1, timeout))
+    def arc_msg(
+        self, noc_id: int, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int
+    ):
+        return self._check_result(
+            ttexalens_pybind.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
+        )
 
 
-def init_pybind(wanted_devices=None, init_jtag=False, use_noc1=False):
+def init_pybind(wanted_devices=None, init_jtag=False, initialize_with_noc1=False):
     if not wanted_devices:
         wanted_devices = []
 
-    communicator = TTExaLensPybind(wanted_devices, init_jtag, use_noc1)
+    communicator = TTExaLensPybind(wanted_devices, init_jtag, initialize_with_noc1)
     util.VERBOSE("Device opened successfully.")
     return communicator
 

--- a/ttexalens/tt_exalens_ifc_base.py
+++ b/ttexalens/tt_exalens_ifc_base.py
@@ -12,19 +12,19 @@ class TTExaLensCommunicator(ABC):
     """
 
     @abstractmethod
-    def pci_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
+    def pci_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         pass
 
     @abstractmethod
-    def pci_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+    def pci_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
         pass
 
     @abstractmethod
-    def pci_read(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
+    def pci_read(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int):
         pass
 
     @abstractmethod
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
         pass
 
     @abstractmethod
@@ -40,7 +40,9 @@ class TTExaLensCommunicator(ABC):
         pass
 
     @abstractmethod
-    def pci_read_tile(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int, data_format: int):
+    def pci_read_tile(
+        self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int, data_format: int
+    ):
         pass
 
     @abstractmethod
@@ -72,11 +74,11 @@ class TTExaLensCommunicator(ABC):
         pass
 
     @abstractmethod
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         pass
 
     @abstractmethod
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
         pass
 
     @abstractmethod

--- a/ttexalens/tt_exalens_ifc_cache.py
+++ b/ttexalens/tt_exalens_ifc_cache.py
@@ -68,26 +68,28 @@ class TTExaLensCacheThrough(TTExaLensCache):
         return wrapper
 
     @cache_decorator
-    def pci_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self.communicator.pci_read32(chip_id, noc_x, noc_y, address)
+    def pci_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self.communicator.pci_read32(noc_id, chip_id, noc_x, noc_y, address)
 
-    def pci_write32(self, chip_id, noc_x, noc_y, reg_addr, data):
-        return self.communicator.pci_write32(chip_id, noc_x, noc_y, reg_addr, data)
+    def pci_write32(self, noc_id: int, chip_id, noc_x, noc_y, address, data):
+        return self.communicator.pci_write32(noc_id, chip_id, noc_x, noc_y, address, data)
 
     @cache_decorator
-    def pci_read(self, chip_id, x, y, noc_id, reg_addr, size):
-        return self.communicator.pci_read(chip_id, x, y, noc_id, reg_addr, size)
+    def pci_read(self, noc_id: int, chip_id, noc_x, noc_y, address, size):
+        return self.communicator.pci_read(noc_id, chip_id, noc_x, noc_y, address, size)
 
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
-        return self.communicator.pci_write(chip_id, noc_x, noc_y, address, data)
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+        return self.communicator.pci_write(noc_id, chip_id, noc_x, noc_y, address, data)
 
     @cache_decorator
     def dma_buffer_read32(self, chip_id, dram_addr, dram_chan):
         return self.communicator.dma_buffer_read32(chip_id, dram_addr, dram_chan)
 
     @cache_decorator
-    def pci_read_tile(self, chip_id: int, noc_x: int, noc_y: int, address: int, size: int, data_format: int):
-        return self.communicator.pci_read_tile(chip_id, noc_x, noc_y, address, size, data_format)
+    def pci_read_tile(
+        self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, size: int, data_format: int
+    ):
+        return self.communicator.pci_read_tile(noc_id, chip_id, noc_x, noc_y, address, size, data_format)
 
     @cache_decorator
     def pci_read32_raw(self, chip_id, reg_addr):
@@ -125,11 +127,11 @@ class TTExaLensCacheThrough(TTExaLensCache):
         return self.communicator.get_binary(binary_path)
 
     @cache_decorator
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self.communicator.jtag_read32(chip_id, noc_x, noc_y, address)
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self.communicator.jtag_read32(noc_id, chip_id, noc_x, noc_y, address)
 
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
-        return self.communicator.jtag_write32(chip_id, noc_x, noc_y, address, data)
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+        return self.communicator.jtag_write32(noc_id, chip_id, noc_x, noc_y, address, data)
 
     @cache_decorator
     def jtag_read32_axi(self, chip_id: int, address: int):
@@ -192,17 +194,17 @@ class TTExaLensCacheReader(TTExaLensCache):
         return wrapper
 
     @read_decorator
-    def pci_read32(self, chip_id, noc_x, noc_y, reg_addr):
+    def pci_read32(self, noc_id: int, chip_id, noc_x, noc_y, reg_addr):
         pass
 
-    def pci_write32(self, chip_id, noc_x, noc_y, reg_addr, data):
+    def pci_write32(self, noc_id: int, chip_id, noc_x, noc_y, reg_addr, data):
         raise util.TTException("Device not available, cannot write to cache.")
 
     @read_decorator
-    def pci_read(self, chip_id, noc_x, noc_y, reg_addr, size):
+    def pci_read(self, noc_id: int, chip_id, noc_x, noc_y, reg_addr, size):
         pass
 
-    def pci_write(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
+    def pci_write(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: bytes):
         raise util.TTException("Device not available, cannot write to cache.")
 
     @read_decorator
@@ -210,7 +212,7 @@ class TTExaLensCacheReader(TTExaLensCache):
         pass
 
     @read_decorator
-    def pci_read_tile(self, chip_id, x, y, z, reg_addr, msg_size, data_format):
+    def pci_read_tile(self, noc_id: int, chip_id, x, y, z, reg_addr, msg_size, data_format):
         pass
 
     @read_decorator
@@ -249,11 +251,11 @@ class TTExaLensCacheReader(TTExaLensCache):
         pass
 
     @read_decorator
-    def jtag_read32(self, chip_id: int, noc_x: int, noc_y: int, address: int):
-        return self.communicator.jtag_read32(chip_id, noc_x, noc_y, address)
+    def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
+        return self.communicator.jtag_read32(noc_id, chip_id, noc_x, noc_y, address)
 
-    def jtag_write32(self, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
-        return self.communicator.jtag_write32(chip_id, noc_x, noc_y, address, data)
+    def jtag_write32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int, data: int):
+        return self.communicator.jtag_write32(noc_id, chip_id, noc_x, noc_y, address, data)
 
     @read_decorator
     def jtag_read32_axi(self, chip_id: int, address: int):

--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -64,7 +64,7 @@ def init_ttexalens_remote(
     if cache_path:
         lens_ifc = tt_exalens_ifc_cache.init_cache_writer(lens_ifc, cache_path)
 
-    return load_context(lens_ifc, use_noc1=False)  # TODO: Unsupported!
+    return load_context(lens_ifc)
 
 
 def init_ttexalens_cached(

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -37,7 +37,7 @@ def read_word_from_device(
 
     validate_addr(addr)
     validate_device_id(device_id, context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
 
     if not isinstance(core_loc, OnChipCoordinate):
         core_loc = OnChipCoordinate.create(core_loc, device=context.devices[device_id])
@@ -73,7 +73,7 @@ def read_words_from_device(
 
     validate_addr(addr)
     validate_device_id(device_id, context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
     if word_count <= 0:
         raise TTException("word_count must be greater than 0.")
 
@@ -114,7 +114,7 @@ def read_from_device(
 
     validate_addr(addr)
     validate_device_id(device_id, context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
     if num_bytes <= 0:
         raise TTException("num_bytes must be greater than 0.")
 
@@ -155,7 +155,7 @@ def write_words_to_device(
 
     validate_addr(addr)
     validate_device_id(device_id, context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
 
     if not isinstance(core_loc, OnChipCoordinate):
         core_loc = OnChipCoordinate.create(core_loc, device=context.devices[device_id])
@@ -201,7 +201,7 @@ def write_to_device(
 
     validate_addr(addr)
     validate_device_id(device_id, context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
 
     if isinstance(data, list):
         data = bytes(data)
@@ -348,6 +348,12 @@ def check_context(context: Context = None) -> Context:
     return tt_exalens_init.GLOBAL_CONTEXT
 
 
+def check_noc_id(noc_id: int | None, context: Context) -> int:
+    if noc_id is None:
+        return 1 if context.use_noc1 else 0
+    assert noc_id in (0, 1), f"Invalid NOC ID {noc_id}. Expected 0 or 1."
+
+
 def validate_addr(addr: int) -> None:
     if addr < 0:
         raise TTException("addr must be greater than or equal to 0.")
@@ -384,7 +390,7 @@ def arc_msg(
             List[int]: return code, reply0, reply1.
     """
     context = check_context(context)
-    noc_id = noc_id if noc_id is not None else 1 if context.use_noc1 else 0
+    noc_id = check_noc_id(noc_id, context)
 
     validate_device_id(device_id, context)
     if timeout < 0:

--- a/ttexalens/tt_exalens_lib_utils.py
+++ b/ttexalens/tt_exalens_lib_utils.py
@@ -34,10 +34,11 @@ def arc_read(context: Context, device_id: int, core_loc: tuple, reg_addr: int) -
     """
     Reads a 32-bit value from an ARC address space.
     """
+    noc_id = 1 if context.use_noc1 else 0
     if context.devices[device_id]._has_mmio:
         read_val = context.server_ifc.pci_read32_raw(device_id, reg_addr)
     else:
-        read_val = context.server_ifc.pci_read32(device_id, *context.convert_loc_to_umd(core_loc), reg_addr)
+        read_val = context.server_ifc.pci_read32(noc_id, device_id, *context.convert_loc_to_umd(core_loc), reg_addr)
     return read_val
 
 
@@ -45,7 +46,8 @@ def arc_write(context: Context, device_id: int, core_loc: tuple, reg_addr: int, 
     """
     Writes a 32-bit value to an ARC address space.
     """
+    noc_id = 1 if context.use_noc1 else 0
     if context.devices[device_id]._has_mmio:
         context.server_ifc.pci_write32_raw(device_id, reg_addr, value)
     else:
-        context.server_ifc.pci_write32(device_id, *context.convert_loc_to_umd(core_loc), reg_addr, value)
+        context.server_ifc.pci_write32(noc_id, device_id, *context.convert_loc_to_umd(core_loc), reg_addr, value)

--- a/ttexalens/tt_exalens_server.py
+++ b/ttexalens/tt_exalens_server.py
@@ -14,13 +14,13 @@ def start_server(
     port: int,
     wanted_devices: "List[int]" = None,
     init_jtag=False,
-    use_noc1=False,
+    initialize_with_noc1=False,
     simulation_directory: str = None,
     background=False,
 ) -> subprocess.Popen:
     if util.is_port_available(int(port)):
         ttexalens_server = spawn_standalone_ttexalens_stub(
-            port, wanted_devices, init_jtag, use_noc1, simulation_directory, background
+            port, wanted_devices, init_jtag, initialize_with_noc1, simulation_directory, background
         )
         if ttexalens_server is None:
             raise util.TTFatalException("Could not start ttexalens-server.")
@@ -33,7 +33,7 @@ def spawn_standalone_ttexalens_stub(
     port: int,
     wanted_devices: "List[int]" = None,
     init_jtag=False,
-    use_noc1=False,
+    initialize_with_noc1=False,
     simulation_directory: str = None,
     background=False,
 ) -> subprocess.Popen:
@@ -56,8 +56,8 @@ def spawn_standalone_ttexalens_stub(
         if init_jtag:
             ttexalens_stub_args += ["--jtag"]
 
-        if use_noc1:
-            ttexalens_stub_args += ["--use-noc1"]
+        if initialize_with_noc1:
+            ttexalens_stub_args += ["--initialize-with-noc1"]
 
         if background:
             ttexalens_stub_args += ["--background"]


### PR DESCRIPTION
Exposing noc_id in read/write API.
Currently it is hack for UMD since they don't fully support it in API, but we can now select which noc_id to use when reading/writing to noc.
When you start cli/create context, using intialize_with_noc1 will boot UMD with noc1 instead of noc0 (in case noc0 doesn't work).
Server is only initialized with noc1/0, but requests use noc_id, so argument changed from use_noc1 to initialize_with_noc1.
CLI is working the same (for now). Meaning, command line argument is use_noc1 and all the API uses whatever was set in context.
API is working a bit different. You still initialize context with use_noc1, but later you can override it with read/write functions (optional noc_id argument).

This will allow us to read noc1/0 registers on locations that can only access one NIU (router_only, arc, etc).