### PR TITLE
Add missing header

### DIFF
--- a/ttexalens/server/lib/inc/ttexalensserver/jtag.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/jtag.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <mutex>
+#include <string>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
If you try to compile master exalens on debian testing, you'll get:
```
FAILED: ttexalens/server/lib/CMakeFiles/ttexalens_server_lib.dir/src/jtag.cpp.o
ccache /usr/bin/clang++-17  -I/root/src/tt-exalens/ttexalens/server/lib/inc -I/root/src/tt-exalens/third_party/umd/device/api -I/root/src/tt-exalens/.cpmcache/fmt/69912fb6b71fcb1f7e5deca191a2bb4748c4e7b6/include -g -std=gnu++17 -fPIC -MD -MT ttexalens/server/lib/CMakeFiles/ttexalens_server_lib.dir/src/jtag.cpp.o -MF ttexalens/server/lib/CMakeFiles/ttexalens_server_lib.dir/src/jtag.cpp.o.d -o ttexalens/server/lib/CMakeFiles/ttexalens_server_lib.dir/src/jtag.cpp.o -c /root/src/tt-exalens/ttexalens/server/lib/src/jtag.cpp
In file included from /root/src/tt-exalens/ttexalens/server/lib/src/jtag.cpp:4:
/root/src/tt-exalens/ttexalens/server/lib/inc/ttexalensserver/jtag.h:38:29: error: no member named 'string' in namespace 'std'
   38 |     std::unordered_map<std::string, void*> funcMap;
      |                        ~~~~~^
1 error generated.
```

Adding that header fixes build.