### PR TITLE
Fixing simulator initialization

### DIFF
--- a/ttexalens/server/lib/src/open_implementation.cpp
+++ b/ttexalens/server/lib/src/open_implementation.cpp
@@ -451,7 +451,8 @@ std::unique_ptr<open_implementation<umd_implementation>> open_implementation<umd
     const std::filesystem::path &simulation_directory) {
     std::unique_ptr<tt::umd::Cluster> cluster =
         std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{.chip_type = tt::umd::ChipType::SIMULATION,
-            .target_devices = {0}, .simulator_directory = simulation_directory});
+                                                                   .target_devices = {0},
+                                                                   .simulator_directory = simulation_directory});
 
     // Initialize simulation device
     cluster->start_device({});


### PR DESCRIPTION
After upgrading to new UMD version, we needed to include additional settings to `tt::umd::ClusterOptions`...