### PR TITLE
Remove error check after writing reset signal

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -516,9 +516,6 @@ class BabyRiscDebug(RiscDebug):
         reset_reg = self.__read(self.RISC_DBG_SOFT_RESET0)
         reset_reg = (reset_reg & ~(1 << self.risc_info.reset_flag_shift)) | (value << self.risc_info.reset_flag_shift)
         self.__write(self.RISC_DBG_SOFT_RESET0, reset_reg)
-        new_reset_reg = self.__read(self.RISC_DBG_SOFT_RESET0)
-        if new_reset_reg != reset_reg:
-            util.ERROR(f"Error writing reset signal. Expected 0x{reset_reg:08x}, got 0x{new_reset_reg:08x}")
 
     def assert_not_in_reset(self, message=""):
         """


### PR DESCRIPTION
It is not easy check to verify that risc was taken out of reset. Check that currently exists is not valid (there is valid scenario that is triggering this check).

LLK team switched in their tests to take brisc out of reset which will during its run take triscs out of reset. Since brisc code is much faster than host, it will change soft reset debug register before we read its value and check will fail.

This change just removes the check until we create more robust check.