### PR TITLE
Moving GDB to new RiscDebug API

### DIFF
--- a/ttexalens/debug_risc.py
+++ b/ttexalens/debug_risc.py
@@ -945,7 +945,8 @@ class RiscLoader:
             util.ERROR(e)
             raise util.TTException(f"Error loading elf file {elf_path}")
 
-        self.context.elf_loaded(self.risc_debug.location.loc, self.risc_debug.location.risc_id, elf_path)
+        # TODO: This will be removed with PR that moves RiscLoader to new API
+        # self.context.elf_loaded(self.risc_debug.location.loc, self.risc_debug.location.risc_id, elf_path)
         return init_section_address
 
     def load_elf(self, elf_path: str):

--- a/ttexalens/gdb/gdb_data.py
+++ b/ttexalens/gdb/gdb_data.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from dataclasses import dataclass
 from functools import cached_property
-from ttexalens.debug_risc import RiscDebug
+from ttexalens.hardware.risc_debug import RiscDebug
 
 
 @dataclass
@@ -18,7 +18,7 @@ class GdbThreadId:
 @dataclass
 class GdbProcess:
     process_id: int
-    elf_path: str
+    elf_path: str | None
     risc_debug: RiscDebug
     virtual_core_id: int
     core_type: str

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -9,7 +9,7 @@ from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.device import Device
 from ttexalens.hardware.baby_risc_info import BabyRiscInfo
-from ttexalens.hardware.risc_debug import RiscDebug
+from ttexalens.hardware.risc_debug import RiscDebug, RiscLocation
 from ttexalens.register_store import RegisterDescription, RegisterStore
 from ttexalens.tt_exalens_lib import read_word_from_device, write_words_to_device
 
@@ -492,6 +492,7 @@ class BabyRiscDebugHardware:
 
 class BabyRiscDebug(RiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, verbose: bool = False, enable_asserts: bool = True):
+        super().__init__(RiscLocation(risc_info.noc_block.location, risc_info.neo_id, risc_info.risc_name))
         register_store = risc_info.noc_block.get_register_store(neo_id=risc_info.neo_id)
         self.risc_info = risc_info
         self.register_store = register_store
@@ -697,3 +698,6 @@ class BabyRiscDebug(RiscDebug):
         self.assert_debug_hardware()
         assert self.debug_hardware is not None, "Debug hardware is not initialized"
         self.debug_hardware.write_memory(address, value)
+
+    def can_debug(self) -> bool:
+        return self.risc_info.debug_hardware_present

--- a/ttexalens/hardware/noc_block.py
+++ b/ttexalens/hardware/noc_block.py
@@ -37,6 +37,15 @@ class NocBlock:
         except NotImplementedError:
             return False
 
+    @cached_property
+    def debuggable_riscs(self) -> list[RiscDebug]:
+        return [risc_debug for risc_debug in self.all_riscs if risc_debug.can_debug]
+
+    @cached_property
+    @abstractmethod
+    def all_riscs(self) -> list[RiscDebug]:
+        pass
+
     @cache
     def get_default_risc_debug(self) -> RiscDebug:
         """


### PR DESCRIPTION
Introducing `RiscLocation` and ability to get `RiscDebug` using it.
Replacing `RiscDebug` implementation in GDB classes.
Exposing needed API in new `RiscDebug` that is needed for GDB.
When we add support for Rocket cores, we need to revisit this...

Note: ...currently it is missing support for watchpoints...
