### PR TITLE
Refactor ELF and DWARF handling to use ParsedElfFile for improved clarity and structure

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -580,9 +580,9 @@ class TestRunElf(unittest.TestCase):
 
         # Step 5b: Continue and check that the core reached 0xFFB12088. But first set the breakpoint at
         # function "decrement_mailbox"
-        decrement_mailbox_die = elf.names["fw"]["subprogram"]["decrement_mailbox"]
+        decrement_mailbox_die = elf.names["fw"].subprograms["decrement_mailbox"]
         decrement_mailbox_linkage_name = decrement_mailbox_die.attributes["DW_AT_linkage_name"].value.decode("utf-8")
-        decrement_mailbox_address = elf.names["fw"]["symbols"][decrement_mailbox_linkage_name]
+        decrement_mailbox_address = elf.names["fw"].symbols[decrement_mailbox_linkage_name]
 
         # Step 6. Setting breakpoint at decrement_mailbox
         watchpoint_id = 1  # Out of 8

--- a/test/ttexalens/unit_tests/test_parse_elf.py
+++ b/test/ttexalens/unit_tests/test_parse_elf.py
@@ -4,7 +4,7 @@
 import unittest
 import os
 
-from ttexalens.parse_elf import read_elf, mem_access
+from ttexalens.parse_elf import ParsedElfFile, read_elf, mem_access
 from ttexalens import util as util
 
 
@@ -284,32 +284,32 @@ class TestParseElf(unittest.TestCase):
         }
         program_path = os.path.join(TestParseElf.output_dir, program_name)
         compile_test_cpp_program(program_path, program_definition["program_text"])
-        name_dict = read_elf(file_ifc, f"{program_path}.elf")
-        assert mem_access(name_dict, "my_s.my_union.an_int", mem_reader)[0] == [722360]
-        assert mem_access(name_dict, "my_s.my_union.a_float", mem_reader)[0] == [722360]
-        assert mem_access(name_dict, "my_s.an_unnamed_int", mem_reader)[0] == [722320]
-        assert mem_access(name_dict, "my_s.a_unnamed_float", mem_reader)[0] == [722320]
-        assert mem_access(name_dict, "my_unnamed_s.x", mem_reader)[0] == [722400]
+        elf = read_elf(file_ifc, f"{program_path}.elf")
+        assert mem_access(elf, "my_s.my_union.an_int", mem_reader)[0] == [722360]
+        assert mem_access(elf, "my_s.my_union.a_float", mem_reader)[0] == [722360]
+        assert mem_access(elf, "my_s.an_unnamed_int", mem_reader)[0] == [722320]
+        assert mem_access(elf, "my_s.a_unnamed_float", mem_reader)[0] == [722320]
+        assert mem_access(elf, "my_unnamed_s.x", mem_reader)[0] == [722400]
 
     def test_firmware_elf(self):
         """Test finding text section in firmware elf"""
         program_name = "firmware_brisc"
         program_path = os.path.join(TestParseElf.elf_dir, program_name)
-        name_dict = read_elf(file_ifc, f"{program_path}.elf")
+        elf = read_elf(file_ifc, f"{program_path}.elf")
 
-        assert name_dict["dwarf"].loaded_offset == 0
+        assert type(elf) == ParsedElfFile
 
     def test_decode_symbols(self):
         """Test decode_symbols for object files"""
         program_name = "firmware_brisc"
         program_path = os.path.join(TestParseElf.elf_dir, program_name)
-        name_dict = read_elf(file_ifc, f"{program_path}.elf")
+        elf = read_elf(file_ifc, f"{program_path}.elf")
 
-        assert name_dict["symbols"]["noc_reads_num_issued"] == 4289724472
-        assert name_dict["symbols"]["noc_nonposted_writes_num_issued"] == 4289724464
-        assert name_dict["symbols"]["noc_nonposted_writes_acked"] == 4289724456
-        assert name_dict["symbols"]["noc_nonposted_atomics_acked"] == 4289724448
-        assert name_dict["symbols"]["noc_posted_writes_num_issued"] == 4289724440
+        assert elf.symbols["noc_reads_num_issued"] == 4289724472
+        assert elf.symbols["noc_nonposted_writes_num_issued"] == 4289724464
+        assert elf.symbols["noc_nonposted_writes_acked"] == 4289724456
+        assert elf.symbols["noc_nonposted_atomics_acked"] == 4289724448
+        assert elf.symbols["noc_posted_writes_num_issued"] == 4289724440
 
     def get_var_addr(self, name_dict, name):
         if name in name_dict:

--- a/ttexalens/cli_commands/dump-gpr.py
+++ b/ttexalens/cli_commands/dump-gpr.py
@@ -50,7 +50,7 @@ def get_register_data(device, context, loc, args):
     riscs_to_include = range(0, 4) if "all" in args["-r"] else [int(risc) for risc in riscs_to_include]
     elf_file = args["<elf-file>"] if args["<elf-file>"] else None
     elf = ELF(context.server_ifc, {"elf": elf_file}) if elf_file else None
-    pc_map = elf.names["elf"]["file-line"] if elf else None
+    pc_map = elf.names["elf"].file_line if elf else None
 
     reg_value: Dict[int, Dict[int, int]] = {}
     noc_id = 0  # Always use noc 0

--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import List, Union
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
-from ttexalens.parse_elf import read_elf
+from ttexalens.parse_elf import ParsedElfFile, read_elf
 from ttexalens.tt_exalens_lib import read_word_from_device, write_words_to_device, read_from_device, write_to_device
 from ttexalens import util as util
 import os
@@ -957,7 +957,7 @@ class RiscLoader:
             not self.risc_debug.is_halted() or self.risc_debug.read_status().is_ebreak_hit
         ), f"RISC at location {self.risc_debug.location} is still halted, but not because of ebreak."
 
-    def _read_elfs(self, elf_paths: List[str], offsets: List[int | None]) -> List[dict]:
+    def _read_elfs(self, elf_paths: List[str], offsets: List[int | None]) -> list[ParsedElfFile]:
         if not isinstance(elf_paths, list):
             elf_paths = [elf_paths]
         offsets = [None] * len(elf_paths) if offsets is None else offsets
@@ -969,9 +969,9 @@ class RiscLoader:
 
         return elfs
 
-    def _find_elf_and_frame_description(self, elfs: List[dict], pc: int):
+    def _find_elf_and_frame_description(self, elfs: list[ParsedElfFile], pc: int):
         for elf in elfs:
-            frame_description = elf["frame-info"].get_frame_description(pc, self.risc_debug)
+            frame_description = elf.frame_info.get_frame_description(pc, self.risc_debug)
             # If we get frame description from elf we return that elf and frame description
             if frame_description is not None:
                 return elf, frame_description
@@ -1001,8 +1001,8 @@ class RiscLoader:
             frame_pointer = frame_description.read_previous_cfa()
             i = 0
             while i < limit:
-                file_line = elf["dwarf"].find_file_line_by_address(pc)
-                function_die = elf["dwarf"].find_function_by_address(pc)
+                file_line = elf._dwarf.find_file_line_by_address(pc)
+                function_die = elf._dwarf.find_function_by_address(pc)
 
                 # Skipping lexical blocks since we do not print them
                 if function_die is not None and (
@@ -1063,7 +1063,7 @@ class RiscLoader:
                 pc = return_address
                 i = i + 1
 
-                frame_description = elf["frame-info"].get_frame_description(pc, self.risc_debug)
+                frame_description = elf.frame_info.get_frame_description(pc, self.risc_debug)
                 # If we do not get frame description from current elf check in others
                 if frame_description is None:
                     new_elf, frame_description = self._find_elf_and_frame_description(elfs, pc)

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -37,16 +37,23 @@ Examples:
   Options:
   -h --help      Show this screen.
 """
+from __future__ import annotations
 from functools import cached_property
 import os
 import re
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
+
+from ttexalens.tt_exalens_ifc_base import TTExaLensCommunicator
+
+if TYPE_CHECKING:
+    from ttexalens.debug_risc import RiscDebug
 
 try:
     from elftools.elf.elffile import ELFFile
     from elftools.dwarf.callframe import CIE, FDE
     from elftools.dwarf.compileunit import CompileUnit as DWARF_CU
     from elftools.dwarf.dwarfinfo import DWARFInfo
+    from elftools.dwarf.lineprogram import LineProgram
     from elftools.dwarf.die import DIE as DWARF_DIE
     from elftools.elf.enums import ENUM_ST_INFO_TYPE
     from docopt import docopt
@@ -82,9 +89,8 @@ def strip_DW_(s):
 
 
 class MY_DWARF:
-    def __init__(self, dwarf: DWARFInfo, loaded_offset=0):
+    def __init__(self, dwarf: DWARFInfo):
         self.dwarf = dwarf
-        self.loaded_offset = loaded_offset
         self._cus: Dict[int, MY_CU] = {}
 
     @cached_property
@@ -111,7 +117,6 @@ class MY_DWARF:
         """
         Given an address, find the function that contains that address. Goes through all CUs and all DIEs and all inlined functions.
         """
-        address += self.loaded_offset
         # Try to find CU that contains this address
         for cu in self.iter_CUs():
             # Top DIE should contain the address
@@ -168,12 +173,43 @@ class MY_DWARF:
         return result
 
     def find_file_line_by_address(self, address):
-        address += self.loaded_offset
         ranges = self.file_lines_ranges
         for (start, end), info in ranges.items():
             if start <= address < end:
                 return info
         return None
+
+
+class MY_DWARFWithOffset(MY_DWARF):
+    def __init__(self, my_dwarf: MY_DWARF, loaded_offset: int):
+        super().__init__(my_dwarf.dwarf)
+        self._my_dwarf = my_dwarf
+        self.loaded_offset = loaded_offset
+
+    @cached_property
+    def range_lists(self):
+        return self._my_dwarf.range_lists()
+
+    def get_cu(self, dwarf_cu: DWARF_CU):
+        return self._my_dwarf.get_cu(dwarf_cu)
+
+    def get_die(self, dwarf_die: DWARF_DIE):
+        return self._my_dwarf.get_die(dwarf_die)
+
+    def iter_CUs(self):
+        return self._my_dwarf.iter_CUs()
+
+    def find_function_by_address(self, address):
+        address += self.loaded_offset
+        return self._my_dwarf.find_function_by_address(address)
+
+    @cached_property
+    def file_lines_ranges(self):
+        return self._my_dwarf.file_lines_ranges
+
+    def find_file_line_by_address(self, address):
+        address += self.loaded_offset
+        return self._my_dwarf.find_file_line_by_address(address)
 
 
 class MY_CU:
@@ -586,12 +622,13 @@ def recurse_DIE(DIE: MY_DIE, recurse_dict, r_depth=0):
             recurse_DIE(child, recurse_dict, r_depth + 1)
 
 
-def decode_file_line(dwarfinfo):
+def decode_file_line(dwarf: DWARFInfo) -> dict[int, tuple[str, int, int]]:
     PC_to_fileline_map = {}
-    for CU in dwarfinfo.iter_CUs():
-        lineprog = dwarfinfo.line_program_for_CU(CU)
+    for CU in dwarf.iter_CUs():
+        lineprog = dwarf.line_program_for_CU(CU)
+        if lineprog is None:
+            continue
         delta = 1 if lineprog.header.version < 5 else 0
-        prevstate = None
         for entry in lineprog.get_entries():
             if entry.state is None:
                 continue
@@ -607,7 +644,7 @@ def decode_file_line(dwarfinfo):
 
 
 class FrameDescription:
-    def __init__(self, pc: int, fde: FDE, risc_debug):
+    def __init__(self, pc: int, fde: FDE, risc_debug: RiscDebug):
         self.pc = pc
         self.fde = fde
         self.risc_debug = risc_debug
@@ -630,7 +667,7 @@ class FrameDescription:
                 return self.risc_debug.read_memory(address)
         return self.risc_debug.read_gpr(register_index)
 
-    def read_previous_cfa(self, current_cfa: Optional[int] = None):
+    def read_previous_cfa(self, current_cfa: Optional[int] = None) -> int | None:
         if self.current_fde_entry is not None and self.fde.cie is not None:
             cfa_location = self.current_fde_entry["cfa"]
             register_index = cfa_location.reg
@@ -648,13 +685,12 @@ class FrameDescription:
                 return self.read_register(register_index, current_cfa)
 
         # We don't know how to calculate CFA, return 0 which will stop callstack evaluation
-        return 0
+        return None
 
 
 class FrameInfoProvider:
-    def __init__(self, dwarf_info, loaded_offset):
+    def __init__(self, dwarf_info):
         self.dwarf_info = dwarf_info
-        self.loaded_offset = loaded_offset
         self.fdes = []
 
         # Check if we have dwarf_frame CFI section
@@ -667,14 +703,25 @@ class FrameInfoProvider:
                 self.fdes.append((start_address, end_address, entry))
 
     def get_frame_description(self, pc, risc_debug) -> FrameDescription | None:
-        pc = pc + self.loaded_offset
         for start_address, end_address, fde in self.fdes:
             if start_address <= pc < end_address:
                 return FrameDescription(pc, fde, risc_debug)
         return None
 
 
-def decode_symbols(elf_file):
+class FrameInfoProviderWithOffset(FrameInfoProvider):
+    def __init__(self, frame_info: FrameInfoProvider, loaded_offset: int):
+        self.dwarf_info = frame_info.dwarf_info
+        self.fdes = frame_info.fdes
+        self._frame_info = frame_info
+        self.loaded_offset = loaded_offset
+
+    def get_frame_description(self, pc, risc_debug) -> FrameDescription | None:
+        pc = pc + self.loaded_offset
+        return self._frame_info.get_frame_description(pc, risc_debug)
+
+
+def decode_symbols(elf_file) -> dict[str, int]:
     symbols = {}
     for section in elf_file.iter_sections():
         # Check if it's a symbol table section
@@ -691,7 +738,7 @@ def decode_symbols(elf_file):
     return symbols
 
 
-def parse_dwarf(dwarf: DWARFInfo, loaded_offset=0):
+def recurse_dwarf(dwarf: MY_DWARF) -> dict[str, dict[str, MY_DIE]]:
     """
     Itaretes recursively over all the DIEs in the DWARF info and returns a dictionary
     with the following keys:
@@ -701,16 +748,14 @@ def parse_dwarf(dwarf: DWARFInfo, loaded_offset=0):
         'enumerator' - all the enumerators in the DWARF info
         'PC' - mappings between PC values and source code locations
     """
-    my_dwarf = MY_DWARF(dwarf)
-    recurse_dict = {
+    recurse_dict: dict[str, dict[str, MY_DIE]] = {
         "variable": dict(),
         "type": dict(),
         "member": dict(),
         "enumerator": dict(),
-        "dwarf": my_dwarf,
     }
 
-    for cu in my_dwarf.iter_CUs():
+    for cu in dwarf.iter_CUs():
         top_DIE = cu.top_DIE
         cu_name = "N/A"
         if "DW_AT_name" in top_DIE.attributes:
@@ -720,49 +765,132 @@ def parse_dwarf(dwarf: DWARFInfo, loaded_offset=0):
         # Process the names etc
         recurse_DIE(top_DIE, recurse_dict)
 
-    # Process the PC (program counter) values so we can map them to source code
-    recurse_dict["file-line"] = decode_file_line(dwarf)
-
-    # Process frame info
-    recurse_dict["frame-info"] = FrameInfoProvider(dwarf, loaded_offset)
-
     return recurse_dict
 
 
-def read_elf(file_ifc, elf_file_path, load_address=None):
+class ParsedElfFile:
+    def __init__(self, elf: ELFFile, elf_file_path: str):
+        self.elf = elf
+        self.elf_file_path = elf_file_path
+
+    @cached_property
+    def _dwarf(self) -> MY_DWARF:
+        dwarf = self.elf.get_dwarf_info()
+        return MY_DWARF(dwarf)
+
+    @cached_property
+    def _recursed_dwarf(self):
+        return recurse_dwarf(self._dwarf)
+
+    @cached_property
+    def variables(self):
+        return self._recursed_dwarf["variable"]
+
+    @cached_property
+    def types(self):
+        return self._recursed_dwarf["type"]
+
+    @cached_property
+    def members(self):
+        return self._recursed_dwarf["member"]
+
+    @cached_property
+    def enumerators(self):
+        return self._recursed_dwarf["enumerator"]
+
+    @cached_property
+    def subprograms(self):
+        return self._recursed_dwarf["subprogram"]
+
+    @cached_property
+    def code_load_address(self) -> int:
+        # TODO: Figure out how GDB knows the load address
+        text_sh = self.elf.get_section_by_name(".text")
+        if text_sh is None:
+            text_sh = self.elf.get_section_by_name(".firmware_text")
+        if text_sh is None:
+            raise ValueError(f"Could not locate text section in {self.elf_file_path}.")
+        return text_sh["sh_addr"]
+
+    @cached_property
+    def symbols(self):
+        return decode_symbols(self.elf)
+
+    @cached_property
+    def file_line(self):
+        return decode_file_line(self._dwarf.dwarf)
+
+    @cached_property
+    def frame_info(self) -> FrameInfoProvider:
+        return FrameInfoProvider(self._dwarf.dwarf)
+
+
+class ParsedElfFileWithOffset(ParsedElfFile):
+    def __init__(self, parsed_elf: ParsedElfFile, load_address: int):
+        super().__init__(parsed_elf.elf, parsed_elf.elf_file_path)
+        self.parsed_elf = parsed_elf
+        self.load_address = load_address
+        self.loaded_offset = parsed_elf.code_load_address - load_address
+
+    @cached_property
+    def _dwarf(self) -> MY_DWARF:
+        return MY_DWARFWithOffset(self.parsed_elf._dwarf, self.loaded_offset)
+
+    @cached_property
+    def _recursed_dwarf(self):
+        return self.parsed_elf._recursed_dwarf
+
+    @cached_property
+    def variables(self):
+        return self.parsed_elf.variables
+
+    @cached_property
+    def types(self):
+        return self.parsed_elf.types
+
+    @cached_property
+    def members(self):
+        return self.parsed_elf.members
+
+    @cached_property
+    def enumerators(self):
+        return self.parsed_elf.enumerators
+
+    @cached_property
+    def subprograms(self):
+        return self.parsed_elf.subprograms
+
+    @cached_property
+    def code_load_address(self) -> int:
+        return self.loaded_offset
+
+    @cached_property
+    def symbols(self):
+        return self.parsed_elf.symbols
+
+    @cached_property
+    def file_line(self):
+        return self.parsed_elf.file_line
+
+    @cached_property
+    def frame_info(self) -> FrameInfoProviderWithOffset:
+        return FrameInfoProviderWithOffset(self.frame_info, self.code_load_address)
+
+
+def read_elf(file_ifc: TTExaLensCommunicator, elf_file_path: str, load_address: int | None = None) -> ParsedElfFile:
     """
     Reads the ELF file and returns a dictionary with the DWARF info
     """
     # This is redirected to read from tmp folder in case of remote runs.
     f = file_ifc.get_binary(elf_file_path)
-
     elf = ELFFile(f)
 
     if not elf.has_dwarf_info():
-        print(f"ERROR: {elf_file_path} does not have DWARF info. Source file must be compiled with -g")
-        return
-
-    text_sh = elf.get_section_by_name(".text")
-    if text_sh is None:
-        text_sh = elf.get_section_by_name(".firmware_text")
-    if text_sh is None:
-        print(f"ERROR: Could not locate text section in {elf_file_path}.")
-        return
-
-    text_sh_address = text_sh["sh_addr"]
-
+        raise ValueError(f"{elf_file_path} does not have DWARF info. Source file must be compiled with -g")
+    parsed_elf = ParsedElfFile(elf, elf_file_path)
     if load_address is None:
-        load_address = text_sh_address
-
-    dwarf = elf.get_dwarf_info()
-
-    recurse_dict = parse_dwarf(dwarf, loaded_offset=text_sh_address - load_address)
-
-    recurse_dict["symbols"] = decode_symbols(elf)
-
-    recurse_dict["dwarf"].loaded_offset = text_sh_address - load_address
-
-    return recurse_dict
+        return parsed_elf
+    return ParsedElfFileWithOffset(parsed_elf, load_address)
 
 
 #
@@ -829,19 +957,18 @@ def resolve_unnamed_union_member(type_die, member_name):
     return None
 
 
-def mem_access(name_dict, access_path, mem_access_function):
+def mem_access(elf: ParsedElfFile, access_path, mem_access_function):
     """
     Given an access path such as "s_ptr->an_int", "s_ptr->an_int[2]", or "s_ptr->an_int[2][3]",
     calls the mem_access_function to read the memory, and returns the value array.
     """
     debug(f"Accessing {CLR_GREEN}{access_path}{CLR_END}")
 
-    # At the top level, the next name should be found in the 'variable'
-    # section of the name dict: name_dict["variable"]
+    # At the top level, the next name should be found in the elf.variables
     # We also check for pointer dereferences here
     access_path, ptr_dereference_count = get_ptr_dereference_count(access_path)
     name, path_divider, rest_of_path = split_access_path(access_path)
-    die: MY_DIE = name_dict["variable"][name]
+    die: MY_DIE = elf.variables[name]
     current_address = die.address
     type_die = die.resolved_type
 
@@ -974,7 +1101,7 @@ def access_logger(addr, size_bytes):
     return words_read
 
 
-class FileInterface:
+class FileInterface(TTExaLensCommunicator):
     def __init__(self):
         pass
 
@@ -989,9 +1116,9 @@ if __name__ == "__main__":
     debug_enabled = args["--debug"]
 
     file_ifc = FileInterface()
-    name_dict = read_elf(file_ifc, elf_file_path)
+    elf = read_elf(file_ifc, elf_file_path)
     if access_path:
-        mem_access(name_dict, access_path, access_logger)
+        mem_access(elf, access_path, access_logger)
     else:
         # Debugging display
         header = [
@@ -1009,9 +1136,7 @@ if __name__ == "__main__":
             header.append("DIE")
 
         rows = []
-        for cat, cat_dict in name_dict.items():
-            if cat in ["dwarf", "file-line", "frame-info", "symbols"]:  # Skip non-DIE objects
-                continue
+        for cat, cat_dict in elf._recursed_dwarf.items():
             for key, die in cat_dict.items():
                 if not hasattr(die, "path"):  # Skip if not a DIE object
                     continue


### PR DESCRIPTION
Method `read_elf` now returns class instead of dictionary. Fields in class are same as in dictionary, just are lazily loaded. This improves performance since not everything is being used in all scenarios.
New class has been added as well. When we load elf on offset, we can do that on already parsed elf, instead of forcing elf parsing again and again for different offsets.
This will greatly improve performance of tt-triage and make integration more readable.