### PR TITLE
Remove verification for continue

### DIFF
--- a/test/ttexalens/unit_tests/core_simulator.py
+++ b/test/ttexalens/unit_tests/core_simulator.py
@@ -93,17 +93,14 @@ class RiscvCoreSimulator:
         """Halt core execution."""
         self.risc_debug.halt()
 
-    def continue_execution(self, enable_debug: bool = True, verify: bool = True):
+    def continue_execution(self, enable_debug: bool = True):
         """Continue core execution.
 
         Args:
             enable_debug: Whether to enable debug mode when continuing
         """
         if enable_debug:
-            if verify:
-                self.risc_debug.cont()
-            else:
-                self.debug_hardware.cont(verify=False)
+            self.risc_debug.cont()
         else:
             self.debug_hardware.continue_without_debug()
 

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -701,7 +701,7 @@ class TestRunElf(unittest.TestCase):
         self.assertTrue(status.is_halted, f"Step 7: RISC at location {loc} is not halted.")
         if not status.is_memory_watchpoint_hit or not status.watchpoints_hit[3]:
             raise util.TTFatalException(f"Step 7: RISC at location {loc} is not halted with memory watchpoint 3.")
-        rdbg.debug_hardware.cont(verify=False)
+        rdbg.cont()
 
         mbox_val = rloader.read_block(MAILBOX_ADDR, MAILBOX_SIZE)
         da = DataArray("g_MAILBOX")
@@ -711,7 +711,7 @@ class TestRunElf(unittest.TestCase):
         self.assertTrue(status.is_halted, f"Step 7: RISC at location {loc} is not halted.")
         if not status.is_memory_watchpoint_hit or not status.watchpoints_hit[5]:
             raise util.TTFatalException(f"Step 7: RISC at location {loc} is not halted with memory watchpoint 5.")
-        rdbg.debug_hardware.cont(verify=False)
+        rdbg.cont()
 
         mbox_val = rloader.read_block(MAILBOX_ADDR, MAILBOX_SIZE)
         da = DataArray("g_MAILBOX")
@@ -722,7 +722,7 @@ class TestRunElf(unittest.TestCase):
         if not status.is_memory_watchpoint_hit or not status.watchpoints_hit[0]:
             raise util.TTFatalException(f"Step 7: RISC at location {loc} is not halted with memory watchpoint 0.")
             return False
-        rdbg.debug_hardware.cont(verify=False)
+        rdbg.cont()
 
         mbox_val = rloader.read_block(MAILBOX_ADDR, MAILBOX_SIZE)
         da = DataArray("g_MAILBOX")
@@ -732,7 +732,7 @@ class TestRunElf(unittest.TestCase):
         self.assertTrue(status.is_halted, f"Step 7: RISC at location {loc} is not halted.")
         if not status.is_memory_watchpoint_hit or not status.watchpoints_hit[4]:
             raise util.TTFatalException(f"Step 7: RISC at location {loc} is not halted with memory watchpoint 4.")
-        rdbg.debug_hardware.cont(verify=False)
+        rdbg.cont()
 
         # STEP END:
         mbox_val = rloader.read_block(MAILBOX_ADDR, MAILBOX_SIZE)

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -332,7 +332,7 @@ class TestDebugging(unittest.TestCase):
         while True:
             try:
                 self.core_sim.halt()
-                self.core_sim.continue_execution(False)
+                self.core_sim.continue_execution(enable_debug=False)
                 iteration = iteration + 1
                 if iteration > 1000:
                     break
@@ -695,7 +695,7 @@ class TestDebugging(unittest.TestCase):
         self.core_sim.debug_hardware.set_watchpoint_on_pc_address(1, self.core_sim.program_base_address + 32)
 
         # Continue and verify that we hit first watchpoint
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.continue_execution()
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
         self.assertFalse(self.core_sim.is_ebreak_hit(), "ebreak should not be the cause.")
         self.assertTrue(self.core_sim.read_status().is_pc_watchpoint_hit, "PC watchpoint should be the cause.")
@@ -709,7 +709,7 @@ class TestDebugging(unittest.TestCase):
         self.assertEqual(self.core_sim.read_data(addr), 0x12345678)
 
         # Continue and verify that we hit first watchpoint
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.continue_execution()
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
         self.assertFalse(self.core_sim.is_ebreak_hit(), "ebreak should not be the cause.")
         self.assertTrue(self.core_sim.read_status().is_pc_watchpoint_hit, "PC watchpoint should be the cause.")
@@ -1173,7 +1173,7 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.continue_execution()
 
         # Confirm failure
         self.assertFalse(self.core_sim.is_halted(), "Core should not be halted.")
@@ -1242,7 +1242,7 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(False)
+        self.core_sim.continue_execution(enable_debug=False)
 
         # We should pass for loop very fast and should be halted here already
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
@@ -1320,7 +1320,7 @@ class TestDebugging(unittest.TestCase):
             self.core_sim.set_branch_prediction(False)
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.continue_execution()
 
         # We should pass for loop very fast and should be halted here already
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -332,7 +332,7 @@ class BabyRiscDebugHardware:
         if self.device._arch == "blackhole":
             self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_STEP)
 
-    def cont(self, verify=True):
+    def cont(self):
         if not self.is_halted():
             util.WARN(
                 f"Continue: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already running"
@@ -341,9 +341,6 @@ class BabyRiscDebugHardware:
         if self.verbose:
             util.INFO("  cont()")
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_CONTINUE)
-        assert (
-            not verify or not self.is_halted()
-        ), f"Failed to continue {self.risc_info.risc_name} core at {self.risc_info.noc_block.location}"
 
     def continue_without_debug(self):
         """
@@ -649,7 +646,7 @@ class BabyRiscDebug(RiscDebug):
             self.assert_not_in_reset()
         self.assert_debug_hardware()
         assert self.debug_hardware is not None, "Debug hardware is not initialized"
-        return self.debug_hardware.cont(verify=False)
+        return self.debug_hardware.cont()
 
     @contextmanager
     def ensure_halted(self):


### PR DESCRIPTION
Problem with current version of verification for continue is that it can hit break point or finish before we do check.
Since verification logic for continue is complex, we are just disabling it.