### PR TITLE
Start using RegisterStore in DebugBusSignalStore

### DIFF
--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -45,7 +45,12 @@ The following coordinate systems are available to represent a grid location on t
                     grid. It is used by the NOC hardware and it is programmable ahead of time. Notation: X-Y
 """
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
 from ttexalens.util import TTException
+
+if TYPE_CHECKING:
+    from ttexalens.device import Device
 
 VALID_COORDINATE_TYPES = [
     "die",
@@ -80,10 +85,10 @@ class OnChipCoordinate:
     coordinate systems we use.
     """
 
-    _noc0_coord: tuple[int, int] = (None, None)  # This uses noc0 coordinates: (X,Y)
-    _device = None  # Used for conversions
+    _noc0_coord: tuple[int, int]  # This uses noc0 coordinates: (X,Y)
+    _device: Device  # Used for conversions
 
-    def __init__(self, x: int, y: int, input_type: str, device, core_type="any"):
+    def __init__(self, x: int, y: int, input_type: str, device: Device, core_type: str = "any"):
         """
         Constructor for the Coordinate class.
 

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -10,7 +10,6 @@ from typing import Iterable, Sequence
 
 from tabulate import tabulate
 from ttexalens.context import Context
-from ttexalens.debug_bus_signal_store import DebugBusSignalStore
 from ttexalens.hardware.noc_block import NocBlock
 from ttexalens.object import TTObject
 from ttexalens import util as util

--- a/ttexalens/hardware/blackhole/eth_block.py
+++ b/ttexalens/hardware/blackhole/eth_block.py
@@ -86,7 +86,7 @@ register_store_noc1_initialization = RegisterStore.create_initialization(
 
 class BlackholeEthBlock(BlackholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
-        super().__init__(location, block_type="eth", debug_bus=DebugBusSignalStore(debug_bus_signal_map, location))
+        super().__init__(location, block_type="eth", debug_bus=DebugBusSignalStore(debug_bus_signal_map, self))
 
         self.l1 = MemoryBlock(
             # TODO: Check if this size is correct

--- a/ttexalens/hardware/blackhole/functional_worker_block.py
+++ b/ttexalens/hardware/blackhole/functional_worker_block.py
@@ -3524,7 +3524,7 @@ register_store_noc1_initialization = RegisterStore.create_initialization(
 class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(
-            location, block_type="functional_workers", debug_bus=DebugBusSignalStore(debug_bus_signal_map, location)
+            location, block_type="functional_workers", debug_bus=DebugBusSignalStore(debug_bus_signal_map, self)
         )
 
         self.l1 = MemoryBlock(

--- a/ttexalens/hardware/wormhole/eth_block.py
+++ b/ttexalens/hardware/wormhole/eth_block.py
@@ -76,7 +76,7 @@ register_store_noc1_initialization = RegisterStore.create_initialization(
 
 class WormholeEthBlock(WormholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
-        super().__init__(location, block_type="eth", debug_bus=DebugBusSignalStore(debug_bus_signal_map, location))
+        super().__init__(location, block_type="eth", debug_bus=DebugBusSignalStore(debug_bus_signal_map, self))
 
         self.l1 = MemoryBlock(
             size=256 * 1024, address=DeviceAddress(private_address=0x00000000, noc_address=0x00000000)

--- a/ttexalens/hardware/wormhole/functional_worker_block.py
+++ b/ttexalens/hardware/wormhole/functional_worker_block.py
@@ -745,7 +745,7 @@ register_store_noc1_initialization = RegisterStore.create_initialization(
 class WormholeFunctionalWorkerBlock(WormholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(
-            location, block_type="functional_workers", debug_bus=DebugBusSignalStore(debug_bus_signal_map, location)
+            location, block_type="functional_workers", debug_bus=DebugBusSignalStore(debug_bus_signal_map, self)
         )
 
         self.l1 = MemoryBlock(

--- a/ttexalens/register_store.py
+++ b/ttexalens/register_store.py
@@ -171,11 +171,15 @@ class RegisterStore:
 
     @cached_property
     def _control_register_address(self) -> int:
-        return self.get_register_noc_address("RISCV_DEBUG_REG_CFGREG_RD_CNTL")
+        address = self.get_register_noc_address("RISCV_DEBUG_REG_CFGREG_RD_CNTL")
+        assert address is not None, "Control register address must be defined."
+        return address
 
     @cached_property
     def _data_register_address(self) -> int:
-        return self.get_register_noc_address("RISCV_DEBUG_REG_CFGREG_RDDATA")
+        address = self.get_register_noc_address("RISCV_DEBUG_REG_CFGREG_RDDATA")
+        assert address is not None, "Data register address must be defined."
+        return address
 
     def get_register_names(self) -> list[str]:
         return list(self.registers.keys())


### PR DESCRIPTION
We can now start using `RegisterStore` in `DebugBusSignalStore` to get debug registers for reading debug bus signals.