### PR TITLE
Simplify type hints

### DIFF
--- a/docs/bin/doc_utils.py
+++ b/docs/bin/doc_utils.py
@@ -39,7 +39,7 @@ class ElementPPrinter:
     def print_code(self, code: str) -> str:
         return f"```\n{code}\n```\n"
 
-    def print_items(self, items: List[str]) -> str:
+    def print_items(self, items: list[str]) -> str:
         result = ""
         for item in items:
             result += f"- {item}\n"

--- a/docs/bin/doc_utils.py
+++ b/docs/bin/doc_utils.py
@@ -6,7 +6,6 @@ A module containing utility functions and classes for documentation generation.
 """
 
 from abc import abstractmethod
-from typing import List, Dict
 
 
 def INFO(text: str) -> None:
@@ -140,14 +139,14 @@ class SectionPPrinter:
         self.eprinter = element_printer
 
     @abstractmethod
-    def print_docs(self, docstring: Dict) -> str:
+    def print_docs(self, docstring: dict) -> str:
         """
         This abstract method should be implemented in the child class to print the documentation.
         All printing should be done through element_printer to guarantee consistent formatting.
         """
         pass
 
-    def print_usage(self, usage: Dict) -> str:
+    def print_usage(self, usage: dict) -> str:
         return self.eprinter.print_code(usage["code"])
 
     def print_description(self, description: dict) -> str:
@@ -167,7 +166,7 @@ class SectionPPrinter:
 
         return self.eprinter.print_items(argstrings)
 
-    def print_examples(self, examples: Dict) -> str:
+    def print_examples(self, examples: dict) -> str:
         result = ""
         for cmd in examples["commands"]:
             result += self.eprinter.print_text(cmd["text"])  # Command description

--- a/test/ttexalens/pybind/test_bindings.py
+++ b/test/ttexalens/pybind/test_bindings.py
@@ -6,8 +6,6 @@ import unittest
 import sys
 import os
 
-from typing import Union
-
 ttexalens_pybind_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../build/lib"))
 sys.path.append(ttexalens_pybind_path)
 
@@ -44,7 +42,7 @@ class TestBindings(unittest.TestCase):
         assert pb.pci_write32_raw(1, 1, data) == data, "Error: pci_write32_raw should return the data written."
         assert pb.pci_read32_raw(1, 1) == data, "Error: pci_read32_raw should return the data written."
 
-    def test_pci_read_write(self, data: Union[bytes, bytearray] = bytearray([1, 5, 3]), size=3):
+    def test_pci_read_write(self, data: bytes | bytearray = bytearray([1, 5, 3]), size=3):
         assert pb.pci_read(0, 3, 3, 3, 3, size) is None, "Error: pci_read should return None before writing."
         assert (
             pb.pci_write(0, 3, 3, 3, 3, data, 3) == size

--- a/test/ttexalens/server/test_server.py
+++ b/test/ttexalens/server/test_server.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import sys
-from typing import Any, Callable
 
 from ttexalens.tt_exalens_ifc import ttexalens_client, ttexalens_server_not_supported
 
@@ -10,7 +9,7 @@ server_port = 0
 server = None
 
 
-def check_not_implemented_response(server_command: Callable[[], Any]):
+def check_not_implemented_response(server_command: callable[[], any]):
     try:
         server_command()
         print("fail")

--- a/test/ttexalens/server/test_server.py
+++ b/test/ttexalens/server/test_server.py
@@ -4,12 +4,13 @@
 import sys
 
 from ttexalens.tt_exalens_ifc import ttexalens_client, ttexalens_server_not_supported
+from typing import Callable
 
 server_port = 0
 server = None
 
 
-def check_not_implemented_response(server_command: callable[[], any]):
+def check_not_implemented_response(server_command: Callable[[], any]):
     try:
         server_command()
         print("fail")

--- a/ttexalens/__init__.py
+++ b/ttexalens/__init__.py
@@ -20,7 +20,7 @@ class Verbosity(Enum):
     DEBUG = 5
 
     @staticmethod
-    def set(verbosity: Union[int , "Verbosity"]) -> None:
+    def set(verbosity: Union[int, "Verbosity"]) -> None:
         """Set the verbosity level of messages shown.
 
         Args:

--- a/ttexalens/__init__.py
+++ b/ttexalens/__init__.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
-from typing import Union
 
 __all__ = [
     "tt_exalens_init",
@@ -20,7 +19,7 @@ class Verbosity(Enum):
     DEBUG = 5
 
     @staticmethod
-    def set(verbosity: Union[int, "Verbosity"]) -> None:
+    def set(verbosity: int | "Verbosity") -> None:
         """Set the verbosity level of messages shown.
 
         Args:

--- a/ttexalens/__init__.py
+++ b/ttexalens/__init__.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
+from typing import Union
 
 __all__ = [
     "tt_exalens_init",
@@ -19,7 +20,7 @@ class Verbosity(Enum):
     DEBUG = 5
 
     @staticmethod
-    def set(verbosity: int | "Verbosity") -> None:
+    def set(verbosity: Union[int , "Verbosity"]) -> None:
         """Set the verbosity level of messages shown.
 
         Args:

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -58,7 +58,6 @@ except ModuleNotFoundError as e:
     exit(1)
 
 
-from typing import List
 from ttexalens import tt_exalens_init
 from ttexalens import tt_exalens_server
 from ttexalens import util as util
@@ -408,7 +407,7 @@ def main():
         util.WARN("Verbosity level must be an integer. Falling back to default value.")
     util.VERBOSE(f"Verbosity level: {Verbosity.get().name} ({Verbosity.get().value})")
 
-    wanted_devices: List[int] = None
+    wanted_devices: list[int] = None
     if args["--devices"]:
         wanted_devices = args["--devices"].split(",")
         wanted_devices = [int(d) for d in wanted_devices]

--- a/ttexalens/cli_commands/callstack.py
+++ b/ttexalens/cli_commands/callstack.py
@@ -29,7 +29,6 @@ command_metadata = {
 }
 
 import os
-from typing import List
 from ttexalens.uistate import UIState
 
 from ttexalens import command_parser

--- a/ttexalens/cli_commands/debug-bus.py
+++ b/ttexalens/cli_commands/debug-bus.py
@@ -31,7 +31,6 @@ command_metadata = {
 }
 
 import re
-from typing import List
 
 from ttexalens.uistate import UIState
 
@@ -80,7 +79,7 @@ def parse_command_arguments(args):
     if not (args.get("<signals>")):
         raise ValueError("Missing debug bus signal parameter")
 
-    result: List[str | DebugBusSignalDescription] = []
+    result: list[str | DebugBusSignalDescription] = []
 
     signals = parse_string(args.get("<signals>"))
 

--- a/ttexalens/cli_commands/device-summary.py
+++ b/ttexalens/cli_commands/device-summary.py
@@ -37,7 +37,6 @@ command_metadata = {
     "common_option_names": ["--device"],
 }
 
-from typing import List
 from docopt import docopt
 
 from ttexalens import command_parser, util as util
@@ -147,5 +146,5 @@ def run(cmd_text, context, ui_state=None):
             )
         )
 
-    navigation_suggestions: List[int] = []
+    navigation_suggestions: list[int] = []
     return navigation_suggestions

--- a/ttexalens/cli_commands/dump-config-reg.py
+++ b/ttexalens/cli_commands/dump-config-reg.py
@@ -43,7 +43,6 @@ from ttexalens.util import (
     CLR_END,
     dict_list_to_table,
 )
-from typing import List
 from tabulate import tabulate
 
 possible_registers = ["all", "alu", "pack", "unpack"]
@@ -57,7 +56,7 @@ def create_column_names(num_of_columns):
 
 
 # Converts list of configuration registers to table
-def config_regs_to_table(config_regs: List[dict], table_name: str, debug_tensix: TensixDebug, device: Device):
+def config_regs_to_table(config_regs: list[dict], table_name: str, debug_tensix: TensixDebug, device: Device):
     keys = list(config_regs[0].keys())
 
     if "blobs_y_start_lo" in keys and "blobs_y_start_hi" in keys:

--- a/ttexalens/cli_commands/dump-gpr.py
+++ b/ttexalens/cli_commands/dump-gpr.py
@@ -26,7 +26,6 @@ command_metadata = {
     "common_option_names": ["--device", "--loc", "--verbose", "--risc"],
 }
 
-from typing import Dict
 import tabulate
 
 from ttexalens.uistate import UIState
@@ -52,7 +51,7 @@ def get_register_data(device, context, loc, args):
     elf = ELF(context.server_ifc, {"elf": elf_file}) if elf_file else None
     pc_map = elf.names["elf"].file_line if elf else None
 
-    reg_value: Dict[int, Dict[int, int]] = {}
+    reg_value: dict[int, dict[int, int]] = {}
     noc_id = 0  # Always use noc 0
 
     halted_state = {}

--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -38,10 +38,10 @@ from docopt import docopt
 from ttexalens.uistate import UIState
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.debug_tensix import TensixDebug
-from typing import List, Union
+from typing import List
 
 
-def print_regfile(data: List[Union[int, float]]):
+def print_regfile(data: List[int | float]):
     for i in range(len(data)):
         print(data[i], end="\t")
         if i % 32 == 31:

--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -38,10 +38,9 @@ from docopt import docopt
 from ttexalens.uistate import UIState
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.debug_tensix import TensixDebug
-from typing import List
 
 
-def print_regfile(data: List[int | float]):
+def print_regfile(data: list[int | float]):
     for i in range(len(data)):
         print(data[i], end="\t")
         if i % 32 == 31:

--- a/ttexalens/cli_commands/interfaces.py
+++ b/ttexalens/cli_commands/interfaces.py
@@ -21,7 +21,6 @@ command_metadata = {
     "context": ["limited", "metal"],
 }
 
-from typing import Tuple
 from docopt import docopt
 from ttexalens.context import Context
 
@@ -79,7 +78,7 @@ def run(cmd_text, context: Context, ui_state=None):
     devices_list = list(context.devices.keys())
     for device_id in devices_list:
         if not context.devices[device_id]._has_jtag:
-            arc_location: Tuple[int, int] = context.devices[device_id]._block_locations["arc"][0].to("noc0")
+            arc_location: tuple[int, int] = context.devices[device_id]._block_locations["arc"][0].to("noc0")
             print(
                 f"NOC Device {device_id}: "
                 + str(

--- a/ttexalens/cli_commands/interfaces.py
+++ b/ttexalens/cli_commands/interfaces.py
@@ -21,7 +21,7 @@ command_metadata = {
     "context": ["limited", "metal"],
 }
 
-from typing import List, Tuple
+from typing import Tuple
 from docopt import docopt
 from ttexalens.context import Context
 
@@ -111,5 +111,5 @@ def run(cmd_text, context: Context, ui_state=None):
                 + str(decode_test_id(read_axi_size(context, device_id, efuse_jtag_axi, TEST_ID_SIZE)))
             )
 
-    navigation_suggestions: List[int] = []
+    navigation_suggestions: list[int] = []
     return navigation_suggestions

--- a/ttexalens/cli_commands/noc.py
+++ b/ttexalens/cli_commands/noc.py
@@ -32,9 +32,6 @@ Examples:
     noc register NIU_MST_RD_REQ_SENT,NIU_MST_RD_DATA_WORD_RECEIVED  # Prints multiple registers
 """
 
-# Standard imports first
-from typing import Dict, Optional
-
 # Third-party imports
 from docopt import docopt
 
@@ -85,7 +82,7 @@ def read_noc_register(loc: OnChipCoordinate, device, noc_id: int, reg_name: str)
 ###############################################################################
 # Register Definitions and Extraction
 ###############################################################################
-def get_noc_status_registers(loc: OnChipCoordinate, device, noc_id: int) -> Dict[str, Dict[str, int]]:
+def get_noc_status_registers(loc: OnChipCoordinate, device, noc_id: int) -> dict[str, dict[str, int]]:
     """
     Get all NOC status registers organized by groups.
 
@@ -120,14 +117,14 @@ def get_noc_status_registers(loc: OnChipCoordinate, device, noc_id: int) -> Dict
         },
     }
 
-    noc_registers: Dict[str, Dict[str, int]] = {group_name: {} for group_name in register_groups.keys()}
+    noc_registers: dict[str, dict[str, int]] = {group_name: {} for group_name in register_groups.keys()}
     for group_name, registers in register_groups.items():
         for register_desc, reg_name in registers.items():
             noc_registers[group_name][register_desc] = read_noc_register(loc, device, noc_id, reg_name)
     return noc_registers
 
 
-def get_all_noc_registers(loc: OnChipCoordinate, device) -> Dict[str, Dict[str, int]]:
+def get_all_noc_registers(loc: OnChipCoordinate, device) -> dict[str, dict[str, int]]:
     """
     Get all NOC registers for both NOC0 and NOC1.
 
@@ -138,7 +135,7 @@ def get_all_noc_registers(loc: OnChipCoordinate, device) -> Dict[str, Dict[str, 
     Returns:
         Dictionary of all register values for both NOCs
     """
-    noc_registers: Dict[str, Dict[str, int]] = {"Noc0 Registers": {}, "Noc1 Registers": {}}
+    noc_registers: dict[str, dict[str, int]] = {"Noc0 Registers": {}, "Noc1 Registers": {}}
     register_names = device.get_noc_register_names()
     for reg_name in register_names:
         noc_registers["Noc0 Registers"][reg_name] = read_noc_register(loc, device, 0, reg_name)
@@ -219,7 +216,7 @@ def display_specific_noc_registers(
     valid_register_names = device.get_noc_register_names()
 
     # Create a data structure to hold register values
-    register_data: Dict[str, Dict[str, int]] = {f"NOC{noc_id} Registers": {}}
+    register_data: dict[str, dict[str, int]] = {f"NOC{noc_id} Registers": {}}
 
     # Check if we have valid registers to display
     valid_registers_found = False

--- a/ttexalens/cli_commands/noc.py
+++ b/ttexalens/cli_commands/noc.py
@@ -33,7 +33,7 @@ Examples:
 """
 
 # Standard imports first
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 # Third-party imports
 from docopt import docopt
@@ -203,7 +203,7 @@ def display_all_noc_status_registers(loc: OnChipCoordinate, device, simple_print
 
 
 def display_specific_noc_registers(
-    loc: OnChipCoordinate, device, reg_names: List[str], noc_id: int, simple_print: bool = False
+    loc: OnChipCoordinate, device, reg_names: list[str], noc_id: int, simple_print: bool = False
 ) -> None:
     """
     Display one or more specific NOC registers by name.
@@ -255,7 +255,7 @@ def display_specific_noc_registers(
 ###############################################################################
 # Main Command Entry
 ###############################################################################
-def run(cmd_text: str, context: Context, ui_state: UIState) -> List:
+def run(cmd_text: str, context: Context, ui_state: UIState) -> list:
     """
     Main entry point for the NOC command.
 

--- a/ttexalens/cli_commands/tensix-reg.py
+++ b/ttexalens/cli_commands/tensix-reg.py
@@ -57,7 +57,6 @@ from ttexalens.device import (
 from ttexalens import command_parser
 from ttexalens.util import TTException, INFO, WARN, DATA_TYPE, convert_int_to_data_type, convert_data_type_to_int
 from ttexalens.unpack_regfile import TensixDataFormat
-from typing import List
 import re
 from fnmatch import fnmatch
 
@@ -77,7 +76,7 @@ def convert_str_to_int(param: str) -> int:
 
 
 # Convert register parameters to integers
-def convert_reg_params(reg_params: str) -> List[int]:
+def convert_reg_params(reg_params: str) -> list[int]:
     params = []
     for param in reg_params.split(","):
         params.append(convert_str_to_int(param))
@@ -86,7 +85,7 @@ def convert_reg_params(reg_params: str) -> List[int]:
 
 
 # Create register description object given parameters
-def create_register_description(reg_type: str, reg_params: List[int], data_type: str) -> TensixRegisterDescription:
+def create_register_description(reg_type: str, reg_params: list[int], data_type: str) -> TensixRegisterDescription:
     if reg_type == "cfg":
         if len(reg_params) != 3:
             raise TTException(
@@ -116,7 +115,7 @@ def parse_register_argument(register: str):
 
 
 # Print strings that match wildcard pattern. Maximum max_prints, negaitve values enable print all.
-def print_matches(pattern: str, strings: List[str], max_prints: int) -> None:
+def print_matches(pattern: str, strings: list[str], max_prints: int) -> None:
     pattern = pattern.lower()
     for s in strings:
         if max_prints == 0:

--- a/ttexalens/context.py
+++ b/ttexalens/context.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import abstractmethod
 from functools import cached_property
-from typing import Dict, Iterable, Optional, Set, Tuple
+from typing import Iterable
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens import util as util
 from ttexalens.firmware import ELF
@@ -30,7 +30,7 @@ class Context:
         from ttexalens import device
 
         device_ids = self.device_ids
-        devices: Dict[int, device.Device] = dict()
+        devices: dict[int, device.Device] = dict()
         for device_id in device_ids:
             device_desc_path = self.server_ifc.get_device_soc_description(device_id)
             util.DEBUG(f"Loading device {device_id} from {device_desc_path}")
@@ -69,16 +69,16 @@ class Context:
         raise util.TTException(f"We are running with limited functionality, elf files are not available.")
 
     @abstractmethod
-    def get_risc_elf_path(self, location: OnChipCoordinate, risc_id: int) -> Optional[str]:
+    def get_risc_elf_path(self, location: OnChipCoordinate, risc_id: int) -> str | None:
         pass
 
     def elf_loaded(self, location: OnChipCoordinate, risc_id: int, elf_path: str):
         pass
 
-    def convert_loc_to_jtag(self, location: OnChipCoordinate) -> Tuple[int, int]:
+    def convert_loc_to_jtag(self, location: OnChipCoordinate) -> tuple[int, int]:
         return location.to("noc0")
 
-    def convert_loc_to_umd(self, location: OnChipCoordinate) -> Tuple[int, int]:
+    def convert_loc_to_umd(self, location: OnChipCoordinate) -> tuple[int, int]:
         return location.to("noc0")
 
     def __repr__(self):
@@ -88,9 +88,9 @@ class Context:
 class LimitedContext(Context):
     def __init__(self, server_ifc: TTExaLensCommunicator, cluster_desc_yaml, use_noc1=False):
         super().__init__(server_ifc, cluster_desc_yaml, "limited", use_noc1)
-        self.loaded_elfs: Dict[Tuple[OnChipCoordinate, int], str] = {}  # (OnChipCoordinate, risc_id) => elf_path
+        self.loaded_elfs: dict[tuple[OnChipCoordinate, int], str] = {}  # (OnChipCoordinate, risc_id) => elf_path
 
-    def get_risc_elf_path(self, location: OnChipCoordinate, risc_id: int) -> Optional[str]:
+    def get_risc_elf_path(self, location: OnChipCoordinate, risc_id: int) -> str | None:
         return self.loaded_elfs.get((location, risc_id))
 
     def elf_loaded(self, location: OnChipCoordinate, risc_id: int, elf_path: str):

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -45,7 +45,6 @@ The following coordinate systems are available to represent a grid location on t
                     grid. It is used by the NOC hardware and it is programmable ahead of time. Notation: X-Y
 """
 
-from typing import Tuple
 from ttexalens.util import TTException
 
 VALID_COORDINATE_TYPES = [
@@ -81,7 +80,7 @@ class OnChipCoordinate:
     coordinate systems we use.
     """
 
-    _noc0_coord: Tuple[int, int] = (None, None)  # This uses noc0 coordinates: (X,Y)
+    _noc0_coord: tuple[int, int] = (None, None)  # This uses noc0 coordinates: (X,Y)
     _device = None  # Used for conversions
 
     def __init__(self, x: int, y: int, input_type: str, device, core_type="any"):

--- a/ttexalens/debug_bus_signal_store.py
+++ b/ttexalens/debug_bus_signal_store.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from functools import cached_property
-from typing import Dict, Iterable, TYPE_CHECKING
+from typing import Iterable, TYPE_CHECKING
 
 from ttexalens.tt_exalens_lib import read_word_from_device, write_words_to_device
 
@@ -23,7 +23,7 @@ class DebugBusSignalDescription:
 
 class DebugBusSignalStore:
     def __init__(
-        self, signals: Dict[str, DebugBusSignalDescription], location: OnChipCoordinate, neo_id: int | None = None
+        self, signals: dict[str, DebugBusSignalDescription], location: OnChipCoordinate, neo_id: int | None = None
     ):
         self.signals = signals
         self.location = location

--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -4,7 +4,7 @@
 from collections import namedtuple
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List, Union
+from typing import List
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.parse_elf import ParsedElfFile, ParsedElfFileWithOffset, read_elf
@@ -847,7 +847,7 @@ class RiscLoader:
             return address
         return address
 
-    def load_elf_sections(self, elf_path, loader_data: Union[str, int], loader_code: Union[str, int]):
+    def load_elf_sections(self, elf_path, loader_data: str | int, loader_code: str | int):
         """
         Given an ELF file, this function loads the sections specified in SECTIONS_TO_LOAD to the
         memory of the RISC-V core. It also loads (into location 0) the jump instruction to the

--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -4,7 +4,6 @@
 from collections import namedtuple
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.parse_elf import ParsedElfFile, ParsedElfFileWithOffset, read_elf
@@ -1024,8 +1023,8 @@ class RiscLoader:
 
     def get_callstack(
         self,
-        parsed_elfs: List[ParsedElfFile],
-        offsets: List[int | None] | None = None,
+        parsed_elfs: list[ParsedElfFile],
+        offsets: list[int | None] | None = None,
         limit: int = 100,
         stop_on_main: bool = True,
     ):

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union, List
+from typing import List
 from enum import Enum
 
 from ttexalens.coordinate import OnChipCoordinate
@@ -29,7 +29,7 @@ class REGFILE(Enum):
     DSTACC = 2
 
 
-def convert_regfile(regfile: Union[int, str, REGFILE]) -> REGFILE:
+def convert_regfile(regfile: int | str | REGFILE) -> REGFILE:
     if isinstance(regfile, REGFILE):
         return regfile
 
@@ -55,7 +55,7 @@ class TensixDebug:
 
     def __init__(
         self,
-        core_loc: Union[str, OnChipCoordinate],
+        core_loc: str | OnChipCoordinate,
         device_id: int,
         context: Context = None,
     ) -> None:
@@ -145,7 +145,7 @@ class TensixDebug:
         while (self.dbg_buff_status() & 0x10) == 0:
             pass
 
-    def read_tensix_register(self, register: Union[str, TensixRegisterDescription]) -> int:
+    def read_tensix_register(self, register: str | TensixRegisterDescription) -> int:
         """Reads the value of a configuration or debug register from the tensix core.
 
         Args:
@@ -204,7 +204,7 @@ class TensixDebug:
             )
             return (a & register.mask) >> register.shift
 
-    def write_tensix_register(self, register: Union[str, TensixRegisterDescription], value: int) -> None:
+    def write_tensix_register(self, register: str | TensixRegisterDescription, value: int) -> None:
         """Writes value to the configuration or debug register on the tensix core.
 
         Args:
@@ -263,14 +263,14 @@ class TensixDebug:
 
     def read_regfile_data(
         self,
-        regfile: Union[int, str, REGFILE],
+        regfile: int | str | REGFILE,
     ) -> list[int]:
         """Dumps SRCA/DSTACC register file from the specified core.
             Due to the architecture of SRCA, you can see only see last two faces written.
             SRCB is currently not supported.
 
         Args:
-                regfile (Union[int, str, REGFILE]): Register file to dump (0: SRCA, 1: SRCB, 2: DSTACC).
+                regfile (int | str | REGFILE): Register file to dump (0: SRCA, 1: SRCB, 2: DSTACC).
 
         Returns:
                 bytearray: 64x32 bytes of register file data (64 rows, 32 bytes per row).
@@ -354,14 +354,14 @@ class TensixDebug:
         )
         return data
 
-    def read_regfile(self, regfile: Union[int, str, REGFILE]) -> List[Union[float, int]]:
+    def read_regfile(self, regfile: int | str | REGFILE) -> List[float | int]:
         """Dumps SRCA/DSTACC register file from the specified core, and parses the data into a list of values.
 
         Args:
-                regfile (Union[int, str, REGFILE]): Register file to dump (0: SRCA, 1: SRCB, 2: DSTACC).
+                regfile (int | str | REGFILE): Register file to dump (0: SRCA, 1: SRCB, 2: DSTACC).
 
         Returns:
-                List[Union[float, int]]: 64x(8/16) values in register file (64 rows, 8 or 16 values per row, depending on the format of the data).
+                List[float | int]: 64x(8/16) values in register file (64 rows, 8 or 16 values per row, depending on the format of the data).
         """
         regfile = convert_regfile(regfile)
         data = self.read_regfile_data(regfile)

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from typing import List
 from enum import Enum
 
 from ttexalens.coordinate import OnChipCoordinate
@@ -354,14 +353,14 @@ class TensixDebug:
         )
         return data
 
-    def read_regfile(self, regfile: int | str | REGFILE) -> List[float | int]:
+    def read_regfile(self, regfile: int | str | REGFILE) -> list[float | int]:
         """Dumps SRCA/DSTACC register file from the specified core, and parses the data into a list of values.
 
         Args:
                 regfile (int | str | REGFILE): Register file to dump (0: SRCA, 1: SRCB, 2: DSTACC).
 
         Returns:
-                List[float | int]: 64x(8/16) values in register file (64 rows, 8 or 16 values per row, depending on the format of the data).
+                list[float | int]: 64x(8/16) values in register file (64 rows, 8 or 16 values per row, depending on the format of the data).
         """
         regfile = convert_regfile(regfile)
         data = self.read_regfile_data(regfile)

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from functools import cached_property
-from typing import Dict, Iterable, Iterator, List, Sequence, Tuple
+from typing import Dict, Iterable, Iterator, Sequence, Tuple
 
 from tabulate import tabulate
 from ttexalens.context import Context
@@ -105,10 +105,10 @@ class NocControlRegisterDescription(TensixRegisterDescription):
 #
 class Device(TTObject):
     instructions: TensixInstructions = None
-    DIE_X_TO_NOC_0_X: List[int] = []
-    DIE_Y_TO_NOC_0_Y: List[int] = []
-    NOC_0_X_TO_DIE_X: List[int] = []
-    NOC_0_Y_TO_DIE_Y: List[int] = []
+    DIE_X_TO_NOC_0_X: list[int] = []
+    DIE_Y_TO_NOC_0_Y: list[int] = []
+    NOC_0_X_TO_DIE_X: list[int] = []
+    NOC_0_Y_TO_DIE_Y: list[int] = []
     PCI_ARC_RESET_BASE_ADDR: int = None
     NOC_ARC_RESET_BASE_ADDR: int = None
     PCI_ARC_CSM_DATA_BASE_ADDR: int = None
@@ -126,7 +126,7 @@ class Device(TTObject):
     @cached_property
     def debuggable_cores(self):
         # Base implementation for wormhole and blackhole
-        cores: List[RiscDebug] = []
+        cores: list[RiscDebug] = []
         for coord in self.get_block_locations("functional_workers"):
             for risc_id in range(4):  # 4 because we have a hardware bug for debugging ncrisc
                 risc_location = RiscLoc(coord, 0, risc_id)
@@ -244,7 +244,7 @@ class Device(TTObject):
         # Base class doesn't know if it is translated coordinate, but specialized classes do
         return False
 
-    def get_block_locations(self, block_type="functional_workers") -> List[OnChipCoordinate]:
+    def get_block_locations(self, block_type="functional_workers") -> list[OnChipCoordinate]:
         """
         Returns locations of all blocks of a given type
         """
@@ -265,7 +265,7 @@ class Device(TTObject):
         """
         Returns locations of all blocks as dictionary of tuples (unchanged coordinates from YAML)
         """
-        result: Dict[str, List[OnChipCoordinate]] = {}
+        result: Dict[str, list[OnChipCoordinate]] = {}
         for block_type in self.block_types:
             locs = []
             dev = self.yaml_file.root
@@ -309,7 +309,7 @@ class Device(TTObject):
     # See coordinate.py for valid values of axis_coordinates
     def render(self, axis_coordinate="die", cell_renderer=None, legend=None):
         dev = self.yaml_file.root
-        rows: List[List[str]] = []
+        rows: list[list[str]] = []
 
         # Retrieve all block locations
         all_block_locs = dict()
@@ -413,36 +413,36 @@ class Device(TTObject):
                 util.ERROR(f"Expected to write {ALL_SOFT_RESET:x} to {loc.to_str()} but read {rst_reg:x}")
 
     # ALU GETTER
-    def get_alu_config(self) -> List[dict]:
+    def get_alu_config(self) -> list[dict]:
         return []
 
     # UNPACKER GETTERS
 
-    def get_unpack_tile_descriptor(self) -> List[dict]:
+    def get_unpack_tile_descriptor(self) -> list[dict]:
         return []
 
-    def get_unpack_config(self) -> List[dict]:
+    def get_unpack_config(self) -> list[dict]:
         return []
 
     # PACKER GETTERS
 
-    def get_pack_config(self) -> List[dict]:
+    def get_pack_config(self) -> list[dict]:
         return []
 
-    def get_relu_config(self) -> List[dict]:
+    def get_relu_config(self) -> list[dict]:
         return []
 
-    def get_pack_dest_rd_ctrl(self) -> List[dict]:
+    def get_pack_dest_rd_ctrl(self) -> list[dict]:
         return []
 
-    def get_pack_edge_offset(self) -> List[dict]:
+    def get_pack_edge_offset(self) -> list[dict]:
         return []
 
-    def get_pack_counters(self) -> List[dict]:
+    def get_pack_counters(self) -> list[dict]:
         return []
 
     @abstractmethod
-    def _get_tensix_register_map_keys(self) -> List[str]:
+    def _get_tensix_register_map_keys(self) -> list[str]:
         pass
 
     @abstractmethod
@@ -458,7 +458,7 @@ class Device(TTObject):
         pass
 
     @abstractmethod
-    def _get_arc_telemetry_tags_map_keys(self) -> List[str] | None:
+    def _get_arc_telemetry_tags_map_keys(self) -> list[str] | None:
         pass
 
     @abstractmethod
@@ -575,7 +575,7 @@ class Device(TTObject):
         base_addr = description.address
         return base_addr + (noc_id * self.NOC_REGISTER_OFFSET)
 
-    def get_noc_register_names(self) -> List[str]:
+    def get_noc_register_names(self) -> list[str]:
         """
         Get the list of NOC register names.
 

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -6,7 +6,7 @@ from abc import abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from functools import cached_property
-from typing import Dict, Iterable, Iterator, Sequence, Tuple
+from typing import Iterable, Sequence
 
 from tabulate import tabulate
 from ttexalens.context import Context
@@ -187,7 +187,7 @@ class Device(TTObject):
 
     def _init_coordinate_systems(self):
         # Fill in coordinates for each block type
-        self._noc0_to_block_type: Dict[Tuple[int, int], str] = {}
+        self._noc0_to_block_type: dict[tuple[int, int], str] = {}
         for block_type, locations in self._block_locations.items():
             for loc in locations:
                 self._noc0_to_block_type[loc._noc0_coord] = block_type
@@ -219,7 +219,7 @@ class Device(TTObject):
             self._to_noc0[(die_location, "die", core_type)] = noc0_location
             self._to_noc0[(die_location, "die", "any")] = noc0_location
 
-    def to_noc0(self, coord_tuple: Tuple[int, int], coord_system: str, core_type: str = "any") -> Tuple[int, int]:
+    def to_noc0(self, coord_tuple: tuple[int, int], coord_system: str, core_type: str = "any") -> tuple[int, int]:
         try:
             return self._to_noc0[(coord_tuple, coord_system, core_type)]
         except:
@@ -227,7 +227,7 @@ class Device(TTObject):
                 f"to_noc0(coord_tuple={coord_tuple}, coord_system={coord_system}, core_type={core_type})"
             )
 
-    def from_noc0(self, noc0_tuple: Tuple[int, int], coord_system: str) -> Tuple[Tuple[int, int], str]:
+    def from_noc0(self, noc0_tuple: tuple[int, int], coord_system: str) -> tuple[tuple[int, int], str]:
         try:
             return self._from_noc0[(noc0_tuple, coord_system)]
         except:
@@ -265,7 +265,7 @@ class Device(TTObject):
         """
         Returns locations of all blocks as dictionary of tuples (unchanged coordinates from YAML)
         """
-        result: Dict[str, list[OnChipCoordinate]] = {}
+        result: dict[str, list[OnChipCoordinate]] = {}
         for block_type in self.block_types:
             locs = []
             dev = self.yaml_file.root
@@ -506,7 +506,7 @@ class Device(TTObject):
             return "----"
         return bt
 
-    REGISTER_ADDRESSES: Dict[str, int] = {}
+    REGISTER_ADDRESSES: dict[str, int] = {}
 
     def get_arc_register_addr(self, name: str) -> int:
         try:

--- a/ttexalens/firmware.py
+++ b/ttexalens/firmware.py
@@ -6,7 +6,6 @@ This module is used to represent the firmware
 """
 
 import time
-from typing import Callable, Dict, Tuple
 from ttexalens import parse_elf
 from ttexalens import util as util
 import re
@@ -40,7 +39,7 @@ class ELF:
         self.names. For example, if filemap is { "brisc" : "./build/riscv-src/wormhole/sample.brisc.elf" },
         the parsed content of "./build/riscv-src/wormhole/sample.brisc.elf" will be stored in self.names["brisc"].
         """
-        self.names: Dict[str, parse_elf.ParsedElfFile] = dict()
+        self.names: dict[str, parse_elf.ParsedElfFile] = dict()
         self.filemap = filemap
         self._file_ifc = file_ifc
         self.name_word_pattern = re.compile(r"[_@.a-zA-Z]+")
@@ -70,7 +69,7 @@ class ELF:
             resolved_type = self.names[prefix].types[var["type"]].resolved_type
             self.names[prefix].variables[var_name] = FAKE_DIE(var_name, addr=addr, resolved_type=resolved_type)
 
-    def _get_prefix_and_suffix(self, path_str) -> Tuple[str, str]:
+    def _get_prefix_and_suffix(self, path_str) -> tuple[str, str]:
         dot_pos = path_str.find(".")
         if dot_pos == -1:
             return "", path_str  # just the suffix
@@ -210,7 +209,7 @@ class ELF:
         return data
 
     @staticmethod
-    def get_mem_reader(context, device_id, core_loc) -> Callable[[int, int, int], list[int]]:
+    def get_mem_reader(context, device_id, core_loc) -> callable[[int, int, int], list[int]]:
         """
         Returns a simple memory reader function that reads from a given device and a given core.
         """

--- a/ttexalens/firmware.py
+++ b/ttexalens/firmware.py
@@ -6,6 +6,7 @@ This module is used to represent the firmware
 """
 
 import time
+from typing import Callable
 from ttexalens import parse_elf
 from ttexalens import util as util
 import re
@@ -209,7 +210,7 @@ class ELF:
         return data
 
     @staticmethod
-    def get_mem_reader(context, device_id, core_loc) -> callable[[int, int, int], list[int]]:
+    def get_mem_reader(context, device_id, core_loc) -> Callable[[int, int, int], list[int]]:
         """
         Returns a simple memory reader function that reads from a given device and a given core.
         """

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 from io import StringIO
 import threading
-from typing import Dict, Set
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
 from ttexalens.gdb.gdb_communication import (
@@ -24,7 +23,7 @@ from ttexalens import util as util
 
 # Helper class returns currently debugging list of threads to gdb client in paged manner
 class GdbThreadListPaged:
-    def __init__(self, threads: Dict[int, GdbThreadId]):
+    def __init__(self, threads: dict[int, GdbThreadId]):
         self.threads = [thread for thread in threads.values() if isinstance(thread, GdbThreadId)]
         self.returned = 0
 
@@ -61,8 +60,8 @@ class GdbServer(threading.Thread):
         self.should_ack = True  # flag that indicates if we should send ack after each message
         self.stop_event = threading.Event()  # event that indicates that server should stop
 
-        self.prepared_responses_for_paging: Dict[str, str] = {}  # prepared responses for paged messages
-        self.client_features: Dict[
+        self.prepared_responses_for_paging: dict[str, str] = {}  # prepared responses for paged messages
+        self.client_features: dict[
             str, object
         ] = (
             {}
@@ -76,20 +75,20 @@ class GdbServer(threading.Thread):
         )  # List of status reports that should be returned to gdb client (it is stored in reversed order, so we can pop it from the end of the list)
 
         self.current_process: GdbProcess = None  # currently debugging process (core/thread - all in one)
-        self.debugging_threads: Dict[
+        self.debugging_threads: dict[
             int, GdbThreadId
         ] = {}  # Dictionary of threads that are currently being debugged (key: pid)
         self.next_pid = 1
-        self._last_available_processes: Dict[
+        self._last_available_processes: dict[
             RiscLoc, GdbProcess
         ] = {}  # Dictionary of last executed available processes that can be debugged (key: pid)
 
     @property
     def available_processes(self):
-        available_processes: Dict[
+        available_processes: dict[
             int, GdbProcess
         ] = {}  # Dictionary of available processes that can be debugged (key: pid)
-        last_available_processes: Dict[RiscLoc, GdbProcess] = {}
+        last_available_processes: dict[RiscLoc, GdbProcess] = {}
         for device in self.context.devices.values():
             for risc_debug in device.debuggable_cores:
                 if not risc_debug.is_in_reset():
@@ -618,7 +617,7 @@ class GdbServer(threading.Thread):
             # ‘vCont[;action[:thread-id]]…’
 
             # Create dictionary per thread that will contain actions that should be executed on that thread
-            thread_actions: Dict[int, str] = {}
+            thread_actions: dict[int, str] = {}
             for pid in self.debugging_threads.keys():
                 thread_actions[pid] = None
 

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -696,7 +696,7 @@ class GdbServer(threading.Thread):
                     return True
 
             # Apply actions
-            processes_to_watch: Set[GdbProcess] = set()
+            processes_to_watch: set[GdbProcess] = set()
             for pid in thread_actions.keys():
                 # NOTE: The server must ignore ‘c’, ‘C’, ‘s’, ‘S’, and ‘r’ actions for threads that are already running. Conversely, the server must ignore ‘t’ actions for threads that are already stopped.
                 process = available_processes.get(pid)

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from io import StringIO
 import threading
-from typing import Dict, List, Set
+from typing import Dict, Set
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
 from ttexalens.gdb.gdb_communication import (
@@ -69,7 +69,7 @@ class GdbServer(threading.Thread):
         )  # dictionary of supported gdb client features (key: feature, value: mostly True/False, but can be anything)
         self.paged_thread_list: GdbThreadListPaged = None  # helper class that returns list of threads in paged manner
         self.file_server: GdbFileServer = GdbFileServer(context)  # File server that serves gdb client file operations
-        self.vCont_pending_statuses: List[
+        self.vCont_pending_statuses: list[
             str
         ] = (
             []
@@ -1152,7 +1152,7 @@ class GdbServer(threading.Thread):
         return GdbServer.serialize_to_xml("osdata", "processes", processes)
 
     @staticmethod
-    def serialize_to_xml(name: str, type: str, data: List[Dict[str, str]]):
+    def serialize_to_xml(name: str, type: str, data: list[dict[str, str]]):
         sb = StringIO()
         sb.write(f'<{name} type="{xml_escape(type)}">')
         for item in data:

--- a/ttexalens/hw/arc/arc.py
+++ b/ttexalens/hw/arc/arc.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from typing import List
 from ttexalens.context import Context
 from ttexalens.util import TTException
 import re

--- a/ttexalens/hw/arc/arc.py
+++ b/ttexalens/hw/arc/arc.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from typing import Union, List
+from typing import List
 from ttexalens.context import Context
 from ttexalens.util import TTException
 import re

--- a/ttexalens/hw/arc/arc_dbg_fw.py
+++ b/ttexalens/hw/arc/arc_dbg_fw.py
@@ -4,7 +4,6 @@
 # This code is used to interact with the ARC debug firmware on the device.
 import os
 import time
-from typing import List
 from ttexalens.context import Context
 from ttexalens.util import TTException
 from ttexalens.tt_exalens_lib_utils import check_context, arc_read, arc_write

--- a/ttexalens/hw/arc/arc_dbg_fw.py
+++ b/ttexalens/hw/arc/arc_dbg_fw.py
@@ -4,7 +4,7 @@
 # This code is used to interact with the ARC debug firmware on the device.
 import os
 import time
-from typing import Union, List
+from typing import List
 from ttexalens.context import Context
 from ttexalens.util import TTException
 from ttexalens.tt_exalens_lib_utils import check_context, arc_read, arc_write

--- a/ttexalens/hw/tensix/blackhole/blackhole.py
+++ b/ttexalens/hw/tensix/blackhole/blackhole.py
@@ -5,7 +5,6 @@ from ttexalens.coordinate import OnChipCoordinate
 import ttexalens.util as util
 from ttexalens.debug_tensix import TensixDebug
 from ttexalens.util import DATA_TYPE
-from typing import List
 from ttexalens.device import (
     TensixInstructions,
     Device,
@@ -73,7 +72,7 @@ class BlackholeDevice(Device):
         )
         self.instructions = BlackholeInstructions()
 
-    def _get_tensix_register_map_keys(self) -> List[str]:
+    def _get_tensix_register_map_keys(self) -> list[str]:
         return list(BlackholeDevice.__register_map.keys())
 
     def _get_tensix_register_description(self, register_name: str) -> TensixRegisterDescription | None:
@@ -3928,7 +3927,7 @@ class BlackholeDevice(Device):
         ),
     }
 
-    def get_alu_config(self) -> List[dict]:
+    def get_alu_config(self) -> list[dict]:
         return [
             {
                 "Fpu_srnd_en": "ALU_ROUNDING_MODE_Fpu_srnd_en",
@@ -3950,7 +3949,7 @@ class BlackholeDevice(Device):
 
     # UNPACKER GETTERS
 
-    def get_unpack_tile_descriptor(self) -> List[dict]:
+    def get_unpack_tile_descriptor(self) -> list[dict]:
         struct_name = "UNPACK_TILE_DESCRIPTOR"
         fields = [
             "in_data_format",
@@ -3970,7 +3969,7 @@ class BlackholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_UNPACKERS)]
 
-    def get_unpack_config(self) -> List[dict]:
+    def get_unpack_config(self) -> list[dict]:
         struct_name = "UNPACK_CONFIG"
         fields = [
             "out_data_format",
@@ -3999,7 +3998,7 @@ class BlackholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_UNPACKERS)]
 
-    def get_pack_config(self) -> List[dict]:
+    def get_pack_config(self) -> list[dict]:
         struct_name = "PACK_CONFIG"
 
         fields = [
@@ -4026,7 +4025,7 @@ class BlackholeDevice(Device):
 
         return [{field: f"{struct_name}{i}{j}_{field}" for field in fields} for i in [0] for j in [1]]
 
-    def get_relu_config(self) -> List[dict]:
+    def get_relu_config(self) -> list[dict]:
 
         return [
             {
@@ -4043,7 +4042,7 @@ class BlackholeDevice(Device):
             }
         ]
 
-    def get_pack_dest_rd_ctrl(self) -> List[dict]:
+    def get_pack_dest_rd_ctrl(self) -> list[dict]:
         return [
             {
                 "read_32b_data": "PACK_DEST_RD_CTRL_Read_32b_data",
@@ -4054,7 +4053,7 @@ class BlackholeDevice(Device):
             }
         ]
 
-    def get_pack_edge_offset(self) -> List[dict]:
+    def get_pack_edge_offset(self) -> list[dict]:
         struct_name = "PACK_EDGE_OFFSET"
         fields = [
             "mask",
@@ -4070,7 +4069,7 @@ class BlackholeDevice(Device):
             for i in range(self.NUM_PACKERS)
         ]
 
-    def get_pack_counters(self) -> List[dict]:
+    def get_pack_counters(self) -> list[dict]:
         struct_name = "PACK_COUNTERS"
         fields = [
             "pack_per_xy_plane",
@@ -4082,7 +4081,7 @@ class BlackholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_PACKERS)]
 
-    def get_pack_strides(self) -> List[dict]:
+    def get_pack_strides(self) -> list[dict]:
         struct_name = "PACK_STRIDES"
         fields = ["x_stride", "y_stride", "z_stride", "w_stride"]
 

--- a/ttexalens/hw/tensix/wormhole/wormhole.py
+++ b/ttexalens/hw/tensix/wormhole/wormhole.py
@@ -5,7 +5,6 @@ from ttexalens.coordinate import OnChipCoordinate
 import ttexalens.util as util
 from ttexalens.debug_tensix import TensixDebug
 from ttexalens.util import DATA_TYPE
-from typing import List
 from ttexalens.device import (
     TensixInstructions,
     Device,
@@ -81,7 +80,7 @@ class WormholeDevice(Device):
     def is_translated_coordinate(self, x: int, y: int) -> bool:
         return x >= 16 and y >= 16
 
-    def _get_tensix_register_map_keys(self) -> List[str]:
+    def _get_tensix_register_map_keys(self) -> list[str]:
         return list(WormholeDevice.__register_map.keys())
 
     def _get_tensix_register_description(self, register_name: str) -> TensixRegisterDescription | None:
@@ -956,7 +955,7 @@ class WormholeDevice(Device):
         "ncrisc_pc": DebugBusSignalDescription(rd_sel=0, daisy_sel=7, sig_sel=2 * 12, mask=0x7FFFFFFF),
     }
 
-    def get_alu_config(self) -> List[dict]:
+    def get_alu_config(self) -> list[dict]:
         return [
             {
                 "Fpu_srnd_en": "ALU_ROUNDING_MODE_Fpu_srnd_en",
@@ -978,7 +977,7 @@ class WormholeDevice(Device):
 
     # UNPACKER GETTERS
 
-    def get_unpack_tile_descriptor(self) -> List[dict]:
+    def get_unpack_tile_descriptor(self) -> list[dict]:
         struct_name = "UNPACK_TILE_DESCRIPTOR"
         fields = [
             "in_data_format",
@@ -998,7 +997,7 @@ class WormholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_UNPACKERS)]
 
-    def get_unpack_config(self) -> List[dict]:
+    def get_unpack_config(self) -> list[dict]:
         struct_name = "UNPACK_CONFIG"
         fields = [
             "out_data_format",
@@ -1027,7 +1026,7 @@ class WormholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_UNPACKERS)]
 
-    def get_pack_config(self) -> List[dict]:
+    def get_pack_config(self) -> list[dict]:
         struct_name = "PACK_CONFIG"
 
         fields = [
@@ -1053,7 +1052,7 @@ class WormholeDevice(Device):
 
         return [{field: f"{struct_name}{i}{j}_{field}" for field in fields} for i in [0, 1] for j in [1, 8]]
 
-    def get_relu_config(self) -> List[dict]:
+    def get_relu_config(self) -> list[dict]:
 
         return [
             {
@@ -1070,7 +1069,7 @@ class WormholeDevice(Device):
             }
         ]
 
-    def get_pack_dest_rd_ctrl(self) -> List[dict]:
+    def get_pack_dest_rd_ctrl(self) -> list[dict]:
         return [
             {
                 "read_32b_data": "PACK_DEST_RD_CTRL_Read_32b_data",
@@ -1081,7 +1080,7 @@ class WormholeDevice(Device):
             }
         ]
 
-    def get_pack_edge_offset(self) -> List[dict]:
+    def get_pack_edge_offset(self) -> list[dict]:
         struct_name = "PACK_EDGE_OFFSET"
         fields = [
             "mask",
@@ -1097,7 +1096,7 @@ class WormholeDevice(Device):
             for i in range(self.NUM_PACKERS)
         ]
 
-    def get_pack_counters(self) -> List[dict]:
+    def get_pack_counters(self) -> list[dict]:
         struct_name = "PACK_COUNTERS"
         fields = [
             "pack_per_xy_plane",
@@ -1109,7 +1108,7 @@ class WormholeDevice(Device):
 
         return [{field: f"{struct_name}{i}_{field}" for field in fields} for i in range(self.NUM_PACKERS)]
 
-    def get_pack_strides(self) -> List[dict]:
+    def get_pack_strides(self) -> list[dict]:
         struct_name = "PACK_STRIDES"
         fields = ["x_stride", "y_stride", "z_stride", "w_stride"]
 

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 from functools import cached_property
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     from ttexalens.debug_risc import RiscDebug
@@ -1087,7 +1087,7 @@ def resolve_unnamed_union_member(type_die: ElfDie, member_name: str):
     return None
 
 
-def mem_access(elf: ParsedElfFile, access_path: str, mem_access_function: callable[[int, int, int], list[int]]):
+def mem_access(elf: ParsedElfFile, access_path: str, mem_access_function: Callable[[int, int, int], list[int]]):
     """
     Given an access path such as "s_ptr->an_int", "s_ptr->an_int[2]", or "s_ptr->an_int[2][3]",
     calls the mem_access_function to read the memory, and returns the value array.

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 from functools import cached_property
 import os
 import re
-from typing import Callable, Dict, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ttexalens.debug_risc import RiscDebug
@@ -91,7 +91,7 @@ def strip_DW_(s):
 class ElfDwarf:
     def __init__(self, dwarf: DWARFInfo):
         self.dwarf = dwarf
-        self._cus: Dict[int, ElfCompileUnit] = {}
+        self._cus: dict[int, ElfCompileUnit] = {}
 
     @cached_property
     def range_lists(self):
@@ -234,8 +234,8 @@ class ElfCompileUnit:
     def __init__(self, dwarf: ElfDwarf, dwarf_cu: DWARF_CU):
         self.dwarf = dwarf
         self.dwarf_cu = dwarf_cu
-        self.offsets: Dict[int, ElfDie] = {}
-        self._dies: Dict[int, ElfDie] = {}
+        self.offsets: dict[int, ElfDie] = {}
+        self._dies: dict[int, ElfDie] = {}
 
     def get_die(self, dwarf_die: DWARF_DIE):
         die = self._dies.get(id(dwarf_die))
@@ -796,7 +796,7 @@ class FrameDescription:
                 return self.risc_debug.read_memory(address)
         return self.risc_debug.read_gpr(register_index)
 
-    def read_previous_cfa(self, current_cfa: Optional[int] = None) -> int | None:
+    def read_previous_cfa(self, current_cfa: int | None = None) -> int | None:
         if self.current_fde_entry is not None and self.fde.cie is not None:
             cfa_location = self.current_fde_entry["cfa"]
             register_index = cfa_location.reg
@@ -1087,7 +1087,7 @@ def resolve_unnamed_union_member(type_die: ElfDie, member_name: str):
     return None
 
 
-def mem_access(elf: ParsedElfFile, access_path: str, mem_access_function: Callable[[int, int, int], list[int]]):
+def mem_access(elf: ParsedElfFile, access_path: str, mem_access_function: callable[[int, int, int], list[int]]):
     """
     Given an access path such as "s_ptr->an_int", "s_ptr->an_int[2]", or "s_ptr->an_int[2][3]",
     calls the mem_access_function to read the memory, and returns the value array.

--- a/ttexalens/rich_formatters.py
+++ b/ttexalens/rich_formatters.py
@@ -97,7 +97,7 @@ Examples:
     console.print("[bold red]Warning:[/bold red] Temperature exceeds threshold")
 """
 
-from typing import Dict, List, Any, Optional
+from typing import Dict, Any, Optional
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -196,7 +196,7 @@ class RichFormatter:
         else:
             return str(raw_value)
 
-    def flatten_grouping(self, grouping: List[List[str]]) -> List[List[str]]:
+    def flatten_grouping(self, grouping: list[list[str]]) -> list[list[str]]:
         """
         Flattens the grouping structure for simple print mode.
 
@@ -215,7 +215,7 @@ class RichFormatter:
     def display_grouped_data(
         self,
         data: Dict[str, Dict[str, Any]],
-        grouping: List[List[str]],
+        grouping: list[list[str]],
         simple_print: bool = False,
         empty_text: str = "<No data>",
     ) -> None:

--- a/ttexalens/rich_formatters.py
+++ b/ttexalens/rich_formatters.py
@@ -104,6 +104,8 @@ from rich.columns import Columns
 from rich import box
 from rich.rule import Rule
 
+from typing import Any
+
 # Shared console instance that commands can use
 console = Console()
 
@@ -120,7 +122,7 @@ class RichFormatter:
     def create_data_table(
         self,
         group_name: str,
-        data: dict[str, any],
+        data: dict[str, Any],
         simple_print: bool = False,
         title_style: str = "bold magenta",
         key_style: str = "cyan",
@@ -165,7 +167,7 @@ class RichFormatter:
             table.add_row(str(key), formatted_value)
         return table
 
-    def format_value(self, value_info: dict[str, any]) -> str:
+    def format_value(self, value_info: dict[str, Any]) -> str:
         """
         Format a value based on its format specification.
 
@@ -213,7 +215,7 @@ class RichFormatter:
 
     def display_grouped_data(
         self,
-        data: dict[str, dict[str, any]],
+        data: dict[str, dict[str, Any]],
         grouping: list[list[str]],
         simple_print: bool = False,
         empty_text: str = "<No data>",
@@ -244,7 +246,7 @@ class RichFormatter:
     def display_key_value_table(
         self,
         title: str,
-        key_values: dict[str, any],
+        key_values: dict[str, Any],
         simple_print: bool = False,
         key_col_name: str = "Parameter",
         value_col_name: str = "Value",

--- a/ttexalens/rich_formatters.py
+++ b/ttexalens/rich_formatters.py
@@ -97,7 +97,6 @@ Examples:
     console.print("[bold red]Warning:[/bold red] Temperature exceeds threshold")
 """
 
-from typing import Dict, Any, Optional
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
@@ -121,7 +120,7 @@ class RichFormatter:
     def create_data_table(
         self,
         group_name: str,
-        data: Dict[str, Any],
+        data: dict[str, any],
         simple_print: bool = False,
         title_style: str = "bold magenta",
         key_style: str = "cyan",
@@ -166,7 +165,7 @@ class RichFormatter:
             table.add_row(str(key), formatted_value)
         return table
 
-    def format_value(self, value_info: Dict[str, Any]) -> str:
+    def format_value(self, value_info: dict[str, any]) -> str:
         """
         Format a value based on its format specification.
 
@@ -214,7 +213,7 @@ class RichFormatter:
 
     def display_grouped_data(
         self,
-        data: Dict[str, Dict[str, Any]],
+        data: dict[str, dict[str, any]],
         grouping: list[list[str]],
         simple_print: bool = False,
         empty_text: str = "<No data>",
@@ -245,7 +244,7 @@ class RichFormatter:
     def display_key_value_table(
         self,
         title: str,
-        key_values: Dict[str, Any],
+        key_values: dict[str, any],
         simple_print: bool = False,
         key_col_name: str = "Parameter",
         value_col_name: str = "Value",

--- a/ttexalens/rich_formatters.py
+++ b/ttexalens/rich_formatters.py
@@ -97,7 +97,7 @@ Examples:
     console.print("[bold red]Warning:[/bold red] Temperature exceeds threshold")
 """
 
-from typing import Dict, List, Union, Any, Optional
+from typing import Dict, List, Any, Optional
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel

--- a/ttexalens/tt_exalens_ifc_base.py
+++ b/ttexalens/tt_exalens_ifc_base.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 import io
-from typing import Iterable, Tuple
+from typing import Iterable
 
 
 class TTExaLensCommunicator(ABC):
@@ -51,7 +51,7 @@ class TTExaLensCommunicator(ABC):
         pass
 
     @abstractmethod
-    def convert_from_noc0(self, chip_id, noc_x, noc_y, core_type, coord_system) -> Tuple[int, int]:
+    def convert_from_noc0(self, chip_id, noc_x, noc_y, core_type, coord_system) -> tuple[int, int]:
         pass
 
     @abstractmethod

--- a/ttexalens/tt_exalens_ifc_base.py
+++ b/ttexalens/tt_exalens_ifc_base.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from abc import ABC, abstractmethod
 import io
-from typing import Iterable, List, Tuple
+from typing import Iterable, Tuple
 
 
 class TTExaLensCommunicator(ABC):
@@ -93,7 +93,7 @@ class TTExaLensCommunicator(ABC):
     @abstractmethod
     def arc_msg(
         self, noc_id: int, device_id: int, msg_code: int, wait_for_done: bool, arg0: int, arg1: int, timeout: int
-    ) -> List[int]:
+    ) -> list[int]:
         pass
 
     @abstractmethod

--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import os
-from typing import Union
 
 from ttexalens import tt_exalens_ifc
 from ttexalens import tt_exalens_ifc_cache
@@ -123,7 +122,7 @@ def set_active_context(context: Context) -> None:
     GLOBAL_CONTEXT = context
 
 
-def locate_most_recent_build_output_dir() -> Union[str, None]:
+def locate_most_recent_build_output_dir() -> str | None:
     """Try to find a default output directory."""
     most_recent_modification_time = None
     try:

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -151,8 +151,7 @@ def read_from_device(
 
 
 def write_words_to_device(
-    core_loc: str,
-    OnChipCoordinate,
+    core_loc: str | OnChipCoordinate,
     addr: int,
     data: int | list[int],
     device_id: int = 0,

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -5,7 +5,7 @@ import os
 import re
 import struct
 
-from typing import Union, List
+from typing import List
 
 from ttexalens import tt_exalens_init
 
@@ -16,7 +16,7 @@ from ttexalens.util import TTException
 
 
 def convert_coordinate(
-    core_loc: Union[str, OnChipCoordinate], device_id: int = 0, context: Context = None
+    core_loc: str | OnChipCoordinate, device_id: int = 0, context: Context = None
 ) -> OnChipCoordinate:
     """Converts a string coordinate to an OnChipCoordinate object.
 
@@ -36,7 +36,7 @@ def convert_coordinate(
 
 
 def read_word_from_device(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
     device_id: int = 0,
     context: Context = None,
@@ -69,7 +69,7 @@ def read_word_from_device(
 
 
 def read_words_from_device(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
     device_id: int = 0,
     word_count: int = 1,
@@ -113,7 +113,7 @@ def read_words_from_device(
 
 
 def read_from_device(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
     device_id: int = 0,
     num_bytes: int = 4,
@@ -153,9 +153,10 @@ def read_from_device(
 
 
 def write_words_to_device(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str,
+    OnChipCoordinate,
     addr: int,
-    data: Union[int, List[int]],
+    data: int | List[int],
     device_id: int = 0,
     context: Context = None,
     noc_id: int | None = None,
@@ -198,9 +199,9 @@ def write_words_to_device(
 
 
 def write_to_device(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
-    data: "Union[List[int], bytes]",
+    data: "List[int] | bytes",
     device_id: int = 0,
     context: Context = None,
     noc_id: int | None = None,
@@ -247,7 +248,7 @@ def write_to_device(
 
 def load_elf(
     elf_file: str,
-    core_loc: Union[str, OnChipCoordinate, List[Union[str, OnChipCoordinate]]],
+    core_loc: str | OnChipCoordinate | List[str | OnChipCoordinate],
     risc_id: int = 0,
     device_id: int = 0,
     context: Context = None,
@@ -302,7 +303,7 @@ def load_elf(
 
 def run_elf(
     elf_file: str,
-    core_loc: Union[str, OnChipCoordinate, List[Union[str, OnChipCoordinate]]],
+    core_loc: str | OnChipCoordinate | List[str | OnChipCoordinate],
     risc_id: int = 0,
     device_id: int = 0,
     context: Context = None,
@@ -452,7 +453,7 @@ def read_arc_telemetry_entry(device_id: int, telemetry_tag: int | str, context: 
 
 
 def read_tensix_register(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     register,
     device_id: int = 0,
     context: Context = None,
@@ -486,7 +487,7 @@ def read_tensix_register(
 
 
 def write_tensix_register(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     register,
     value: int,
     device_id: int = 0,
@@ -531,7 +532,7 @@ def parse_elf(elf_path: str, context: Context | None = None) -> ParsedElfFile:
 
 def top_callstack(
     pc: int,
-    elfs: Union[List[str], str, List[ParsedElfFile], ParsedElfFile],
+    elfs: List[str] | str | List[ParsedElfFile] | ParsedElfFile,
     offsets: int | List[int | None] = None,
     context: Context = None,
 ) -> List:
@@ -574,8 +575,8 @@ def top_callstack(
 
 
 def callstack(
-    core_loc: Union[str, OnChipCoordinate],
-    elfs: Union[List[str], str, List[ParsedElfFile], ParsedElfFile],
+    core_loc: str | OnChipCoordinate,
+    elfs: List[str] | str | List[ParsedElfFile] | ParsedElfFile,
     offsets: int | List[int | None] = None,
     risc_id: int = 0,
     max_depth: int = 100,
@@ -637,7 +638,7 @@ def callstack(
 
 
 def read_riscv_memory(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
     noc_id: int = 0,
     risc_id: int = 0,
@@ -695,7 +696,7 @@ def read_riscv_memory(
 
 
 def write_riscv_memory(
-    core_loc: Union[str, OnChipCoordinate],
+    core_loc: str | OnChipCoordinate,
     addr: int,
     value: int,
     noc_id: int = 0,

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -5,8 +5,6 @@ import os
 import re
 import struct
 
-from typing import List
-
 from ttexalens import tt_exalens_init
 
 from ttexalens.coordinate import OnChipCoordinate
@@ -75,7 +73,7 @@ def read_words_from_device(
     word_count: int = 1,
     context: Context = None,
     noc_id: int | None = None,
-) -> "List[int]":
+) -> "list[int]":
     """Reads word_count four-byte words of data, starting from address 'addr' at core <x-y>.
 
     Args:
@@ -87,7 +85,7 @@ def read_words_from_device(
             noc_id (int, optional): NOC ID to use. If None, it will be set based on context initialization.
 
     Returns:
-            List[int]: Data read from the device.
+            list[int]: Data read from the device.
     """
     context = check_context(context)
 
@@ -156,7 +154,7 @@ def write_words_to_device(
     core_loc: str,
     OnChipCoordinate,
     addr: int,
-    data: int | List[int],
+    data: int | list[int],
     device_id: int = 0,
     context: Context = None,
     noc_id: int | None = None,
@@ -166,7 +164,7 @@ def write_words_to_device(
     Args:
             core_loc (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location of a core in string format, dram channel (e.g. ch3), or OnChipCoordinate object.
             addr (int): Memory address to write to. If multiple words are to be written, the address is the starting address.
-            data (int | List[int]): 4-byte integer word to be written, or a list of them.
+            data (int | list[int]): 4-byte integer word to be written, or a list of them.
             device_id (int, default 0): ID number of device to write to.
             context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentailly initialized.
             noc_id (int, optional): NOC ID to use. If None, it will be set based on context initialization.
@@ -201,7 +199,7 @@ def write_words_to_device(
 def write_to_device(
     core_loc: str | OnChipCoordinate,
     addr: int,
-    data: "List[int] | bytes",
+    data: "list[int] | bytes",
     device_id: int = 0,
     context: Context = None,
     noc_id: int | None = None,
@@ -211,7 +209,7 @@ def write_to_device(
     Args:
             core_loc (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location of a core in string format, dram channel (e.g. ch3), or OnChipCoordinate object.
             addr (int):	Memory address to write to.
-            data (List[int] | bytes): Data to be written. Lists are converted to bytes before writing, each element a byte. Elements must be between 0 and 255.
+            data (list[int] | bytes): Data to be written. Lists are converted to bytes before writing, each element a byte. Elements must be between 0 and 255.
             device_id (int, default 0):	ID number of device to write to.
             context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentailly initialized.
             noc_id (int, optional): NOC ID to use. If None, it will be set based on context initialization.
@@ -248,7 +246,7 @@ def write_to_device(
 
 def load_elf(
     elf_file: str,
-    core_loc: str | OnChipCoordinate | List[str | OnChipCoordinate],
+    core_loc: str | OnChipCoordinate | list[str | OnChipCoordinate],
     risc_id: int = 0,
     device_id: int = 0,
     context: Context = None,
@@ -257,7 +255,7 @@ def load_elf(
 
     Args:
             elf_file (str): Path to the ELF file to run.
-            core_loc (str | OnChipCoordinate | List[str | OnChipCoordinate]): One of the following:
+            core_loc (str | OnChipCoordinate | list[str | OnChipCoordinate]): One of the following:
                     1. "all" to run the ELF on all cores;
                     2. an X-Y (noc0/translated) or X,Y (logical) location of a core in string format;
                     3. a list of X-Y (noc0/translated), X,Y (logical) or OnChipCoordinate locations of cores, possibly mixed;
@@ -276,7 +274,7 @@ def load_elf(
 
     device = context.devices[device_id]
 
-    locs: List[OnChipCoordinate] = []
+    locs: list[OnChipCoordinate] = []
     if isinstance(core_loc, OnChipCoordinate):
         locs = [core_loc]
     elif isinstance(core_loc, list):
@@ -303,7 +301,7 @@ def load_elf(
 
 def run_elf(
     elf_file: str,
-    core_loc: str | OnChipCoordinate | List[str | OnChipCoordinate],
+    core_loc: str | OnChipCoordinate | list[str | OnChipCoordinate],
     risc_id: int = 0,
     device_id: int = 0,
     context: Context = None,
@@ -312,7 +310,7 @@ def run_elf(
 
     Args:
             elf_file (str): Path to the ELF file to run.
-            core_loc (str | OnChipCoordinate | List[str | OnChipCoordinate]): One of the following:
+            core_loc (str | OnChipCoordinate | list[str | OnChipCoordinate]): One of the following:
                     1. "all" to run the ELF on all cores;
                     2. an X-Y (noc0/translated) or X,Y (logical) location of a core in string format;
                     3. a list of X-Y (noc0/translated), X,Y (logical) or OnChipCoordinate locations of cores, possibly mixed;
@@ -395,7 +393,7 @@ def arc_msg(
     timeout: int,
     context: Context = None,
     noc_id: int | None = None,
-) -> "List[int]":
+) -> "list[int]":
     """Sends an ARC message to the device.
 
     Args:
@@ -409,7 +407,7 @@ def arc_msg(
             noc_id (int, optional): NOC ID to use. If None, it will be set based on context initialization.
 
     Returns:
-            List[int]: return code, reply0, reply1.
+            list[int]: return code, reply0, reply1.
     """
     context = check_context(context)
     noc_id = check_noc_id(noc_id, context)
@@ -532,17 +530,17 @@ def parse_elf(elf_path: str, context: Context | None = None) -> ParsedElfFile:
 
 def top_callstack(
     pc: int,
-    elfs: List[str] | str | List[ParsedElfFile] | ParsedElfFile,
-    offsets: int | List[int | None] = None,
+    elfs: list[str] | str | list[ParsedElfFile] | ParsedElfFile,
+    offsets: int | list[int | None] = None,
     context: Context = None,
-) -> List:
+) -> list:
 
     """Retrieves the top frame of the callstack for the specified PC on the given ELF.
     There is no stack walking, so the function will return the function at the given PC and all inlined functions on the top frame (if there are any).
     Args:
             pc (int): Program counter to be used for the callstack.
-            elfs (List[str] | str | List[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
-            offsets (List[int], int, optional): List of offsets for each ELF file. Default: None.
+            elfs (list[str] | str | list[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
+            offsets (list[int], int, optional): List of offsets for each ELF file. Default: None.
             context (Context): TTExaLens context object used for interaction with the device. If None, the global context is used and potentially initialized. Default: None
     Returns:
             List: Callstack (list of functions and information about them) of the specified RISC core for the given ELF.
@@ -576,21 +574,21 @@ def top_callstack(
 
 def callstack(
     core_loc: str | OnChipCoordinate,
-    elfs: List[str] | str | List[ParsedElfFile] | ParsedElfFile,
-    offsets: int | List[int | None] = None,
+    elfs: list[str] | str | list[ParsedElfFile] | ParsedElfFile,
+    offsets: int | list[int | None] = None,
     risc_id: int = 0,
     max_depth: int = 100,
     stop_on_main: bool = True,
     verbose: bool = False,
     device_id: int = 0,
     context: Context = None,
-) -> List:
+) -> list:
 
     """Retrieves the callstack of the specified RISC core for a given ELF.
     Args:
             core_loc (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location of a core in string format, DRAM channel (e.g., ch3), or OnChipCoordinate object.
-            elfs (List[str] | str | List[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
-            offsets (List[int], int, optional): List of offsets for each ELF file. Default: None.
+            elfs (list[str] | str | list[ParsedElfFile] | ParsedElfFile): ELF files to be used for the callstack.
+            offsets (list[int], int, optional): List of offsets for each ELF file. Default: None.
             risc_id (int): RISC-V ID (0: brisc, 1-3 triscs). Default: 0.
             max_depth (int): Maximum depth of the callstack. Default: 100.
             stop_on_main (bool): If True, stops at the main function. Default: True.

--- a/ttexalens/tt_exalens_server.py
+++ b/ttexalens/tt_exalens_server.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from typing import List
 from ttexalens import util as util
 
 import os
@@ -12,7 +11,7 @@ import time
 
 def start_server(
     port: int,
-    wanted_devices: "List[int]" = None,
+    wanted_devices: "list[int]" = None,
     init_jtag=False,
     initialize_with_noc1=False,
     simulation_directory: str = None,
@@ -31,7 +30,7 @@ def start_server(
 
 def spawn_standalone_ttexalens_stub(
     port: int,
-    wanted_devices: "List[int]" = None,
+    wanted_devices: "list[int]" = None,
     init_jtag=False,
     initialize_with_noc1=False,
     simulation_directory: str = None,

--- a/ttexalens/unpack_regfile.py
+++ b/ttexalens/unpack_regfile.py
@@ -4,7 +4,6 @@
 
 import struct
 from enum import Enum
-from typing import Union
 
 
 class TensixDataFormat(Enum):
@@ -111,7 +110,7 @@ def unpack_bfp8_b(data):
     return bfloat16_values
 
 
-def unpack_data(data, df: Union[int, TensixDataFormat]):
+def unpack_data(data, df: int | TensixDataFormat):
     if isinstance(df, int):
         df = TensixDataFormat(df)
 

--- a/ttexalens/util.py
+++ b/ttexalens/util.py
@@ -7,7 +7,7 @@ from tabulate import tabulate
 from sortedcontainers import SortedSet
 import traceback, socket
 import ryml, yaml
-from typing import Dict, List
+from typing import Dict
 from ttexalens import Verbosity
 import re
 
@@ -175,7 +175,7 @@ def dict_to_table(dct):
 
 
 # Converts list of dictionaries with same keys to a table where every column is one dictionary.
-def dict_list_to_table(dicts: List[dict], table_name: str, column_names: List[str]) -> str:
+def dict_list_to_table(dicts: list[dict], table_name: str, column_names: list[str]) -> str:
     keys = dicts[0].keys()
     data = []
     for key in keys:
@@ -198,7 +198,7 @@ def merge_tables_side_by_side(a, b):
     width_b = len(b[0])
     t = []
     for i in range(max(len(a), len(b))):
-        row: List[str | None] = [None] * (width_a + width_b)
+        row: list[str | None] = [None] * (width_a + width_b)
 
         for j in range(width_a):
             row[j] = "" if i >= len(a) else a[i][j]
@@ -211,7 +211,7 @@ def merge_tables_side_by_side(a, b):
 
 
 # Puts tables from the list side by side.
-def put_table_list_side_by_side(tables: List[str]) -> str:
+def put_table_list_side_by_side(tables: list[str]) -> str:
     # Split each table into rows by lines
     split_tables = [table.split("\n") for table in tables]
 

--- a/ttexalens/util.py
+++ b/ttexalens/util.py
@@ -7,7 +7,6 @@ from tabulate import tabulate
 from sortedcontainers import SortedSet
 import traceback, socket
 import ryml, yaml
-from typing import Dict
 from ttexalens import Verbosity
 import re
 
@@ -440,7 +439,7 @@ def ryml_load_all(yaml_string):
 # Container for YAML
 class YamlContainer:
     def __init__(self, yaml_string, source="N/A"):
-        self.root: Dict = dict()
+        self.root: dict = dict()
         parsed_documents = ryml_load_all(yaml_string)
         for d in parsed_documents:
             # Merge the documents
@@ -458,7 +457,7 @@ class YamlContainer:
 # Includes a cache in case a file is loaded multiple times
 class YamlFile:
     # Cache
-    file_cache: Dict = {}
+    file_cache: dict = {}
 
     def __init__(self, file_ifc, filepath, post_process_yaml=None, content=None):
         self.filepath = filepath


### PR DESCRIPTION
Closes #361 

Since we stopped supporting python3.8 we can utilize new features for type hints such as list, dict, set.. instead of equivalents from typing module. Also we can use | instead of Union and | None instead of Optional. This PR deals with this.

*Note* In ttexalens/__init__.py switching from Union to | creates an error so this is the only place where Union is left.

Some things (such as Callable, Iterable, TYPE_CHECKING...) does not have identical alternatives so they are not changed.

 