### PR TITLE
Exposing reading ARC telemetry entries from UMD

### DIFF
--- a/test/ttexalens/server/test_communication.cpp
+++ b/test/ttexalens/server/test_communication.cpp
@@ -200,6 +200,13 @@ TEST(ttexalens_communication, arc_msg) {
                  "\n  noc_id: 0\n  chip_id: 1\n  msg_code: 2\n  wait_for_done: 1\n  arg0: 3\n  arg1: 4\n  timeout: 5");
 }
 
+TEST(ttexalens_communication, read_arc_telemetry_entry) {
+    auto req = tt::exalens::read_arc_telemetry_entry_request{tt::exalens::request_type::read_arc_telemetry_entry, 0, 1};
+    test_yaml_request(
+        req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::read_arc_telemetry_entry)) +
+                 "\n  chip_id: 0\n  telemetry_tag: 1");
+}
+
 TEST(ttexalens_communication, jtag_read32) {
     auto req = tt::exalens::jtag_read32_request{tt::exalens::request_type::jtag_read32, 0, 1, 2, 3, 123456};
     test_yaml_request(req, "- type: " + std::to_string(static_cast<int>(tt::exalens::request_type::jtag_read32)) +

--- a/test/ttexalens/server/test_server.cpp
+++ b/test/ttexalens/server/test_server.cpp
@@ -155,6 +155,13 @@ class yaml_not_implemented_implementation : public ttexalens_implementation {
         return {};
     }
 
+    std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) override {
+        server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::read_arc_telemetry_entry)) +
+                          "\n  chip_id: " + std::to_string(chip_id) +
+                          "\n  telemetry_tag: " + std::to_string(telemetry_tag));
+        return {};
+    }
+
     std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
                                         uint64_t address) override {
         server->send_yaml("- type: " + std::to_string(static_cast<int>(request_type::jtag_read32)) +

--- a/test/ttexalens/server/yaml_communication.cpp
+++ b/test/ttexalens/server/yaml_communication.cpp
@@ -54,6 +54,9 @@ void yaml_communication::process(const tt::exalens::request& request) {
         case tt::exalens::request_type::arc_msg:
             respond(serialize(static_cast<const tt::exalens::arc_msg_request&>(request)));
             break;
+        case tt::exalens::request_type::read_arc_telemetry_entry:
+            respond(serialize(static_cast<const tt::exalens::read_arc_telemetry_entry_request&>(request)));
+            break;
         case tt::exalens::request_type::jtag_read32:
             respond(serialize(static_cast<const tt::exalens::jtag_read32_request&>(request)));
             break;

--- a/test/ttexalens/server/yaml_communication.cpp
+++ b/test/ttexalens/server/yaml_communication.cpp
@@ -165,6 +165,11 @@ std::string yaml_communication::serialize(const tt::exalens::arc_msg_request& re
            "\n  arg1: " + std::to_string(request.arg1) + "\n  timeout: " + std::to_string(request.timeout);
 }
 
+std::string yaml_communication::serialize(const tt::exalens::read_arc_telemetry_entry_request& request) {
+    return "- type: " + std::to_string(static_cast<int>(request.type)) +
+           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  entry_id: " + std::to_string(request.telemetry_tag);
+}
+
 std::string yaml_communication::serialize(const tt::exalens::jtag_read32_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
            "\n  noc_id: " + std::to_string(request.noc_id) + "\n  chip_id: " + std::to_string(request.chip_id) +

--- a/test/ttexalens/server/yaml_communication.cpp
+++ b/test/ttexalens/server/yaml_communication.cpp
@@ -167,7 +167,8 @@ std::string yaml_communication::serialize(const tt::exalens::arc_msg_request& re
 
 std::string yaml_communication::serialize(const tt::exalens::read_arc_telemetry_entry_request& request) {
     return "- type: " + std::to_string(static_cast<int>(request.type)) +
-           "\n  chip_id: " + std::to_string(request.chip_id) + "\n  entry_id: " + std::to_string(request.telemetry_tag);
+           "\n  chip_id: " + std::to_string(request.chip_id) +
+           "\n  telemetry_tag: " + std::to_string(request.telemetry_tag);
 }
 
 std::string yaml_communication::serialize(const tt::exalens::jtag_read32_request& request) {

--- a/test/ttexalens/server/yaml_communication.h
+++ b/test/ttexalens/server/yaml_communication.h
@@ -30,6 +30,7 @@ class yaml_communication : public tt::exalens::communication {
     std::string serialize(const tt::exalens::get_device_soc_description_request& request);
     std::string serialize(const tt::exalens::get_file_request& request);
     std::string serialize(const tt::exalens::arc_msg_request& request);
+    std::string serialize(const tt::exalens::read_arc_telemetry_entry_request& request);
     std::string serialize(const tt::exalens::jtag_read32_request& request);
     std::string serialize(const tt::exalens::jtag_write32_request& request);
     std::string serialize(const tt::exalens::jtag_read32_axi_request& request);

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -781,6 +781,23 @@ class TestARC(unittest.TestCase):
 
     fw_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../..", "fw/arc/arc_bebaceca.hex")
 
+    def test_read_arc_telemetry_entry(self, device_id = 0):
+        # Check vendor ID
+        vendor_id = lib.read_arc_telemetry_entry(device_id, 1) & 0xFFFF
+        self.assertEqual(vendor_id, 0x1e52)
+ 
+        # Check if heartbeat is increasing
+        import time
+        heartbeat1 = lib.read_arc_telemetry_entry(device_id, 19)
+        time.sleep(0.1)
+        heartbeat2 = lib.read_arc_telemetry_entry(device_id, 19)
+        self.assertGreaterEqual(heartbeat2, heartbeat1)
+
+        # Check ARC Clock   
+        arc_clock = lib.read_arc_telemetry_entry(device_id, 26)
+        self.assertEqual(arc_clock, 540)
+
+
     def test_load_arc_fw(self):
 
         if self.is_blackhole():

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -782,20 +782,26 @@ class TestARC(unittest.TestCase):
     fw_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../..", "fw/arc/arc_bebaceca.hex")
 
     def test_read_arc_telemetry_entry(self, device_id = 0):
-        # Check vendor ID
-        vendor_id = lib.read_arc_telemetry_entry(device_id, 1) & 0xFFFF
-        self.assertEqual(vendor_id, 0x1e52)
- 
-        # Check if heartbeat is increasing
-        import time
-        heartbeat1 = lib.read_arc_telemetry_entry(device_id, 19)
-        time.sleep(0.1)
-        heartbeat2 = lib.read_arc_telemetry_entry(device_id, 19)
-        self.assertGreaterEqual(heartbeat2, heartbeat1)
 
-        # Check ARC Clock   
-        arc_clock = lib.read_arc_telemetry_entry(device_id, 26)
-        self.assertEqual(arc_clock, 540)
+        if self.is_wormhole():
+            # Check vendor ID
+            vendor_id = lib.read_arc_telemetry_entry(device_id, 1) & 0xFFFF
+            self.assertEqual(vendor_id, 0x1e52)
+    
+            # Check if heartbeat is increasing
+            import time
+            heartbeat1 = lib.read_arc_telemetry_entry(device_id, 19)
+            time.sleep(0.1)
+            heartbeat2 = lib.read_arc_telemetry_entry(device_id, 19)
+            self.assertGreaterEqual(heartbeat2, heartbeat1)
+
+            # Check ARC Clock   
+            arc_clock = lib.read_arc_telemetry_entry(device_id, 26)
+            self.assertEqual(arc_clock, 540)
+        elif self.is_blackhole():
+            pass
+        else:
+            self.skipTest("ARC telemetry is not supported for this architecture")
 
 
     def test_load_arc_fw(self):

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -802,12 +802,6 @@ class TestARC(unittest.TestCase):
             time.sleep(0.1)
             heartbeat2 = lib.read_arc_telemetry_entry(device_id, heartbeat_tag)
             self.assertGreater(heartbeat2, heartbeat1)
-
-            # Check ARC Clock
-            expected_arc_clock = 540
-            arc_clock_tag = 26
-            arc_clock = lib.read_arc_telemetry_entry(device_id, arc_clock_tag)
-            self.assertEqual(arc_clock, expected_arc_clock)
         elif self.is_blackhole():
             # Check if heartbeat is increasing
             import time
@@ -817,12 +811,6 @@ class TestARC(unittest.TestCase):
             time.sleep(0.1)
             heartbeat2 = lib.read_arc_telemetry_entry(device_id, heartbeat_tag)
             self.assertGreater(heartbeat2, heartbeat1)
-
-            # Check ARC Clock
-            expected_arc_clock = 800
-            arc_clock_tag = 16
-            arc_clock = lib.read_arc_telemetry_entry(device_id, arc_clock_tag)
-            self.assertEqual(arc_clock, expected_arc_clock)
         else:
             self.skipTest("ARC telemetry is not supported for this architecture")
 

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -842,7 +842,7 @@ class TestARC(unittest.TestCase):
             ("TAG_ASIC_ID", 3),
             ("TAG_AICLK", 14),
             ("TAG_ARCCLK", 16),
-            ("TAG_DDR_SPEED", 23),
+            ("TAG_GDDR_SPEED", 23),
         ]
     )
     def test_read_arc_telemetry_entry_blackhole(self, tag_name, tag_id):

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -785,8 +785,9 @@ class TestARC(unittest.TestCase):
 
     fw_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../..", "fw/arc/arc_bebaceca.hex")
 
-    def test_read_arc_telemetry_entry(self, device_id=0):
-
+    def test_read_arc_telemetry(self):
+        """Test reading ARC telemetry entries of known values"""
+        device_id = 0
         if self.is_wormhole():
             # Check vendor ID
             vendor_id_tag = 1
@@ -813,6 +814,49 @@ class TestARC(unittest.TestCase):
             self.assertGreater(heartbeat2, heartbeat1)
         else:
             self.skipTest("ARC telemetry is not supported for this architecture")
+
+    @parameterized.expand(
+        [
+            ("TAG_ENUM_VERSION", 0),
+            ("TAG_BOARD_ID_HIGH", 4),
+            ("TAG_AICLK", 24),
+            ("TAG_ARCCLK", 26),
+        ]
+    )
+    def test_read_arc_telemetry_entry_wormhole(self, tag_name, tag_id):
+        """Test reading ARC telemetry entry by tag name or tag ID"""
+
+        if not self.is_wormhole():
+            self.skipTest("This test applies only to wormhole architecture")
+
+        device_id = 0
+
+        # Check if reading by tag name and tag ID gives the same result
+        ret_from_name = lib.read_arc_telemetry_entry(device_id, tag_name)
+        ret_from_id = lib.read_arc_telemetry_entry(device_id, tag_id)
+        self.assertEqual(ret_from_name, ret_from_id)
+
+    @parameterized.expand(
+        [
+            ("TAG_BOARD_ID_HIGH", 1),
+            ("TAG_ASIC_ID", 3),
+            ("TAG_AICLK", 14),
+            ("TAG_ARCCLK", 16),
+            ("TAG_DDR_SPEED", 23),
+        ]
+    )
+    def test_read_arc_telemetry_entry_blackhole(self, tag_name, tag_id):
+        """Test reading ARC telemetry entry by tag name or tag ID"""
+
+        if not self.is_blackhole():
+            self.skipTest("This test applies only to blackhole architecture")
+
+        device_id = 0
+
+        # Check if reading by tag name and tag ID gives the same result
+        ret_from_name = lib.read_arc_telemetry_entry(device_id, tag_name)
+        ret_from_id = lib.read_arc_telemetry_entry(device_id, tag_id)
+        self.assertEqual(ret_from_name, ret_from_id)
 
     def test_load_arc_fw(self):
 

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -458,6 +458,14 @@ class Device(TTObject):
         pass
 
     @abstractmethod
+    def _get_arc_telemetry_tags_map_keys(self) -> List[str] | None:
+        pass
+
+    @abstractmethod
+    def _get_arc_telemetry_tag_id(self, tag_name: str) -> int | None:
+        pass
+
+    @abstractmethod
     def _get_riscv_local_memory_base_address(self) -> int:
         pass
 

--- a/ttexalens/hw/tensix/blackhole/blackhole.py
+++ b/ttexalens/hw/tensix/blackhole/blackhole.py
@@ -105,6 +105,16 @@ class BlackholeDevice(Device):
         else:
             return None
 
+    def _get_arc_telemetry_tags_map_keys(self) -> list[str]:
+        """Returns the keys of the ARC telemetry tags map."""
+        return list(BlackholeDevice.__arc_telemetry_tags_map.keys())
+
+    def _get_arc_telemetry_tag_id(self, tag_name) -> int | None:
+        """Returns the telemetry tag ID for a given tag name."""
+        if tag_name in BlackholeDevice.__arc_telemetry_tags_map:
+            return BlackholeDevice.__arc_telemetry_tags_map[tag_name]
+        return None
+
     def _get_riscv_local_memory_base_address(self) -> int:
         return BlackholeDevice.RISC_LOCAL_MEM_BASE
 
@@ -117,6 +127,72 @@ class BlackholeDevice(Device):
             return BlackholeDevice.NCRISC_LOCAL_MEM_SIZE
         else:
             return None
+
+    __arc_telemetry_tags_map = {
+        "TAG_BOARD_ID_HIGH": 1,
+        "TAG_BOARD_ID_LOW": 2,
+        "TAG_ASIC_ID": 3,
+        "TAG_HARVESTING_STATE": 4,
+        "TAG_UPDATE_TELEM_SPEED": 5,
+        "TAG_VCORE": 6,
+        "TAG_TDP": 7,
+        "TAG_TDC": 8,
+        "TAG_VDD_LIMITS": 9,
+        "TAG_THM_LIMIT_SHUTDOWN": 10,
+        "TAG_THM_LIMITS": 10,  # Same as TAG_THM_LIMIT_SHUTDOWN
+        "TAG_ASIC_TEMPERATURE": 11,
+        "TAG_VREG_TEMPERATURE": 12,
+        "TAG_BOARD_TEMPERATURE": 13,
+        "TAG_AICLK": 14,
+        "TAG_AXICLK": 15,
+        "TAG_ARCCLK": 16,
+        "TAG_L2CPUCLK0": 17,
+        "TAG_L2CPUCLK1": 18,
+        "TAG_L2CPUCLK2": 19,
+        "TAG_L2CPUCLK3": 20,
+        "TAG_ETH_LIVE_STATUS": 21,
+        "TAG_GDDR_STATUS": 22,
+        "TAG_GDDR_SPEED": 23,
+        "TAG_ETH_FW_VERSION": 24,
+        "TAG_GDDR_FW_VERSION": 25,
+        "TAG_BM_APP_FW_VERSION": 26,
+        "TAG_BM_BL_FW_VERSION": 27,
+        "TAG_FLASH_BUNDLE_VERSION": 28,
+        "TAG_CM_FW_VERSION": 29,
+        "TAG_L2CPU_FW_VERSION": 30,
+        "TAG_FAN_SPEED": 31,
+        "TAG_TIMER_HEARTBEAT": 32,
+        "TAG_TELEM_ENUM_COUNT": 33,
+        "TAG_ENABLED_TENSIX_COL": 34,
+        "TAG_ENABLED_ETH": 35,
+        "TAG_ENABLED_GDDR": 36,
+        "TAG_ENABLED_L2CPU": 37,
+        "TAG_PCIE_USAGE": 38,
+        "TAG_INPUT_CURRENT": 39,
+        "TAG_NOC_TRANSLATION": 40,
+        "TAG_FAN_RPM": 41,
+        "TAG_GDDR_0_1_TEMP": 42,
+        "TAG_GDDR_2_3_TEMP": 43,
+        "TAG_GDDR_4_5_TEMP": 44,
+        "TAG_GDDR_6_7_TEMP": 45,
+        "TAG_GDDR_0_1_CORR_ERRS": 46,
+        "TAG_GDDR_2_3_CORR_ERRS": 47,
+        "TAG_GDDR_4_5_CORR_ERRS": 48,
+        "TAG_GDDR_6_7_CORR_ERRS": 49,
+        "TAG_GDDR_UNCORR_ERRS": 50,
+        "TAG_MAX_GDDR_TEMP": 51,
+        "TAG_ASIC_LOCATION": 52,
+        "TAG_AICLK_LIMIT_MAX": 53,
+        "TAG_TDP_LIMIT_MAX": 54,
+        "TAG_TDC_LIMIT_MAX": 55,
+        "TAG_THM_LIMIT_THROTTLE": 56,
+        "TAG_FW_BUILD_DATE": 57,
+        "TAG_TT_FLASH_VERSION": 58,
+        "TAG_ENABLED_TENSIX_ROW": 59,
+        "TAG_THERM_TRIP_COUNT": 61,
+        "TAG_ASIC_ID_HIGH": 62,
+        "TAG_ASIC_ID_LOW": 63,
+    }
 
     __register_map = {
         # UNPACK TILE DESCRIPTOR SEC0

--- a/ttexalens/hw/tensix/wormhole/wormhole.py
+++ b/ttexalens/hw/tensix/wormhole/wormhole.py
@@ -112,6 +112,16 @@ class WormholeDevice(Device):
         else:
             return None
 
+    def _get_arc_telemetry_tags_map_keys(self) -> list[str]:
+        """Returns the keys of the ARC telemetry tags map."""
+        return list(WormholeDevice.__arc_telemetry_tags_map.keys())
+
+    def _get_arc_telemetry_tag_id(self, tag_name) -> int | None:
+        """Returns the telemetry tag ID for a given tag name."""
+        if tag_name in WormholeDevice.__arc_telemetry_tags_map:
+            return WormholeDevice.__arc_telemetry_tags_map[tag_name]
+        return None
+
     def _get_riscv_local_memory_base_address(self) -> int:
         return WormholeDevice.RISC_LOCAL_MEM_BASE
 
@@ -124,6 +134,59 @@ class WormholeDevice(Device):
             return WormholeDevice.NCRISC_LOCAL_MEM_SIZE
         else:
             return None
+
+    __arc_telemetry_tags_map: dict[str, int] = {
+        "TAG_ENUM_VERSION": 0,
+        "TAG_DEVICE_ID": 1,
+        "TAG_ASIC_RO": 2,
+        "TAG_ASIC_IDD": 3,
+        "TAG_BOARD_ID_HIGH": 4,
+        "TAG_BOARD_ID_LOW": 5,
+        "TAG_ARC0_FW_VERSION": 6,
+        "TAG_ARC1_FW_VERSION": 7,
+        "TAG_ARC2_FW_VERSION": 8,
+        "TAG_ARC3_FW_VERSION": 9,
+        "TAG_SPIBOOTROM_FW_VERSION": 10,
+        "TAG_ETH_FW_VERSION": 11,
+        "TAG_M3_BL_FW_VERSION": 12,
+        "TAG_M3_APP_FW_VERSION": 13,
+        "TAG_DDR_STATUS": 14,
+        "TAG_ETH_STATUS0": 15,
+        "TAG_ETH_STATUS1": 16,
+        "TAG_PCIE_STATUS": 17,
+        "TAG_FAULTS": 18,
+        "TAG_ARC0_HEALTH": 19,
+        "TAG_ARC1_HEALTH": 20,
+        "TAG_ARC2_HEALTH": 21,
+        "TAG_ARC3_HEALTH": 22,
+        "TAG_FAN_SPEED": 23,
+        "TAG_AICLK": 24,
+        "TAG_AXICLK": 25,
+        "TAG_ARCCLK": 26,
+        "TAG_THROTTLER": 27,
+        "TAG_VCORE": 28,
+        "TAG_ASIC_TEMPERATURE": 29,
+        "TAG_VREG_TEMPERATURE": 30,
+        "TAG_BOARD_TEMPERATURE": 31,
+        "TAG_TDP": 32,
+        "TAG_TDC": 33,
+        "TAG_VDD_LIMITS": 34,
+        "TAG_THM_LIMITS": 35,
+        "TAG_WH_FW_DATE": 36,
+        "TAG_ASIC_TMON0": 37,
+        "TAG_ASIC_TMON1": 38,
+        "TAG_MVDDQ_POWER": 39,
+        "TAG_GDDR_TRAIN_TEMP0": 40,
+        "TAG_GDDR_TRAIN_TEMP1": 41,
+        "TAG_BOOT_DATE": 42,
+        "TAG_RT_SECONDS": 43,
+        "TAG_ETH_DEBUG_STATUS0": 44,
+        "TAG_ETH_DEBUG_STATUS1": 45,
+        "TAG_TT_FLASH_VERSION": 46,
+        "TAG_ETH_LOOPBACK_STATUS": 47,
+        "TAG_ETH_LIVE_STATUS": 48,
+        "TAG_FW_BUNDLE_VERSION": 49,
+    }
 
     __register_map = {
         # UNPACK TILE DESCRIPTOR SEC 0

--- a/ttexalens/pybind/inc/bindings.h
+++ b/ttexalens/pybind/inc/bindings.h
@@ -40,8 +40,8 @@ std::optional<std::string> get_device_arch(uint8_t chip_id);
 std::optional<std::string> get_device_soc_description(uint8_t chip_id);
 
 std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id, uint32_t msg_code,
-                                                            bool wait_for_done, uint32_t arg0, uint32_t arg1,
-                                                            int timeout);
+                                                           bool wait_for_done, uint32_t arg0, uint32_t arg1,
+                                                           int timeout);
 std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag);
 
 std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);

--- a/ttexalens/pybind/inc/bindings.h
+++ b/ttexalens/pybind/inc/bindings.h
@@ -39,6 +39,11 @@ std::optional<std::vector<uint8_t>> get_device_ids();
 std::optional<std::string> get_device_arch(uint8_t chip_id);
 std::optional<std::string> get_device_soc_description(uint8_t chip_id);
 
+std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8_t chip_id, uint32_t msg_code,
+                                                            bool wait_for_done, uint32_t arg0, uint32_t arg1,
+                                                            int timeout);
+std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag);
+
 std::optional<uint32_t> jtag_read32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address);
 std::optional<uint32_t> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y, uint64_t address,
                                      uint32_t data);

--- a/ttexalens/pybind/src/bindings.cpp
+++ b/ttexalens/pybind/src/bindings.cpp
@@ -213,6 +213,13 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> arc_msg(uint8_t noc_id, uint8
     return {};
 }
 
+std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
+    if (ttexalens_implementation) {
+        return ttexalens_implementation->read_arc_telemetry_entry(chip_id, telemetry_tag);
+    }
+    return {};
+}
+
 PYBIND11_MODULE(ttexalens_pybind, m) {
     m.def("open_device", &open_device, "Opens tt device. Prints error message if failed.",
           pybind11::arg("binary_directory"), pybind11::arg_v("wanted_devices", std::vector<uint8_t>(), "[]"),
@@ -258,4 +265,6 @@ PYBIND11_MODULE(ttexalens_pybind, m) {
     m.def("arc_msg", &arc_msg, "Send ARC message", pybind11::arg("noc_id"), pybind11::arg("chip_id"),
           pybind11::arg("msg_code"), pybind11::arg("wait_for_done"), pybind11::arg("arg0"), pybind11::arg("arg1"),
           pybind11::arg("timeout"));
+    m.def("read_arc_telemetry_entry", &read_arc_telemetry_entry, "Read ARC telemetry entry", pybind11::arg("chip_id"),
+          pybind11::arg("telemetry_tag"));
 }

--- a/ttexalens/server/lib/inc/ttexalensserver/requests.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/requests.h
@@ -27,6 +27,7 @@ enum class request_type : uint8_t {
     get_device_arch,
     get_device_soc_description,
     arc_msg,
+    read_arc_telemetry_entry,
 
     // Device requests over jtag
     jtag_read32 = 50,
@@ -145,6 +146,11 @@ struct arc_msg_request : request {
     uint32_t arg0;
     uint32_t arg1;
     int timeout;
+} __attribute__((packed));
+
+struct read_arc_telemetry_entry_request : request {
+    uint8_t chip_id;
+    uint8_t telemetry_tag;
 } __attribute__((packed));
 
 struct jtag_read32_request : request {

--- a/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
@@ -57,9 +57,7 @@ class ttexalens_implementation {
                                                                        uint32_t arg0, uint32_t arg1, int timeout) {
         return {};
     }
-    virtual std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
-        return {};
-    }
+    virtual std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) { return {}; }
 
     virtual std::optional<int> jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) { return {}; }
     virtual std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,

--- a/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/ttexalens_implementation.h
@@ -57,6 +57,10 @@ class ttexalens_implementation {
                                                                        uint32_t arg0, uint32_t arg1, int timeout) {
         return {};
     }
+    virtual std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
+        return {};
+    }
+
     virtual std::optional<int> jtag_write32_axi(uint8_t chip_id, uint32_t address, uint32_t data) { return {}; }
     virtual std::optional<int> jtag_write32(uint8_t noc_id, uint8_t chip_id, uint8_t noc_x, uint8_t noc_y,
                                             uint64_t address, uint32_t data) {

--- a/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
@@ -37,6 +37,7 @@ class umd_implementation : public ttexalens_implementation {
                                                                        uint32_t msg_code, bool wait_for_done,
                                                                        uint32_t arg0, uint32_t arg1,
                                                                        int timeout) override;
+    virtual std::optional<uint32_t> read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) override;
 
    private:
     bool is_chip_mmio_capable(uint8_t chip_id);

--- a/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
+++ b/ttexalens/server/lib/inc/ttexalensserver/umd_implementation.h
@@ -44,6 +44,9 @@ class umd_implementation : public ttexalens_implementation {
 
     tt::umd::Cluster* cluster = nullptr;
     std::string cluster_descriptor_path;
+
+    std::unique_ptr<tt::umd::ArcTelemetryReader> cached_arc_telemetry_reader;
+    uint8_t cached_arc_telemetry_reader_chip_id = UINT8_MAX;
 };
 
 }  // namespace tt::exalens

--- a/ttexalens/server/lib/src/communication.cpp
+++ b/ttexalens/server/lib/src/communication.cpp
@@ -107,7 +107,9 @@ void tt::exalens::communication::request_loop() {
                     case tt::exalens::request_type::arc_msg:
                         invalid_message = message.size() != sizeof(arc_msg_request);
                         break;
-
+                    case tt::exalens::request_type::read_arc_telemetry_entry:
+                        invalid_message = message.size() != sizeof(read_arc_telemetry_entry_request);
+                        break;
                     case request_type::jtag_read32:
                         invalid_message = message.size() != sizeof(jtag_read32_request);
                         break;

--- a/ttexalens/server/lib/src/server.cpp
+++ b/ttexalens/server/lib/src/server.cpp
@@ -100,6 +100,11 @@ void tt::exalens::server::process(const tt::exalens::request& base_request) {
                                             request.arg0, request.arg1, request.timeout));
             break;
         }
+        case tt::exalens::request_type::read_arc_telemetry_entry: {
+            auto& request = static_cast<const tt::exalens::read_arc_telemetry_entry_request&>(base_request);
+            respond(implementation->read_arc_telemetry_entry(request.chip_id, request.telemetry_tag));
+            break;
+        }
 
         case tt::exalens::request_type::jtag_read32: {
             auto& request = static_cast<const tt::exalens::jtag_read32_request&>(base_request);

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -7,8 +7,8 @@
 #include <tuple>
 
 #include "ttexalensserver/read_tile.hpp"
-#include "umd/device/cluster.h"
 #include "umd/device/arc_telemetry_reader.h"
+#include "umd/device/cluster.h"
 
 namespace tt::exalens {
 
@@ -226,7 +226,8 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(u
 }
 
 std::optional<uint32_t> umd_implementation::read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
-    std::unique_ptr<tt::umd::ArcTelemetryReader> arc_telemetry_reader = tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
+    std::unique_ptr<tt::umd::ArcTelemetryReader> arc_telemetry_reader =
+        tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
     return arc_telemetry_reader->read_entry(telemetry_tag);
 }
 

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -228,7 +228,8 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(u
 std::optional<uint32_t> umd_implementation::read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
     // Speed optimization: cache ArcTelemetryReader to avoid creating it multiple times
     if (!cached_arc_telemetry_reader || cached_arc_telemetry_reader_chip_id != chip_id) {
-        cached_arc_telemetry_reader = std::make_unique<tt::umd::ArcTelemetryReader>(cluster->get_chip(chip_id));
+        cached_arc_telemetry_reader =
+            tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
         cached_arc_telemetry_reader_chip_id = chip_id;
     }
     return cached_arc_telemetry_reader->read_entry(telemetry_tag);

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -226,9 +226,12 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(u
 }
 
 std::optional<uint32_t> umd_implementation::read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
-    std::unique_ptr<tt::umd::ArcTelemetryReader> arc_telemetry_reader =
-        tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
-    return arc_telemetry_reader->read_entry(telemetry_tag);
+    // Speed optimization: cache ArcTelemetryReader to avoid creating it multiple times
+    if (!cached_arc_telemetry_reader || cached_arc_telemetry_reader_chip_id != chip_id) {
+        cached_arc_telemetry_reader = std::make_unique<tt::umd::ArcTelemetryReader>(cluster->get_chip(chip_id));
+        cached_arc_telemetry_reader_chip_id = chip_id;
+    }
+    return cached_arc_telemetry_reader->read_entry(telemetry_tag);
 }
 
 }  // namespace tt::exalens

--- a/ttexalens/server/lib/src/umd_implementation.cpp
+++ b/ttexalens/server/lib/src/umd_implementation.cpp
@@ -8,6 +8,7 @@
 
 #include "ttexalensserver/read_tile.hpp"
 #include "umd/device/cluster.h"
+#include "umd/device/arc_telemetry_reader.h"
 
 namespace tt::exalens {
 
@@ -222,6 +223,11 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(u
     uint32_t return_4 = 0;
     int return_code = cluster->arc_msg(chip_id, msg_code, wait_for_done, arg0, arg1, timeout, &return_3, &return_4);
     return std::make_tuple(return_code, return_3, return_4);
+}
+
+std::optional<uint32_t> umd_implementation::read_arc_telemetry_entry(uint8_t chip_id, uint8_t telemetry_tag) {
+    std::unique_ptr<tt::umd::ArcTelemetryReader> arc_telemetry_reader = tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
+    return arc_telemetry_reader->read_entry(telemetry_tag);
 }
 
 }  // namespace tt::exalens

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -276,7 +276,7 @@ class ttexalens_server_communication:
     def read_arc_telemetry_entry(self, device_id: int, telemetry_tag: int):
         self._socket.send(
             struct.pack(
-                "<BBI",
+                "<BBB",
                 ttexalens_server_request_type.read_arc_telemetry_entry.value,
                 device_id,
                 telemetry_tag,

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -419,6 +419,11 @@ class ttexalens_client(TTExaLensCommunicator):
         return self.parse_uint32_t(
             self._communication.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
         )
+    
+    def read_arc_telemetry_entry(self, device_id, telemetry_tag):
+        return self.parse_uint32_t(
+            self._communication.read_arc_telemetry_entry(device_id, telemetry_tag)
+        )
 
     def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         return self.parse_uint32_t(self._communication.jtag_read32(noc_id, chip_id, noc_x, noc_y, address))
@@ -540,6 +545,11 @@ class TTExaLensPybind(TTExaLensCommunicator):
     ):
         return self._check_result(
             ttexalens_pybind.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
+        )
+
+    def read_arc_telemetry_entry(self, device_id, telemetry_tag):
+        return self._check_result(
+            ttexalens_pybind.read_arc_telemetry_entry(device_id, telemetry_tag)
         )
 
 

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -30,6 +30,7 @@ class ttexalens_server_request_type(Enum):
     get_device_arch = 19
     get_device_soc_description = 20
     arc_msg = 21
+    read_arc_telemetry_entry = 22
 
     jtag_read32 = 50
     jtag_write32 = 51
@@ -268,6 +269,17 @@ class ttexalens_server_communication:
                 arg0,
                 arg1,
                 timeout,
+            )
+        )
+        return self._check(self._socket.recv())
+
+    def read_arc_telemetry_entry(self, device_id: int, telemetry_tag: int):
+        self._socket.send(
+            struct.pack(
+                "<BBI",
+                ttexalens_server_request_type.read_arc_telemetry_entry.value,
+                device_id,
+                telemetry_tag,
             )
         )
         return self._check(self._socket.recv())

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -419,11 +419,9 @@ class ttexalens_client(TTExaLensCommunicator):
         return self.parse_uint32_t(
             self._communication.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
         )
-    
+
     def read_arc_telemetry_entry(self, device_id, telemetry_tag):
-        return self.parse_uint32_t(
-            self._communication.read_arc_telemetry_entry(device_id, telemetry_tag)
-        )
+        return self.parse_uint32_t(self._communication.read_arc_telemetry_entry(device_id, telemetry_tag))
 
     def jtag_read32(self, noc_id: int, chip_id: int, noc_x: int, noc_y: int, address: int):
         return self.parse_uint32_t(self._communication.jtag_read32(noc_id, chip_id, noc_x, noc_y, address))
@@ -548,9 +546,7 @@ class TTExaLensPybind(TTExaLensCommunicator):
         )
 
     def read_arc_telemetry_entry(self, device_id, telemetry_tag):
-        return self._check_result(
-            ttexalens_pybind.read_arc_telemetry_entry(device_id, telemetry_tag)
-        )
+        return self._check_result(ttexalens_pybind.read_arc_telemetry_entry(device_id, telemetry_tag))
 
 
 def init_pybind(wanted_devices=None, init_jtag=False, initialize_with_noc1=False):

--- a/ttexalens/tt_exalens_ifc_base.py
+++ b/ttexalens/tt_exalens_ifc_base.py
@@ -96,5 +96,9 @@ class TTExaLensCommunicator(ABC):
     ) -> List[int]:
         pass
 
+    @abstractmethod
+    def read_arc_telemetry_entry(self, device_id: int, telemetry_tag: int) -> int:
+        pass
+
     def using_cache(self) -> bool:
         return False

--- a/ttexalens/tt_exalens_ifc_cache.py
+++ b/ttexalens/tt_exalens_ifc_cache.py
@@ -146,7 +146,7 @@ class TTExaLensCacheThrough(TTExaLensCache):
     @cache_decorator
     def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
         return self.communicator.arc_msg(device_id, msg_code, wait_for_done, arg0, arg1, timeout)
-    
+
     @cache_decorator
     def read_arc_telemetry_entry(self, device_id, telemetry_tag):
         return self.communicator.read_arc_telemetry_entry(device_id, telemetry_tag)

--- a/ttexalens/tt_exalens_ifc_cache.py
+++ b/ttexalens/tt_exalens_ifc_cache.py
@@ -146,6 +146,10 @@ class TTExaLensCacheThrough(TTExaLensCache):
     @cache_decorator
     def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
         return self.communicator.arc_msg(device_id, msg_code, wait_for_done, arg0, arg1, timeout)
+    
+    @cache_decorator
+    def read_arc_telemetry_entry(self, device_id, telemetry_tag):
+        return self.communicator.read_arc_telemetry_entry(device_id, telemetry_tag)
 
     def using_cache(self) -> bool:
         return True
@@ -275,6 +279,10 @@ class TTExaLensCacheReader(TTExaLensCache):
 
     @read_decorator
     def arc_msg(self, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int):
+        pass
+
+    @read_decorator
+    def read_arc_telemetry_entry(self, device_id, telemetry_tag):
         pass
 
     def using_cache(self) -> bool:

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -419,6 +419,7 @@ def arc_msg(
 
     return context.server_ifc.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
 
+
 def read_arc_telemetry_entry(device_id: int, telemetry_tag: int, context: Context = None) -> int:
     """Reads an ARC telemetry entry from the device.
 

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -419,6 +419,22 @@ def arc_msg(
 
     return context.server_ifc.arc_msg(noc_id, device_id, msg_code, wait_for_done, arg0, arg1, timeout)
 
+def read_arc_telemetry_entry(device_id: int, telemetry_tag: int, context: Context = None) -> int:
+    """Reads an ARC telemetry entry from the device.
+
+    Args:
+            device_id (int): ID number of device to read telemetry from.
+            telemetry_tag (int): Tag for telemetry entry to read.
+            context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentially initialized.
+
+    Returns:
+            int: Value of the telemetry entry.
+    """
+    context = check_context(context)
+    validate_device_id(device_id, context)
+
+    return context.server_ifc.read_arc_telemetry_entry(device_id, telemetry_tag)
+
 
 def read_tensix_register(
     core_loc: Union[str, OnChipCoordinate],


### PR DESCRIPTION
Closes #382 and #390. 

Binded read_entry from ArcTelemetryReader from UMD using pybind and included it in ttexalens library as read_arc_telemetry_entry.

Also added test that checks if read values (using read_arc_telemetry_entry) of vendor_id and ARC clock are as expected and also checks if heartbeat is increasing over time.

Added telemetry tag list as map in Device class. Now it is possible to reference tag by name (string) or ID (int).