### PR TITLE
Rename RiscLoader into ElfLoader

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -25,7 +25,7 @@ from ttexalens.object import DataArray
 from ttexalens.hw.arc.arc import load_arc_fw
 from ttexalens.hw.arc.arc_dbg_fw import arc_dbg_fw_check_msg_loop_running, arc_dbg_fw_command, NUM_LOG_CALLS_OFFSET
 from ttexalens.register_store import ConfigurationRegisterDescription, DebugRegisterDescription
-from ttexalens.risc_loader import RiscLoader
+from ttexalens.elf_loader import ElfLoader
 
 
 def invalid_argument_decorator(func):
@@ -593,7 +593,7 @@ class TestRunElf(unittest.TestCase):
         assert isinstance(risc_debug, BabyRiscDebug), f"Expected BabyRiscDebug, got {type(risc_debug)}"
         rdbg: BabyRiscDebug = risc_debug
         assert rdbg.debug_hardware is not None, "Debug hardware is not available."
-        rloader = RiscLoader(rdbg)
+        rloader = ElfLoader(rdbg)
 
         # Disable branch rediction due to bne instruction in the elf
         rdbg.set_branch_prediction(False)
@@ -864,7 +864,7 @@ class TestCallStack(unittest.TestCase):
     core_desc: str  # Core description ETH0, FW0, FW1 - being parametrized
     core_loc: str  # Core location
     risc_debug: RiscDebug  # RiscDebug object
-    loader: RiscLoader  # RiscLoader object
+    loader: ElfLoader  # ElfLoader object
     pc_register_index: int  # PC register index
 
     @classmethod
@@ -897,7 +897,7 @@ class TestCallStack(unittest.TestCase):
         loc = OnChipCoordinate.create(self.core_loc, device=self.context.devices[0])
         noc_block = loc._device.get_block(loc)
         self.risc_debug = noc_block.get_risc_debug(self.risc_name)
-        self.loader = RiscLoader(self.risc_debug)
+        self.loader = ElfLoader(self.risc_debug)
 
         # Stop risc with reset
         self.risc_debug.set_reset_signal(True)

--- a/test/ttexalens/unit_tests/test_multicore.py
+++ b/test/ttexalens/unit_tests/test_multicore.py
@@ -5,7 +5,7 @@ import unittest
 import time
 from test.ttexalens.unit_tests.test_base import init_default_test_context
 from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
-from ttexalens.risc_loader import RiscLoader
+from ttexalens.elf_loader import ElfLoader
 
 
 class TestMulticore(unittest.TestCase):
@@ -66,7 +66,7 @@ class TestMulticore(unittest.TestCase):
             0x00000E37,  # lui t3, 0x0    - Load upper immediate: t3 = 0 (initialize counter)
             0x001E0E13,  # addi t3, t3, 1 - Add immediate: t3 += 1 (increment counter)
             0x0002A303,  # lw t1, 0(t0)   - Load word: t1 = MEM[t0 + 0] (read from mailbox)
-            RiscLoader.get_jump_to_offset_instruction(-8),  # Jump back 8 bytes (2 instructions) to addi
+            ElfLoader.get_jump_to_offset_instruction(-8),  # Jump back 8 bytes (2 instructions) to addi
         ]
         self._write_program_sequence(self.brisc, brisc_program)
 
@@ -78,7 +78,7 @@ class TestMulticore(unittest.TestCase):
             0x014E1313,  # slli t1, t3, 20 - Shift left logical immediate: t1 = t3 << 20 (delay write frequency)
             0xFE031CE3,  # bne t1, x0, -8  - Branch if not equal: if(t1 != 0) goto t0_loop (branch to addi)
             0x01C2A023,  # sw t3, 0(t0)    - Store word: MEM[t0 + 0] = t3 (write counter to mailbox)
-            RiscLoader.get_jump_to_offset_instruction(-16),  # Jump and link: jump back to addi (loop)
+            ElfLoader.get_jump_to_offset_instruction(-16),  # Jump and link: jump back to addi (loop)
         ]
         self._write_program_sequence(self.trisc0, trisc0_program)
 

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -8,7 +8,7 @@ from test.ttexalens.unit_tests.test_base import init_default_test_context
 from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from ttexalens.context import Context
 from ttexalens.hardware.baby_risc_debug import get_register_index
-from ttexalens.risc_loader import RiscLoader
+from ttexalens.elf_loader import ElfLoader
 
 
 @parameterized_class(
@@ -85,7 +85,7 @@ class TestDebugging(unittest.TestCase):
         # NOP
         self.core_sim.write_program(0, 0x00000013)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(4, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(4, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -120,7 +120,7 @@ class TestDebugging(unittest.TestCase):
         #   while (true);
 
         # Infinite loop (jal 0)
-        self.core_sim.write_program(0, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(0, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -147,7 +147,7 @@ class TestDebugging(unittest.TestCase):
         #   while (true);
 
         # Infinite loop (jal 0)
-        self.core_sim.write_program(0, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(0, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -185,7 +185,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(8, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -217,7 +217,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(12, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -251,7 +251,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(12, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(0))
 
         self.core_sim.set_reset(False)
 
@@ -299,7 +299,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(12, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -325,7 +325,7 @@ class TestDebugging(unittest.TestCase):
         self.core_sim.write_program(4, 0x001E0E13)
         self.core_sim.write_program(8, 0x00002303)
         self.core_sim.write_program(12, 0x00002383)
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(-12))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(-12))
 
         self.core_sim.set_reset(False)
         iteration = 0
@@ -372,7 +372,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(20, 0x00B52023)
         # Infinite loop (jal -8)
-        self.core_sim.write_program(24, RiscLoader.get_jump_to_offset_instruction(-8))
+        self.core_sim.write_program(24, ElfLoader.get_jump_to_offset_instruction(-8))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -426,7 +426,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(12, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -467,10 +467,10 @@ class TestDebugging(unittest.TestCase):
         #   while (true);
         #   while (true);
         #   while (true);
-        self.core_sim.write_program(0, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(4, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(8, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(0, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(4, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(8, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -496,7 +496,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(8, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Invalidate instruction cache
         self.core_sim.invalidate_instruction_cache()
@@ -528,10 +528,10 @@ class TestDebugging(unittest.TestCase):
         #   while (true);
         #   while (true);
         #   while (true);
-        self.core_sim.write_program(0, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(4, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(8, RiscLoader.get_jump_to_offset_instruction(0))
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(0, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(4, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(8, ElfLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -557,7 +557,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(8, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Invalidate instruction cache with reset
         self.core_sim.set_reset(True)
@@ -601,7 +601,7 @@ class TestDebugging(unittest.TestCase):
         for i in range(jump_addr // 4):
             self.core_sim.write_program(i * 4, 0x00000013)
         self.core_sim.write_program(break_addr, 0x00100073)
-        self.core_sim.write_program(jump_addr, RiscLoader.get_jump_to_offset_instruction(-jump_addr))
+        self.core_sim.write_program(jump_addr, ElfLoader.get_jump_to_offset_instruction(-jump_addr))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -625,7 +625,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(8, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(12, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(12, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Continue execution
         self.core_sim.continue_execution()
@@ -678,7 +678,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(28, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(32, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(32, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -732,7 +732,7 @@ class TestDebugging(unittest.TestCase):
         # ebreak
         self.core_sim.write_program(0, 0x00100073)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(4, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(4, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -883,7 +883,7 @@ class TestDebugging(unittest.TestCase):
         # ebreak
         self.core_sim.write_program(0, 0x00100073)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(4, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(4, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -1052,7 +1052,7 @@ class TestDebugging(unittest.TestCase):
         self.core_sim.write_program(56, 0x00052603)
 
         # Infinite loop (jal 0)
-        self.core_sim.write_program(60, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(60, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -1148,11 +1148,11 @@ class TestDebugging(unittest.TestCase):
         # See if they are equal (bne x1, x2, 8)
         self.core_sim.write_program(12, 0x00209463)
         # Jump to ebreak
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(12))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(12))
         # Increase value in x1 (addi x1, x1, 1)
         self.core_sim.write_program(20, 0x00108093)
         # Jump to bne
-        self.core_sim.write_program(24, RiscLoader.get_jump_to_offset_instruction(-12))
+        self.core_sim.write_program(24, ElfLoader.get_jump_to_offset_instruction(-12))
         # ebreak
         self.core_sim.write_program(28, 0x00100073)
         # Load Immediate Address 0x10000 into x10 (lui x10, 0x10)
@@ -1162,7 +1162,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(40, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(44, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(44, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -1217,11 +1217,11 @@ class TestDebugging(unittest.TestCase):
         # See if they are equal (bne x1, x2, 8)
         self.core_sim.write_program(12, 0x00209463)
         # Jump to ebreak
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(12))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(12))
         # Increase value in x1 (addi x1, x1, 1)
         self.core_sim.write_program(20, 0x00108093)
         # Jump to bne
-        self.core_sim.write_program(24, RiscLoader.get_jump_to_offset_instruction(-12))
+        self.core_sim.write_program(24, ElfLoader.get_jump_to_offset_instruction(-12))
         # ebreak
         self.core_sim.write_program(28, 0x00100073)
         # Load Immediate Address 0x10000 into x10 (lui x10, 0x10)
@@ -1231,7 +1231,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(40, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(44, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(44, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)
@@ -1290,11 +1290,11 @@ class TestDebugging(unittest.TestCase):
         # See if they are equal (bne x1, x2, 8)
         self.core_sim.write_program(12, 0x00209463)
         # Jump to ebreak
-        self.core_sim.write_program(16, RiscLoader.get_jump_to_offset_instruction(12))
+        self.core_sim.write_program(16, ElfLoader.get_jump_to_offset_instruction(12))
         # Increase value in x1 (addi x1, x1, 1)
         self.core_sim.write_program(20, 0x00108093)
         # Jump to bne
-        self.core_sim.write_program(24, RiscLoader.get_jump_to_offset_instruction(-12))
+        self.core_sim.write_program(24, ElfLoader.get_jump_to_offset_instruction(-12))
         # ebreak
         self.core_sim.write_program(28, 0x00100073)
         # Load Immediate Address 0x10000 into x10 (lui x10, 0x10)
@@ -1304,7 +1304,7 @@ class TestDebugging(unittest.TestCase):
         # Store the word value from register x11 to address from register x10 (sw x11, 0(x10))
         self.core_sim.write_program(40, 0x00B52023)
         # Infinite loop (jal 0)
-        self.core_sim.write_program(44, RiscLoader.get_jump_to_offset_instruction(0))
+        self.core_sim.write_program(44, ElfLoader.get_jump_to_offset_instruction(0))
 
         # Take risc out of reset
         self.core_sim.set_reset(False)

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -13,7 +13,7 @@ from ttexalens.hardware.risc_debug import RiscDebug
 from ttexalens.tt_exalens_lib import read_from_device, write_to_device
 
 
-class RiscLoader:
+class ElfLoader:
     """
     This class is used to load elf file to a RISC-V core.
     """

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -116,10 +116,10 @@ class ElfLoader:
         the debug interface to write them.
         """
         if (
-            RiscLoader.__inside_private_memory(self.risc_debug.get_data_private_memory(), address)
+            ElfLoader.__inside_private_memory(self.risc_debug.get_data_private_memory(), address)
             and self.risc_debug.get_data_private_memory().address.noc_address is None
         ) or (
-            RiscLoader.__inside_private_memory(self.risc_debug.get_code_private_memory(), address)
+            ElfLoader.__inside_private_memory(self.risc_debug.get_code_private_memory(), address)
             and self.risc_debug.get_code_private_memory().address.noc_address is None
         ):
             # Use debug interface
@@ -133,10 +133,10 @@ class ElfLoader:
         the debug interface to read them.
         """
         if (
-            RiscLoader.__inside_private_memory(self.risc_debug.get_data_private_memory(), address)
+            ElfLoader.__inside_private_memory(self.risc_debug.get_data_private_memory(), address)
             and self.risc_debug.get_data_private_memory().address.noc_address is None
         ) or (
-            RiscLoader.__inside_private_memory(self.risc_debug.get_code_private_memory(), address)
+            ElfLoader.__inside_private_memory(self.risc_debug.get_code_private_memory(), address)
             and self.risc_debug.get_code_private_memory().address.noc_address is None
         ):
             # Use debug interface
@@ -146,7 +146,7 @@ class ElfLoader:
 
     def remap_address(self, address: int, loader_data: int | None, loader_code: int | None):
         data_private_memory = self.risc_debug.get_data_private_memory()
-        if RiscLoader.__inside_private_memory(data_private_memory, address):
+        if ElfLoader.__inside_private_memory(data_private_memory, address):
             if loader_data is not None and isinstance(loader_data, int):
                 assert data_private_memory is not None
                 assert data_private_memory.address is not None
@@ -154,7 +154,7 @@ class ElfLoader:
                 return address - data_private_memory.address.private_address + loader_data
             return address
         code_private_memory = self.risc_debug.get_code_private_memory()
-        if RiscLoader.__inside_private_memory(code_private_memory, address):
+        if ElfLoader.__inside_private_memory(code_private_memory, address):
             if loader_code is not None and isinstance(loader_code, int):
                 assert code_private_memory is not None
                 assert code_private_memory.address is not None

--- a/ttexalens/hardware/baby_risc_info.py
+++ b/ttexalens/hardware/baby_risc_info.py
@@ -6,7 +6,7 @@ from ttexalens.hardware.memory_block import MemoryBlock
 from ttexalens.hardware.noc_block import NocBlock
 from ttexalens.hardware.risc_info import RiscInfo
 from ttexalens.register_store import RegisterStore
-from ttexalens.risc_loader import RiscLoader
+from ttexalens.elf_loader import ElfLoader
 from ttexalens.tt_exalens_lib import write_words_to_device
 
 
@@ -69,7 +69,7 @@ class BabyRiscInfo(RiscInfo):
 
             # If we cannot change the code start address, we write a jump instruction to the specified address
             assert self.default_code_start_address is not None
-            jump_instruction = RiscLoader.get_jump_to_offset_instruction(address)
+            jump_instruction = ElfLoader.get_jump_to_offset_instruction(address)
             write_words_to_device(
                 register_store.location,
                 self.default_code_start_address,

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -266,7 +266,7 @@ def load_elf(
             context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentially initialized.
     """
 
-    from ttexalens.risc_loader import RiscLoader
+    from ttexalens.elf_loader import ElfLoader
 
     context = check_context(context)
     validate_device_id(device_id, context)
@@ -294,8 +294,8 @@ def load_elf(
     for loc in locs:
         noc_block = device.get_block(loc)
         risc_debug = noc_block.get_risc_debug(risc_name, neo_id)
-        risc_loader = RiscLoader(risc_debug)
-        risc_loader.load_elf(elf_file)
+        elf_loader = ElfLoader(risc_debug)
+        elf_loader.load_elf(elf_file)
 
 
 def run_elf(
@@ -320,7 +320,7 @@ def run_elf(
             device_id (int, default 0):	ID number of device to run ELF on.
             context (Context, optional): TTExaLens context object used for interaction with device. If None, global context is used and potentially initialized.
     """
-    from ttexalens.risc_loader import RiscLoader
+    from ttexalens.elf_loader import ElfLoader
 
     context = check_context(context)
 
@@ -349,8 +349,8 @@ def run_elf(
     for loc in locs:
         noc_block = device.get_block(loc)
         risc_debug = noc_block.get_risc_debug(risc_name, neo_id)
-        risc_loader = RiscLoader(risc_debug)
-        risc_loader.run_elf(elf_file)
+        elf_loader = ElfLoader(risc_debug)
+        elf_loader.run_elf(elf_file)
 
 
 def check_context(context: Context | None = None) -> Context:


### PR DESCRIPTION
`ElfLoader` means class that loads elfs :)
In the future, we should have at least two different elf loaders: one that we have and one that metal uses (so one can debug metal kernels with tt-exalens)...