### PR TITLE
Workflow permissions fix

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  packages: write
+
 jobs:
   pre-commit:
     uses: ./.github/workflows/pre-commit.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  packages: write
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/build-and-test.yml


### PR DESCRIPTION
### Problem
The organization's switch to GitHub Enterprise has caused our CI workflow permissions to be evaluated differently.

### Solution
Explicitly allow `on-pr` and `on-push` workflows to write to the image registry.