### PR TITLE
Fixing bug that causes attach to target multiple processes

### DIFF
--- a/ttexalens/gdb/gdb_data.py
+++ b/ttexalens/gdb/gdb_data.py
@@ -12,7 +12,7 @@ class GdbThreadId:
     thread_id: int
 
     def to_gdb_string(self):
-        return f"p{self.process_id}.{self.thread_id}"
+        return f"p{hex(self.process_id)[2:]}.{hex(self.thread_id)[2:]}"
 
 
 @dataclass


### PR DESCRIPTION
Closes #491 

Fixes bug that caused attach to target multiple processes.

We were sending process and thread ids as hex in one place (which is correct) and as decimal in other (which caused a bug).