### PR TITLE
Packaging gdb client

### DIFF
--- a/docs/gdb.md
+++ b/docs/gdb.md
@@ -13,13 +13,20 @@ You can start gdb server with ttexalens application:
 
 After starting gdb server, you can stop it with `gdb` command. Run `gdb stop`.
 
+## Getting gdb client
+
+There are three ways to obtain the GDB client:
+- Use the version that is automatically downloaded and extracted during the build process at `build/sfpi/compiler/bin/riscv32-tt-elf-gdb`.
+- Use `tt-exalens --gdb` as a wrapper to start the GDB client (this uses the same binary as above). This is also available in the wheel.
+- Download your preferred version manually from https://github.com/tenstorrent/sfpi or build it yourself from source.
+
 ## Connecting gdb client
 
-- Start the GDB client (`./build/sfpi/compiler/bin/riscv32-tt-elf-gdb`, downloaded during the build process).
+- Start the GDB client.
 - To debug client/server communication, run `set debug remote 1` in the GDB client.
 - Connect the GDB client to the debugger using: `target extended-remote localhost:<gdb_port>`.
 
-After connection has been established, you can use `info os processes` to list all available processes that you can debug with GDB. Use `attach <pid>` to start debugging selested riscv core.
+After connection has been established, you can use `info os processes` to list all available processes that you can debug with GDB. Use `attach <pid>` to start debugging selected riscv core.
 
 ## Sample app debugging script:
 

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,12 @@ ttexalens_files = {
         "output": "build/bin",
         "strip": True,
     },
+    "gdb-client": {
+        "path": "build/sfpi/compiler/bin",
+        "files": ["riscv32-tt-elf-gdb"],
+        "output": "build/sfpi/compiler/bin",
+        "strip": True,
+    },
 }
 
 

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -8,6 +8,7 @@ Usage:
   tt-exalens --server [--port=<port>] [--devices=<devices>] [--test] [--jtag] [-s=<simulation_directory>] [--background] [--initialize-with-noc1]
   tt-exalens --remote [--remote-address=<ip:port>] [--commands=<cmds>] [--write-cache] [--cache-path=<path>] [--start-gdb=<gdb_port>] [--verbosity=<verbosity>] [--test]
   tt-exalens --cached [--cache-path=<path>] [--commands=<cmds>] [--verbosity=<verbosity>] [--test]
+  tt-exalens --gdb [gdb_args...]
   tt-exalens -h | --help
 
 Options:
@@ -29,6 +30,7 @@ Options:
   --test                          Exits with non-zero exit code on any exception.
   --jtag                          Initialize JTAG interface.
   --use-noc1                      Use NOC1 for communication with the device.
+  --gdb                           Start RISC-V gdb client with the specified arguments.
 
 Description:
   TTExaLens parses the build output files and reads the device state to provide a debugging interface for the user.
@@ -39,6 +41,7 @@ Description:
     3. Cached mode: The user can use a cache file from previous TTExaLens run. This is useful for debugging without a connection to the device. Writing is disabled in this mode.
 
   Passing the --server flag will start a TTExaLens server. The server will listen on the specified port (default 5555) for incoming connections.
+  Passing the --gdb flag will start a RISC-V gdb client. The gdb client can be used to connect to gdb server that can be start from another TTExaLens instance.
 """
 
 try:
@@ -397,6 +400,17 @@ def main_loop(args, context):
 
 
 def main():
+    if len(sys.argv) > 1 and sys.argv[1] == "--gdb":
+        gdb_client_path = os.path.abspath(util.application_path() + "/../build/sfpi/compiler/bin/riscv32-tt-elf-gdb")
+        gdb_client_args = sys.argv[2:]
+
+        # Start gdb client with the specified arguments
+        import subprocess
+
+        subprocess.run([gdb_client_path] + gdb_client_args)
+
+        sys.exit(0)
+
     args = docopt(__doc__)
 
     # SETTING VERBOSITY


### PR DESCRIPTION
Adding gdb client to package.
Exposing starting gdb client as tt-exalens command.
Use `--gdb` as first argument to start gdb client and rest of the arguments will be forwarded to gdb client.

Closes https://github.com/tenstorrent/tt-exalens/issues/131