### PR TITLE
Fix PC read on Blackhole

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -992,28 +992,11 @@ class TestCallStack(unittest.TestCase):
         self.loader.run_elf(elf_path)
         callstack = lib.callstack(self.core_loc, elf_path, None, self.risc_id, 100, True, False, 0, self.context)
 
-        # Optimized version for non-blackhole doesn't have halt on callstack
-        if self.is_blackhole():
-            if recursion_count == 1:
-                self.assertEqual(len(callstack), expected_f1_on_callstack_count + 3)
-                self.assertEqual(callstack[0].function_name, "halt")
-                for i in range(1, expected_f1_on_callstack_count + 1):
-                    self.assertEqual(callstack[i].function_name, "f1")
-                self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "recurse")
-                self.assertEqual(callstack[expected_f1_on_callstack_count + 2].function_name, "main")
-            else:
-                self.assertEqual(len(callstack), expected_f1_on_callstack_count + 4)
-                self.assertEqual(callstack[0].function_name, "halt")
-                for i in range(1, expected_f1_on_callstack_count + 2):
-                    self.assertEqual(callstack[i].function_name, "f1")
-                self.assertEqual(callstack[expected_f1_on_callstack_count + 2].function_name, "recurse")
-                self.assertEqual(callstack[expected_f1_on_callstack_count + 3].function_name, "main")
-        else:
-            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
-            for i in range(0, expected_f1_on_callstack_count):
-                self.assertEqual(callstack[i].function_name, "f1")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
+        self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
+        for i in range(0, expected_f1_on_callstack_count):
+            self.assertEqual(callstack[i].function_name, "f1")
+        self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
+        self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
 
     @parameterized.expand([(1, 1)])
     def test_top_callstack_optimized(self, recursion_count, expected_f1_on_callstack_count):
@@ -1024,20 +1007,11 @@ class TestCallStack(unittest.TestCase):
             pc = self.rdbg.read_gpr(32)
         callstack = lib.top_callstack(pc, elf_path, None, self.context)
 
-        # Optimized version for non-blackhole doesn't have halt on callstack
-        if self.is_blackhole():
-            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 3)
-            self.assertEqual(callstack[0].function_name, "halt")
-            for i in range(1, expected_f1_on_callstack_count + 1):
-                self.assertEqual(callstack[i].function_name, "f1")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "recurse")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 2].function_name, "main")
-        else:
-            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
-            for i in range(0, expected_f1_on_callstack_count):
-                self.assertEqual(callstack[i].function_name, "f1")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
-            self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
+        self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
+        for i in range(0, expected_f1_on_callstack_count):
+            self.assertEqual(callstack[i].function_name, "f1")
+        self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
+        self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
 
     @parameterized.expand(
         [

--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -577,6 +577,8 @@ def blackhole_read_pc(location: RiscLoc) -> int:
         value = debug_bus_signal_store.read_signal("trisc1_pc")
     elif location.risc_id == 3:
         value = debug_bus_signal_store.read_signal("trisc2_pc")
+    elif location.risc_id == 4:
+        value = debug_bus_signal_store.read_signal("ncrisc_pc")
     else:
         util.ERROR(f"Could not read PC for RISC ID {location.risc_id}")
     return value


### PR DESCRIPTION
#287
Added a check in `debug_risc.py:read_gpr` for `reg == 32` and `arch == Blackhole` which calls `blackhole_read_pc`. Instead of directly reading the register, debug signals are read.