### PR TITLE
Exposing top_callstack

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -820,6 +820,29 @@ class TestCallStack(unittest.TestCase):
         self.assertEqual(callstack[recursion_count + 1].function_name, "recurse")
         self.assertEqual(callstack[recursion_count + 2].function_name, "main")
 
+    @parameterized.expand([1, 10, 50])
+    def test_top_callstack_with_parsing(self, recursion_count):
+        lib.write_words_to_device(self.core_loc, 0x4000, recursion_count, 0, self.context)
+        elf_path = self.get_elf_path("callstack")
+        self.loader.run_elf(elf_path)
+        with self.rdbg.ensure_halted():
+            pc = self.rdbg.read_gpr(32)
+        parsed_elf = lib.parse_elf(elf_path, self.context)
+        callstack = lib.top_callstack(pc, parsed_elf, None, self.context)
+        self.assertEqual(len(callstack), 1)
+        self.assertEqual(callstack[0].function_name, "halt")
+
+    @parameterized.expand([1, 10, 50])
+    def test_top_callstack(self, recursion_count):
+        lib.write_words_to_device(self.core_loc, 0x4000, recursion_count, 0, self.context)
+        elf_path = self.get_elf_path("callstack")
+        self.loader.run_elf(elf_path)
+        with self.rdbg.ensure_halted():
+            pc = self.rdbg.read_gpr(32)
+        callstack = lib.top_callstack(pc, elf_path, None, self.context)
+        self.assertEqual(len(callstack), 1)
+        self.assertEqual(callstack[0].function_name, "halt")
+
     @parameterized.expand([(1, 1), (10, 9), (50, 49)])
     def test_callstack_optimized(self, recursion_count, expected_f1_on_callstack_count):
         lib.write_words_to_device(self.core_loc, 0x4000, recursion_count, 0, self.context)
@@ -843,6 +866,30 @@ class TestCallStack(unittest.TestCase):
                     self.assertEqual(callstack[i].function_name, "f1")
                 self.assertEqual(callstack[expected_f1_on_callstack_count + 2].function_name, "recurse")
                 self.assertEqual(callstack[expected_f1_on_callstack_count + 3].function_name, "main")
+        else:
+            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
+            for i in range(0, expected_f1_on_callstack_count):
+                self.assertEqual(callstack[i].function_name, "f1")
+            self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
+            self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
+
+    @parameterized.expand([(1, 1)])
+    def test_top_callstack_optimized(self, recursion_count, expected_f1_on_callstack_count):
+        lib.write_words_to_device(self.core_loc, 0x4000, recursion_count, 0, self.context)
+        elf_path = self.get_elf_path("callstack.optimized")
+        self.loader.run_elf(elf_path)
+        with self.rdbg.ensure_halted():
+            pc = self.rdbg.read_gpr(32)
+        callstack = lib.top_callstack(pc, elf_path, None, self.context)
+
+        # Optimized version for non-blackhole doesn't have halt on callstack
+        if self.is_blackhole():
+            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 3)
+            self.assertEqual(callstack[0].function_name, "halt")
+            for i in range(1, expected_f1_on_callstack_count + 1):
+                self.assertEqual(callstack[i].function_name, "f1")
+            self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "recurse")
+            self.assertEqual(callstack[expected_f1_on_callstack_count + 2].function_name, "main")
         else:
             self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
             for i in range(0, expected_f1_on_callstack_count):

--- a/ttexalens/cli_commands/callstack.py
+++ b/ttexalens/cli_commands/callstack.py
@@ -62,12 +62,14 @@ def run(cmd_text, context, ui_state: UIState = None):
             util.ERROR(f"File {elf_path} does not exist")
             return
 
+    elfs = [lib.parse_elf(elf_path, context) for elf_path in elf_paths]
+
     for device in dopt.for_each("--device", context, ui_state):
         for loc in dopt.for_each("--loc", context, ui_state, device=device):
             for risc_id in dopt.for_each("--risc", context, ui_state):
                 callstack = lib.callstack(
                     core_loc=loc,
-                    elf_paths=elf_paths,
+                    elfs=elfs,
                     offsets=offsets,
                     risc_id=risc_id,
                     max_depth=limit,

--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -965,7 +965,7 @@ class RiscLoader:
             parsed_elfs = [parsed_elfs]
         offsets = [None] * len(parsed_elfs) if offsets is None else offsets
 
-        elfs = []
+        elfs: list[ParsedElfFile] = []
         for parsed_elf, offset in zip(parsed_elfs, offsets):
             offset = None if offset == 0 else offset
             if offset is not None:
@@ -1029,7 +1029,7 @@ class RiscLoader:
         limit: int = 100,
         stop_on_main: bool = True,
     ):
-        callstack = []
+        callstack: list[CallstackEntry] = []
         with self.risc_debug.ensure_halted():
 
             # Load elfs at spefied offsets

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -492,7 +492,7 @@ def parse_elf(elf_path: str, context: Context | None = None) -> ParsedElfFile:
     """Reads the ELF file and returns a ParsedElfFile object.
     Args:
             elf_path (str): Path to the ELF file.
-            context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentially initialized. . Default: None
+            context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentially initialized. Default: None
     """
     context = check_context(context)
     return read_elf(context.server_ifc, elf_path)
@@ -510,9 +510,7 @@ def top_callstack(
     Args:
             pc (int): Program counter to be used for the callstack.
             elfs (List[str] | str | List[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
-            offsets (List[int], optional): List of offsets for each ELF file. Default: None.
-            verbose (bool): If True, enables verbose output. Default: False.
-            device_id (int): ID of the device on which the kernel is run. Default: 0.
+            offsets (List[int], int, optional): List of offsets for each ELF file. Default: None.
             context (Context): TTExaLens context object used for interaction with the device. If None, the global context is used and potentially initialized. Default: None
     Returns:
             List: Callstack (list of functions and information about them) of the specified RISC core for the given ELF.
@@ -560,7 +558,7 @@ def callstack(
     Args:
             core_loc (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location of a core in string format, DRAM channel (e.g., ch3), or OnChipCoordinate object.
             elfs (List[str] | str | List[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
-            offsets (List[int], optional): List of offsets for each ELF file. Default: None.
+            offsets (List[int], int, optional): List of offsets for each ELF file. Default: None.
             risc_id (int): RISC-V ID (0: brisc, 1-3 triscs). Default: 0.
             max_depth (int): Maximum depth of the callstack. Default: 100.
             stop_on_main (bool): If True, stops at the main function. Default: True.


### PR DESCRIPTION
Exposing two methods from library:
- top_callstack - returns callstack for top frame given by PC
- parse_elf - parses elf file which allows it to be reused in callstack methods