### PR TITLE
Allow printing actual core types from gdb

### DIFF
--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -104,7 +104,7 @@ class GdbServer(threading.Thread):
                     # TODO: In ideal world, we would have "start time" for a core (time when core was taken out of reset) and use that as a key for reusing process id; for now, we can just check if elf path is the same
                     last_process = self._last_available_processes.get(risc_debug.risc_location)
                     if last_process is None or last_process.elf_path != elf_path:
-                        core_type = device.get_block_type(risc_debug.risc_location)
+                        core_type = device.get_block_type(risc_debug.risc_location.location)
                         # Shorten long core type for cleaner output
                         if core_type == "functional_workers":
                             core_type = "worker"

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -105,7 +105,7 @@ class GdbServer(threading.Thread):
                     last_process = self._last_available_processes.get(risc_debug.risc_location)
                     if last_process is None or last_process.elf_path != elf_path:
                         core_type = risc_debug.get_block_type(risc_debug.risc_location)
-                        # Shoren long core type for cleaner output
+                        # Shorten long core type for cleaner output
                         if core_type == "functional_workers":
                             core_type = "worker"
                         pid = self.next_pid

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -104,7 +104,10 @@ class GdbServer(threading.Thread):
                     # TODO: In ideal world, we would have "start time" for a core (time when core was taken out of reset) and use that as a key for reusing process id; for now, we can just check if elf path is the same
                     last_process = self._last_available_processes.get(risc_debug.risc_location)
                     if last_process is None or last_process.elf_path != elf_path:
-                        core_type = "worker"  # TODO: once we add support for ETH cores, we should update this
+                        core_type = risc_debug.get_block_type(risc_debug.risc_location)
+                        # Shoren long core type for cleaner output
+                        if core_type == "functional_workers":
+                            core_type = "worker"
                         pid = self.next_pid
                         self.next_pid += 1
                         virtual_core = (

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -104,7 +104,7 @@ class GdbServer(threading.Thread):
                     # TODO: In ideal world, we would have "start time" for a core (time when core was taken out of reset) and use that as a key for reusing process id; for now, we can just check if elf path is the same
                     last_process = self._last_available_processes.get(risc_debug.risc_location)
                     if last_process is None or last_process.elf_path != elf_path:
-                        core_type = risc_debug.get_block_type(risc_debug.risc_location)
+                        core_type = device.get_block_type(risc_debug.risc_location)
                         # Shorten long core type for cleaner output
                         if core_type == "functional_workers":
                             core_type = "worker"

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -74,11 +74,6 @@ class RiscDebug:
         noc_block = risc_location.location._device.get_block(risc_location.location)
         return noc_block.get_risc_debug(risc_location.risc_name, risc_location.neo_id)
 
-    @staticmethod
-    def get_block_type(risc_location: RiscLocation) -> str:
-        noc_block = risc_location.location._device.get_block(risc_location.location)
-        return noc_block.block_type
-
     @abstractmethod
     def is_in_reset(self) -> bool:
         """Check if the RISC core is in reset."""

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -73,6 +73,11 @@ class RiscDebug:
     def get_instance(risc_location: RiscLocation) -> "RiscDebug":
         noc_block = risc_location.location._device.get_block(risc_location.location)
         return noc_block.get_risc_debug(risc_location.risc_name, risc_location.neo_id)
+    
+    @staticmethod
+    def get_block_type(risc_location: RiscLocation) -> str:
+        noc_block = risc_location.location._device.get_block(risc_location.location)
+        return noc_block.block_type
 
     @abstractmethod
     def is_in_reset(self) -> bool:

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -73,7 +73,7 @@ class RiscDebug:
     def get_instance(risc_location: RiscLocation) -> "RiscDebug":
         noc_block = risc_location.location._device.get_block(risc_location.location)
         return noc_block.get_risc_debug(risc_location.risc_name, risc_location.neo_id)
-    
+
     @staticmethod
     def get_block_type(risc_location: RiscLocation) -> str:
         noc_block = risc_location.location._device.get_block(risc_location.location)


### PR DESCRIPTION
In `gdb_server.py` added logic to get actual core type (previously we assigned `worker` to every process, but now we have both eth and tensix cores so this is no longer viable).

To enable this added `get_block_type` function to `RiscDebug` that returns `block_type` from `NocBlock` of that risc.