### PR TITLE
Better handling of unknown process error

### DIFF
--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -297,6 +297,11 @@ class GdbServer(threading.Thread):
                     # We are not changing current process
                     thread_id = self.current_process.thread_id
                 else:
+                    # This is expected behavior
+                    if thread_id.process_id == 0 and thread_id.thread_id == 0:
+                        writer.append(b"E01")
+                        return True
+
                     # Since our processes have only 1 thread, we will pick this up from the cache
                     t = self.debugging_threads.get(thread_id.process_id)
                     if t is None:

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -297,16 +297,14 @@ class GdbServer(threading.Thread):
                     # We are not changing current process
                     thread_id = self.current_process.thread_id
                 else:
-                    # This is expected behavior
-                    if thread_id.process_id == 0 and thread_id.thread_id == 0:
-                        writer.append(b"E01")
-                        return True
-
                     # Since our processes have only 1 thread, we will pick this up from the cache
                     t = self.debugging_threads.get(thread_id.process_id)
                     if t is None:
-                        # Unknown process!!!
-                        util.ERROR(f"GDB: Unknown process id in self.debugging_threads: {thread_id.process_id}")
+                        # Process and thread ids equal to 0 is expected behaivour so we should not print error
+                        # Every time before sending message with actual pid/thread id gdb sends Hgp0.0
+                        if not (thread_id.process_id == 0 and thread_id.thread_id == 0):
+                            # Unknown process!!!
+                            util.ERROR(f"GDB: Unknown process id in self.debugging_threads: {thread_id.process_id}")
                         writer.append(b"E01")
                         return True
                     thread_id = t


### PR DESCRIPTION
After issuing attach command before sending correct packet (`Hg<pid>.<thread_id>`) gdb sends `Hg0.0` so every time we use attach we print error. This PR stops error printing in `H` command if both process and thread ids are 0.