### PR TITLE
Creating default mem_reader for mem_access

### DIFF
--- a/ttexalens/firmware.py
+++ b/ttexalens/firmware.py
@@ -165,8 +165,8 @@ class ELF:
         address, size and type_die of the variable. If the variable is not found, return None.
         """
 
-        def my_mem_reader(addr, size_bytes):
-            pass
+        def my_mem_reader(addr: int, size_bytes: int, elements_to_read: int) -> list[int]:
+            return []
 
         if mem_reader is None:
             mem_reader = my_mem_reader

--- a/ttexalens/firmware.py
+++ b/ttexalens/firmware.py
@@ -6,7 +6,7 @@ This module is used to represent the firmware
 """
 
 import time
-from typing import Dict, Tuple
+from typing import Callable, Dict, Tuple
 from ttexalens import parse_elf
 from ttexalens import util as util
 import re
@@ -210,13 +210,23 @@ class ELF:
         return data
 
     @staticmethod
-    def get_mem_reader(context, device_id, core_loc):
+    def get_mem_reader(context, device_id, core_loc) -> Callable[[int, int, int], list[int]]:
         """
         Returns a simple memory reader function that reads from a given device and a given core.
         """
-        from ttexalens.tt_exalens_lib import read_word_from_device
+        from ttexalens.tt_exalens_lib import read_from_device
 
-        def mem_reader(context, addr, size_bytes):
-            return [read_word_from_device(core_loc, addr, device_id, context)]
+        def mem_reader(addr: int, size_bytes: int, elements_to_read: int) -> list[int]:
+            if elements_to_read == 0:
+                return []
+            element_size = size_bytes // elements_to_read
+            assert element_size * elements_to_read == size_bytes, "Size must be divisible by number of elements"
+            bytes_data = read_from_device(
+                core_loc=core_loc, device_id=device_id, addr=addr, num_bytes=size_bytes, context=context
+            )
+            return [
+                int.from_bytes(bytes_data[i * element_size : (i + 1) * element_size], byteorder="little")
+                for i in range(elements_to_read)
+            ]
 
         return mem_reader

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -48,10 +48,13 @@ if TYPE_CHECKING:
 
 try:
     from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
     from elftools.dwarf.callframe import FDE
     from elftools.dwarf.compileunit import CompileUnit as DWARF_CU
+    from elftools.dwarf.dwarf_expr import DWARFExprParser
     from elftools.dwarf.dwarfinfo import DWARFInfo
     from elftools.dwarf.die import DIE as DWARF_DIE
+    from elftools.dwarf.locationlists import LocationParser, LocationExpr
     from docopt import docopt
     from tabulate import tabulate
 except:
@@ -92,6 +95,14 @@ class ElfDwarf:
     @cached_property
     def range_lists(self):
         return self.dwarf.range_lists()
+
+    @cached_property
+    def location_lists(self):
+        return self.dwarf.location_lists()
+
+    @cached_property
+    def location_parser(self):
+        return LocationParser(self.location_lists)
 
     def get_cu(self, dwarf_cu: DWARF_CU):
         cu = self._cus.get(id(dwarf_cu))
@@ -188,6 +199,14 @@ class ElfDwarfWithOffset(ElfDwarf):
     def range_lists(self):
         return self._my_dwarf.range_lists
 
+    @cached_property
+    def location_lists(self):
+        return self._my_dwarf.location_lists
+
+    @cached_property
+    def location_parser(self):
+        return self._my_dwarf.location_parser
+
     def get_cu(self, dwarf_cu: DWARF_CU):
         return self._my_dwarf.get_cu(dwarf_cu)
 
@@ -234,9 +253,18 @@ class ElfCompileUnit:
     def line_program(self):
         return self.dwarf.dwarf.line_program_for_CU(self.dwarf_cu)
 
+    @cached_property
+    def version(self):
+        return self.dwarf_cu["version"]
+
+    @cached_property
+    def expression_parser(self):
+        return DWARFExprParser(self.dwarf_cu.structs)
+
     def iter_DIEs(self):
         for die in self.dwarf_cu.iter_DIEs():
-            yield self.get_die(die)
+            if die.tag is not None:
+                yield self.get_die(die)
 
     def find_DIE_at_local_offset(self, local_offset):
         """
@@ -258,15 +286,15 @@ class ElfCompileUnit:
 
         IMPROVE: What if there are multiple dies to return?
         """
-        for dwarf_cu in self.dwarf_cu.dwarfinfo.iter_CUs():
-            for DIE in dwarf_cu.iter_DIEs():
-                if "DW_AT_specification" in DIE.attributes:
-                    if DIE.attributes["DW_AT_specification"].value == die.offset:
-                        return self.dwarf.get_die(DIE)
-                if "DW_AT_abstract_origin" in DIE.attributes:
-                    dwarf_die = DIE.get_DIE_from_attribute("DW_AT_abstract_origin")
-                    if dwarf_die == die.dwarf_die and len(DIE.attributes) > 1:
-                        return self.dwarf.get_die(DIE)
+        for cu in self.dwarf.iter_CUs():
+            for iter_die in cu.iter_DIEs():
+                if len(iter_die.attributes) > 1:
+                    if "DW_AT_specification" in iter_die.attributes:
+                        if iter_die.get_DIE_from_attribute("DW_AT_specification") == die:
+                            return iter_die
+                    if "DW_AT_abstract_origin" in iter_die.attributes:
+                        if iter_die.get_DIE_from_attribute("DW_AT_abstract_origin") == die:
+                            return iter_die
         return None
 
 
@@ -456,22 +484,48 @@ class ElfDie:
         """
         Return the address of the DIE within the parent type
         """
+        return self.__get_address_recursed(allow_recursion=True)
+
+    def __get_address_recursed(self, allow_recursion: bool) -> int | None:
         addr = None
         if "DW_AT_data_member_location" in self.attributes:
             addr = self.attributes["DW_AT_data_member_location"].value
         else:
-            location = self.attributes.get("DW_AT_location")
-            if location:
-                # Assuming the location's form is a block
-                block = location.value
-                # Check if the first opcode is DW_OP_addr (0x03)
-                if block[0] == 0x03:
-                    addr = int.from_bytes(block[1:], byteorder="little")
+            location_attribute = self.attributes.get("DW_AT_location")
+            location_parser = self.cu.dwarf.location_parser
+            if location_attribute:
+                location = location_parser.parse_from_attribute(location_attribute, self.cu.version, self.dwarf_die)
+                if isinstance(location, LocationExpr):
+                    parsed = self.cu.expression_parser.parse_expr(location.loc_expr)
+                    if len(parsed) == 1 and parsed[0].op_name == "DW_OP_addr":
+                        assert len(parsed[0].args) == 1
+                        addr = parsed[0].args[0]
+                    elif len(parsed) == 1 and parsed[0].op_name == "DW_OP_addrx":
+                        assert len(parsed[0].args) == 1
+                        index = parsed[0].args[0]
+                        addr = self.cu.dwarf.dwarf.get_addr(self.cu.dwarf_cu, index)
+                    else:
+                        # We have expression that needs to be evaluated and applied in order to get to location value.
+                        # In order for this to work, we need to return expression that needs to be evaluated in mem_access method.
+                        pass
+                elif isinstance(location, list):
+                    # We have list of expressions. All need to be evaluated and applied in order to get to location value.
+                    # In order for this to work, we need to return expression that needs to be evaluated in mem_access method.
+                    # for loc in location:
+                    #     parsed = self.cu.expression_parser.parse_expr(loc.loc_expr)
+                    pass
             else:
-                # Try to find another DIE that defines this variable
-                other_die = self.cu.find_DIE_that_specifies(self)
-                if other_die:
-                    addr = other_die.address
+                if allow_recursion and (
+                    not "DW_AT_artificial" in self.attributes or not self.attributes["DW_AT_artificial"].value
+                ):
+                    if "DW_AT_specification" in self.attributes:
+                        other_die = self.get_DIE_from_attribute("DW_AT_specification")
+                    elif "DW_AT_abstract_origin" in self.attributes:
+                        other_die = self.get_DIE_from_attribute("DW_AT_abstract_origin")
+                    else:
+                        other_die = self.cu.find_DIE_that_specifies(self)
+                    if other_die:
+                        addr = other_die.__get_address_recursed(allow_recursion=False)
 
         if addr is None:
             if (
@@ -522,9 +576,11 @@ class ElfDie:
             else:
                 name = "?Unknown?&"
         elif "DW_AT_abstract_origin" in self.attributes:
-            dwarf_die = self.dwarf_die.get_DIE_from_attribute("DW_AT_abstract_origin")
-            die = self.cu.dwarf.get_die(dwarf_die)
-            name = die.name
+            die = self.get_DIE_from_attribute("DW_AT_abstract_origin")
+            if die is not None:
+                name = die.name
+            else:
+                name = None
         else:
             # We can't figure out the name of this variable. Just give it a name based on the ELF offset.
             name = f"{self.tag}-{hex(self.offset)}"
@@ -567,6 +623,12 @@ class ElfDie:
         """
         for child in self.dwarf_die.iter_children():
             yield self.cu.get_die(child)
+
+    def get_DIE_from_attribute(self, attribute_name: str):
+        if attribute_name in self.attributes:
+            dwarf_die = self.dwarf_die.get_DIE_from_attribute(attribute_name)
+            return self.cu.dwarf.get_die(dwarf_die)
+        return None
 
     @cached_property
     def parent(self):
@@ -734,12 +796,13 @@ class FrameInfoProviderWithOffset(FrameInfoProvider):
         return self._frame_info.get_frame_description(pc, risc_debug)
 
 
-def decode_symbols(elf_file) -> dict[str, int]:
+def decode_symbols(elf_file: ELFFile) -> dict[str, int]:
     symbols = {}
     for section in elf_file.iter_sections():
         # Check if it's a symbol table section
         if section.name == ".symtab":
             # Iterate through symbols
+            assert isinstance(section, SymbolTableSection)
             for symbol in section.iter_symbols():
                 # Check if it's a label symbol
                 if symbol["st_info"]["type"] == "STT_NOTYPE" and symbol.name:

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -11,6 +11,43 @@
 
 namespace tt::exalens {
 
+static void read_from_device_reg(tt::umd::Cluster* cluster, void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core,
+                                 uint64_t addr, uint32_t size) {
+    // Read first unaligned word
+    uint32_t first_unaligned_index = addr % 4;
+    if (first_unaligned_index != 0) {
+        uint32_t temp = 0;
+        cluster->read_from_device_reg(&temp, chip, core, addr - first_unaligned_index, sizeof(temp));
+        if (first_unaligned_index + size <= 4) {
+            memcpy(mem_ptr, ((uint8_t*)&temp) + first_unaligned_index, size);
+            return;
+        }
+        memcpy(mem_ptr, ((uint8_t*)&temp) + first_unaligned_index, 4 - first_unaligned_index);
+        mem_ptr = (uint8_t*)mem_ptr + 4 - first_unaligned_index;
+        addr += 4 - first_unaligned_index;
+        size -= 4 - first_unaligned_index;
+    }
+
+    // Read aligned bytes
+    uint32_t aligned_size = size - (size % 4);
+    if (aligned_size > 0) {
+        cluster->read_from_device_reg(mem_ptr, chip, core, addr, aligned_size);
+        mem_ptr = (uint8_t*)mem_ptr + aligned_size;
+        addr += aligned_size;
+        size -= aligned_size;
+    }
+
+    // Read last unaligned word
+    uint32_t last_unaligned_size = size;
+    if (last_unaligned_size != 0) {
+        uint32_t temp = 0;
+        cluster->read_from_device_reg(&temp, chip, core, addr, sizeof(temp));
+        memcpy(mem_ptr, &temp, last_unaligned_size);
+    }
+}
+
+// TODO: Similarly to the read_from_device_reg function, we should implement a write_to_device_reg function
+
 umd_implementation::umd_implementation(tt::umd::Cluster* cluster) : cluster(cluster) {}
 
 std::optional<uint32_t> umd_implementation::pci_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
@@ -21,7 +58,7 @@ std::optional<uint32_t> umd_implementation::pci_read32(uint8_t noc_id, uint8_t c
     uint32_t result;
     tt::umd::CoreCoord target = cluster->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
-    cluster->read_from_device_reg(&result, chip_id, target, address, sizeof(result));
+    read_from_device_reg(cluster, &result, chip_id, target, address, sizeof(result));
     return result;
 }
 
@@ -48,13 +85,13 @@ std::optional<std::vector<uint8_t>> umd_implementation::pci_read(uint8_t noc_id,
     if (!is_chip_mmio_capable(chip_id)) {
         for (uint32_t done = 0; done < size;) {
             uint32_t block = std::min(size - done, 1024u);
-            cluster->read_from_device_reg(result.data() + done, chip_id, target, address + done, block);
+            read_from_device_reg(cluster, result.data() + done, chip_id, target, address + done, block);
             done += block;
         }
         return result;
     }
 
-    cluster->read_from_device_reg(result.data(), chip_id, target, address, size);
+    read_from_device_reg(cluster, result.data(), chip_id, target, address, size);
     return result;
 }
 

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -11,14 +11,16 @@
 
 namespace tt::exalens {
 
-static void read_from_device_reg(tt::umd::Cluster* cluster, void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core,
-                                 uint64_t addr, uint32_t size) {
+// TODO #375: Remove read/write unaligned functions once UMD implements ability to set unaligned access for our TLB
+
+void read_from_device_reg_unaligned(tt::umd::Cluster* cluster, void* mem_ptr, chip_id_t chip, tt::umd::CoreCoord core,
+                                    uint64_t addr, uint32_t size) {
     // Read first unaligned word
     uint32_t first_unaligned_index = addr % 4;
     if (first_unaligned_index != 0) {
         uint32_t temp = 0;
         cluster->read_from_device_reg(&temp, chip, core, addr - first_unaligned_index, sizeof(temp));
-        if (first_unaligned_index + size <= 4) {
+        if (first_unaligned_index + size <= sizeof(temp)) {
             memcpy(mem_ptr, ((uint8_t*)&temp) + first_unaligned_index, size);
             return;
         }
@@ -46,7 +48,47 @@ static void read_from_device_reg(tt::umd::Cluster* cluster, void* mem_ptr, chip_
     }
 }
 
-// TODO: Similarly to the read_from_device_reg function, we should implement a write_to_device_reg function
+void write_to_device_reg_unaligned(tt::umd::Cluster* cluster, const void* mem_ptr, uint32_t size_in_bytes,
+                                   chip_id_t chip, tt::umd::CoreCoord core, uint64_t addr) {
+    {
+        // Read/Write first unaligned word
+        uint32_t first_unaligned_index = addr % 4;
+        if (first_unaligned_index != 0) {
+            uint32_t temp = 0;
+            uint64_t aligned_address = addr - first_unaligned_index;
+            cluster->read_from_device_reg(&temp, chip, core, aligned_address, sizeof(temp));
+            if (first_unaligned_index + size_in_bytes <= sizeof(temp)) {
+                memcpy(((uint8_t*)&temp) + first_unaligned_index, mem_ptr, size_in_bytes);
+                cluster->write_to_device_reg(&temp, sizeof(temp), chip, core, aligned_address);
+                return;
+            }
+            memcpy(((uint8_t*)&temp) + first_unaligned_index, mem_ptr, 4 - first_unaligned_index);
+            cluster->write_to_device_reg(&temp, sizeof(temp), chip, core, aligned_address);
+            mem_ptr = (uint8_t*)mem_ptr + 4 - first_unaligned_index;
+            addr += 4 - first_unaligned_index;
+            size_in_bytes -= 4 - first_unaligned_index;
+        }
+
+        // Write aligned bytes
+        uint32_t aligned_size = size_in_bytes - (size_in_bytes % 4);
+        if (aligned_size > 0) {
+            cluster->write_to_device_reg(mem_ptr, aligned_size, chip, core, addr);
+            mem_ptr = (uint8_t*)mem_ptr + aligned_size;
+            addr += aligned_size;
+            size_in_bytes -= aligned_size;
+        }
+
+        // Read/Write last unaligned word
+        uint32_t last_unaligned_size = size_in_bytes;
+        if (last_unaligned_size != 0) {
+            uint32_t temp = 0;
+            cluster->read_from_device_reg(&temp, chip, core, addr, sizeof(temp));
+            memcpy(&temp, mem_ptr, last_unaligned_size);
+            cluster->write_to_device_reg(&temp, sizeof(temp), chip, core, addr);
+        }
+    }
+
+}  // namespace tt::exalens
 
 umd_implementation::umd_implementation(tt::umd::Cluster* cluster) : cluster(cluster) {}
 
@@ -58,7 +100,7 @@ std::optional<uint32_t> umd_implementation::pci_read32(uint8_t noc_id, uint8_t c
     uint32_t result;
     tt::umd::CoreCoord target = cluster->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
-    read_from_device_reg(cluster, &result, chip_id, target, address, sizeof(result));
+    read_from_device_reg_unaligned(cluster, &result, chip_id, target, address, sizeof(result));
     return result;
 }
 
@@ -69,7 +111,7 @@ std::optional<uint32_t> umd_implementation::pci_write32(uint8_t noc_id, uint8_t 
 
     tt::umd::CoreCoord target = cluster->get_soc_descriptor(chip_id).get_coord_at({noc_x, noc_y}, CoordSystem::NOC0);
 
-    cluster->write_to_device_reg(&data, sizeof(data), chip_id, target, address);
+    write_to_device_reg_unaligned(cluster, &data, sizeof(data), chip_id, target, address);
     return 4;
 }
 
@@ -85,13 +127,13 @@ std::optional<std::vector<uint8_t>> umd_implementation::pci_read(uint8_t noc_id,
     if (!is_chip_mmio_capable(chip_id)) {
         for (uint32_t done = 0; done < size;) {
             uint32_t block = std::min(size - done, 1024u);
-            read_from_device_reg(cluster, result.data() + done, chip_id, target, address + done, block);
+            read_from_device_reg_unaligned(cluster, result.data() + done, chip_id, target, address + done, block);
             done += block;
         }
         return result;
     }
 
-    read_from_device_reg(cluster, result.data(), chip_id, target, address, size);
+    read_from_device_reg_unaligned(cluster, result.data(), chip_id, target, address, size);
     return result;
 }
 
@@ -106,13 +148,13 @@ std::optional<uint32_t> umd_implementation::pci_write(uint8_t noc_id, uint8_t ch
     if (!is_chip_mmio_capable(chip_id)) {
         for (uint32_t done = 0; done < size;) {
             uint32_t block = std::min(size - done, 1024u);
-            cluster->write_to_device(data + done, block, chip_id, target, address + done);
+            write_to_device_reg_unaligned(cluster, data + done, block, chip_id, target, address + done);
             done += block;
         }
         return size;
     }
 
-    cluster->write_to_device(data, size, chip_id, target, address);
+    write_to_device_reg_unaligned(cluster, data, size, chip_id, target, address);
     return size;
 }
 


### PR DESCRIPTION
Improving how we get die address using DW_AT_location.
Incorporating changes so get_mem_reader returns correct callable so mem_access can work.

At the moment, agreement with UMD team is to write our own unaligned read/write functions and in the future they will support it with different change. See #375 for more info.