### PR TITLE
Exposing router_only, security and l2cpu core types in soc_descriptor output

### DIFF
--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -280,6 +280,8 @@ class Device(TTObject):
         "pcie": {"symbol": "P", "desc": "PCIE", "core_type": "pcie", "color": util.CLR_GREY},
         "router_only": {"symbol": " ", "desc": "Router only", "core_type": "router_only", "color": util.CLR_GREY},
         "harvested_workers": {"symbol": "-", "desc": "Harvested", "core_type": "tensix", "color": util.CLR_RED},
+        "security": {"symbol": "S", "desc": "Security", "core_type": "security", "color": util.CLR_GREY},
+        "l2cpu": {"symbol": "C", "desc": "L2CPU", "core_type": "l2cpu", "color": util.CLR_GREY},
     }
 
     core_types = {v["core_type"] for v in block_types.values()}

--- a/ttexalens/server/lib/src/open_implementation.cpp
+++ b/ttexalens/server/lib/src/open_implementation.cpp
@@ -227,7 +227,35 @@ static void write_soc_descriptor(std::string file_name, const tt_SocDescriptor &
     outfile << std::endl;
     outfile << "  ]" << std::endl << std::endl;
 
-    outfile << "router_only:" << std::endl << "  []" << std::endl << std::endl;
+    outfile << "router_only:" << std::endl;
+    outfile << "  [" << std::endl;
+    for (const auto &router_only : soc_descriptor.get_cores(CoreType::ROUTER_ONLY)) {
+        if (router_only.x < soc_descriptor.grid_size.x && router_only.y < soc_descriptor.grid_size.y) {
+            write_coord(outfile, router_only, CoreType::ROUTER_ONLY, soc_descriptor);
+        }
+    }
+    outfile << std::endl;
+    outfile << "  ]" << std::endl << std::endl;
+
+    outfile << "security:" << std::endl;
+    outfile << "  [" << std::endl;
+    for (const auto &security : soc_descriptor.get_cores(CoreType::SECURITY)) {
+        if (security.x < soc_descriptor.grid_size.x && security.y < soc_descriptor.grid_size.y) {
+            write_coord(outfile, security, CoreType::SECURITY, soc_descriptor);
+        }
+    }
+    outfile << std::endl;
+    outfile << "  ]" << std::endl << std::endl;
+
+    outfile << "l2cpu:" << std::endl;
+    outfile << "  [" << std::endl;
+    for (const auto &l2cpu : soc_descriptor.get_cores(CoreType::L2CPU)) {
+        if (l2cpu.x < soc_descriptor.grid_size.x && l2cpu.y < soc_descriptor.grid_size.y) {
+            write_coord(outfile, l2cpu, CoreType::L2CPU, soc_descriptor);
+        }
+    }
+    outfile << std::endl;
+    outfile << "  ]" << std::endl << std::endl;
 
     // Fill in the rest that are static to our device
     outfile << "worker_l1_size:" << std::endl;
@@ -514,6 +542,10 @@ std::optional<std::tuple<uint8_t, uint8_t>> open_implementation<BaseClass>::conv
         core_type_enum = CoreType::ETH;
     } else if (core_type == "worker") {
         core_type_enum = CoreType::WORKER;
+    } else if (core_type == "security") {
+        core_type_enum = CoreType::SECURITY;
+    } else if (core_type == "l2cpu") {
+        core_type_enum = CoreType::L2CPU;
     } else {
         return {};
     }


### PR DESCRIPTION
Updating write_soc_descriptor to include router_only, security and l2cpu coordinates.
Adding support for security and l2cpu block types.