### PR TITLE
Add pybind stub generation support in CMake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,9 @@ include(${PROJECT_SOURCE_DIR}/cmake/ZeroMQ.cmake)
 # Including private repository
 include(${PROJECT_SOURCE_DIR}/cmake/ttexalens_private.cmake)
 
+# Include pybind custom functions
+include(${PROJECT_SOURCE_DIR}/cmake/pybind.cmake)
+
 # Add subdirectories
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttexalens)
 add_subdirectory(${PROJECT_SOURCE_DIR}/utils)

--- a/cmake/pybind.cmake
+++ b/cmake/pybind.cmake
@@ -1,0 +1,45 @@
+# Check if pybind11_stubgen is available in the Python environment
+set(PYBIND11_STUBGEN_AVAILABLE OFF)
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -m pybind11_stubgen --help
+    RESULT_VARIABLE _pybind11_stubgen_found
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+if(_pybind11_stubgen_found EQUAL 0)
+    set(PYBIND11_STUBGEN_AVAILABLE ON)
+else()
+    message(WARNING "pybind11_stubgen is not available in the Python environment. Skipping stub generation.")
+endif()
+
+option(GENERATE_PYBIND_STUBS "Generate pybind11 stub files (.pyi)" ${PYBIND11_STUBGEN_AVAILABLE})
+
+
+function(add_pybind_stubgen TARGET)
+    set(options)
+    set(oneValueArgs OUTPUT_DIR)
+    set(multiValueArgs)
+    cmake_parse_arguments(PYBIND_STUBGEN "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT PYBIND_STUBGEN_OUTPUT_DIR)
+        set(PYBIND_STUBGEN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/stubs")
+    endif()
+
+    get_target_property(MODULE_NAME ${TARGET} OUTPUT_NAME)
+    if(NOT MODULE_NAME)
+        set(MODULE_NAME ${TARGET})
+    endif()
+
+    get_target_property(WORKING_DIRECTORY ${TARGET} LIBRARY_OUTPUT_DIRECTORY)
+    if(NOT WORKING_DIRECTORY)
+        set(WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+    endif()
+
+    if(GENERATE_PYBIND_STUBS)
+        add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND ${Python3_EXECUTABLE} -m pybind11_stubgen ${MODULE_NAME} --output-dir ${PYBIND_STUBGEN_OUTPUT_DIR}
+            WORKING_DIRECTORY ${WORKING_DIRECTORY}
+            COMMENT "Generating .pyi file for ${MODULE_NAME} using pybind11-stubgen"
+        )
+    endif()
+endfunction()

--- a/test/ttexalens/pybind/CMakeLists.txt
+++ b/test/ttexalens/pybind/CMakeLists.txt
@@ -21,3 +21,4 @@ set_target_properties(ttexalens_pybind_unit_tests PROPERTIES
     BUILD_WITH_INSTALL_RPATH true
     INSTALL_RPATH "$ORIGIN:$ORIGIN/../lib"
 )
+add_pybind_stubgen(ttexalens_pybind_unit_tests)

--- a/ttexalens/pybind/CMakeLists.txt
+++ b/ttexalens/pybind/CMakeLists.txt
@@ -23,9 +23,4 @@ set_target_properties(ttexalens_pybind PROPERTIES
     INSTALL_RPATH "$ORIGIN:$ORIGIN/../lib"
 )
 
-# Add post-build event to generate .pyi file
-add_custom_command(TARGET ttexalens_pybind POST_BUILD
-    COMMAND ${Python3_EXECUTABLE} -m pybind11_stubgen ttexalens_pybind --output-dir ${CMAKE_BINARY_DIR}/stubs
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib
-    COMMENT "Generating .pyi file for ttexalens_pybind using pybind11-stubgen"
-)
+add_pybind_stubgen(ttexalens_pybind)


### PR DESCRIPTION
Detecting if pybind11_stubgen is installed instead of forcing its existance. This fixes errors with user installing git version of wheel.
Making simple CMake function for adding stub generation for target.
Added pybind stub generation for tests pybind.