### PR TITLE
Fix RISC debug implementation for wormhole and blackhole hardware

### DIFF
--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -1173,7 +1173,7 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.debug_hardware.cont()  # We need to use debug hardware as there is a bug fix in risc debug implementation for wormhole
 
         # Confirm failure
         self.assertFalse(self.core_sim.is_halted(), "Core should not be halted.")
@@ -1242,14 +1242,14 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(False)
+        self.core_sim.debug_hardware.continue_without_debug()  # We need to use debug hardware as there is a bug fix in risc debug implementation for wormhole
 
         # We should pass for loop very fast and should be halted here already
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Verify value at address
-        self.core_sim.continue_execution()
+        self.core_sim.debug_hardware.cont()  # We need to use debug hardware as there is a bug fix in risc debug implementation for wormhole
         self.assertEqual(self.core_sim.read_data(addr), 0x87654000)
         self.assertFalse(self.core_sim.is_halted(), "Core should not be halted.")
 
@@ -1320,14 +1320,14 @@ class TestDebugging(unittest.TestCase):
             self.core_sim.set_branch_prediction(False)
 
         # Continue to proceed with bne test
-        self.core_sim.continue_execution(verify=False)
+        self.core_sim.debug_hardware.cont()  # We need to use debug hardware as there is a bug fix in risc debug implementation for wormhole
 
         # We should pass for loop very fast and should be halted here already
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
         self.assertTrue(self.core_sim.is_ebreak_hit(), "ebreak should be the cause.")
 
         # Verify value at address
-        self.core_sim.continue_execution()
+        self.core_sim.debug_hardware.cont()  # We need to use debug hardware as there is a bug fix in risc debug implementation for wormhole
         self.assertEqual(self.core_sim.read_data(addr), 0x87654000)
         self.assertFalse(self.core_sim.is_halted(), "Core should not be halted.")
 

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -328,9 +328,6 @@ class BabyRiscDebugHardware:
         if self.verbose:
             util.INFO("  step()")
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_STEP)
-        # There is bug in hardware and for blackhole step should be executed twice
-        if self.device._arch == "blackhole":
-            self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_STEP)
 
     def cont(self, verify=True):
         if not self.is_halted():

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -10,6 +10,11 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, verbose: bool = False, enable_asserts: bool = True):
         super().__init__(risc_info, verbose, enable_asserts)
 
+    def step(self):
+        # There is a bug in hardware and for blackhole step should be executed twice
+        super().step()
+        super().step()
+
     def read_gpr(self, register_index: int) -> int:
         if register_index != 32:
             return super().read_gpr(register_index)

--- a/ttexalens/hardware/wormhole/baby_risc_debug.py
+++ b/ttexalens/hardware/wormhole/baby_risc_debug.py
@@ -10,6 +10,25 @@ class WormholeBabyRiscDebug(BabyRiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, verbose: bool = False, enable_asserts: bool = True):
         super().__init__(risc_info, verbose, enable_asserts)
 
+    def cont(self):
+        # If this is functional worker core, we need to disable branch prediction as a hardware workaround
+        if self.risc_info.branch_prediction_register is not None:
+            self.set_branch_prediction(False)
+            super().cont()
+        else:
+            # For erisc, we don't have option to disable branch prediction, so we should continue without debug
+            if self.enable_asserts:
+                self.assert_not_in_reset()
+            self.assert_debug_hardware()
+            assert self.debug_hardware is not None, "Debug hardware is not initialized"
+            self.debug_hardware.continue_without_debug()
+
+    def step(self):
+        # We need to disable branch prediction as a hardware workaround, if there is an option to do so
+        if self.risc_info.branch_prediction_register is not None:
+            self.set_branch_prediction(False)
+        return super().step()
+
     def read_gpr(self, register_index: int) -> int:
         if register_index != 32:
             return super().read_gpr(register_index)


### PR DESCRIPTION
Removing architecture specific implementation from `BabyRiscDebug` into `WormholeBabyRiscDebug`/`BlackholeBabyRiscDebug`...