### PR TITLE
Making defaul mem_reader able to read private memory

### DIFF
--- a/ttexalens/firmware.py
+++ b/ttexalens/firmware.py
@@ -9,7 +9,8 @@ import time
 from typing import Callable
 from ttexalens import parse_elf
 from ttexalens import util as util
-from ttexalens.tt_exalens_lib import read_riscv_memory
+
+# from ttexalens.tt_exalens_lib import read_riscv_memory
 import re
 from fuzzywuzzy import process, fuzz
 from sys import getsizeof
@@ -223,9 +224,10 @@ class ELF:
             element_size = size_bytes // elements_to_read
             assert element_size * elements_to_read == size_bytes, "Size must be divisible by number of elements"
             if risc_name is not None:
-                return read_riscv_memory(
-                    core_loc=core_loc, addr=addr, risc_name=risc_name, device_id=device_id, context=context
-                )
+                # return read_riscv_memory(
+                #     core_loc=core_loc, addr=addr, risc_name=risc_name, device_id=device_id, context=context
+                # )
+                return addr
             else:
                 bytes_data = read_from_device(
                     core_loc=core_loc, device_id=device_id, addr=addr, num_bytes=size_bytes, context=context

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -89,10 +89,9 @@ def strip_DW_(s):
 
 
 class ElfDwarf:
-    def __init__(self, dwarf: DWARFInfo, parsed_elf: ParsedElfFile | ParsedElfFileWithOffset):
+    def __init__(self, dwarf: DWARFInfo):
         self.dwarf = dwarf
         self._cus: dict[int, ElfCompileUnit] = {}
-        self.parsed_elf = parsed_elf
 
     @cached_property
     def range_lists(self):
@@ -550,10 +549,7 @@ class ElfDie:
                 if self.attributes.get("DW_AT_const_value"):
                     return self.attributes["DW_AT_const_value"].value
                 else:
-                    if self.name in self.cu.dwarf.elf.symbols:
-                        return self.cu.dwarf.elf.symbols[self.name]
-                    else:
-                        print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
+                    print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
         return addr
 
     @cached_property

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -550,8 +550,8 @@ class ElfDie:
                 if self.attributes.get("DW_AT_const_value"):
                     return self.attributes["DW_AT_const_value"].value
                 else:
-                    if self.name in self.cu.dwarf.elf.symbols:
-                        return self.cu.dwarf.elf.symbols[self.name]
+                    if self.name in self.cu.dwarf.parsed_elf.symbols:
+                        return self.cu.dwarf.parsed_elf.symbols[self.name]
                     else:
                         print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
         return addr

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -910,7 +910,7 @@ class ParsedElfFile:
     @cached_property
     def _dwarf(self) -> ElfDwarf:
         dwarf = self.elf.get_dwarf_info(relocate_dwarf_sections=False)
-        return ElfDwarf(dwarf)
+        return ElfDwarf(dwarf, self)
 
     @cached_property
     def _recursed_dwarf(self):

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -485,6 +485,9 @@ class ElfDie:
             if type_die is not None:
                 return type_die.size
 
+        if self.name in self.cu.dwarf.parsed_elf.symbols:
+            return self.cu.dwarf.parsed_elf.symbols[self.name][1]
+
         return None
 
     @cached_property
@@ -551,7 +554,7 @@ class ElfDie:
                     return self.attributes["DW_AT_const_value"].value
                 else:
                     if self.name in self.cu.dwarf.parsed_elf.symbols:
-                        return self.cu.dwarf.parsed_elf.symbols[self.name]
+                        return self.cu.dwarf.parsed_elf.symbols[self.name][0]
                     else:
                         print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
         return addr
@@ -864,11 +867,11 @@ def decode_symbols(elf_file: ELFFile) -> dict[str, int]:
             for symbol in section.iter_symbols():
                 # Check if it's a label symbol
                 if symbol["st_info"]["type"] == "STT_NOTYPE" and symbol.name:
-                    symbols[symbol.name] = symbol["st_value"]
+                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
                 elif symbol["st_info"]["type"] == "STT_FUNC":
-                    symbols[symbol.name] = symbol["st_value"]
+                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
                 elif symbol["st_info"]["type"] == "STT_OBJECT":
-                    symbols[symbol.name] = symbol["st_value"]
+                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
     return symbols
 
 

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -485,8 +485,9 @@ class ElfDie:
             if type_die is not None:
                 return type_die.size
 
+        # Try to find size from symbol table
         if self.name in self.cu.dwarf.parsed_elf.symbols:
-            return self.cu.dwarf.parsed_elf.symbols[self.name][1]
+            return self.cu.dwarf.parsed_elf.symbols[self.name]["size"]
 
         return None
 
@@ -553,8 +554,9 @@ class ElfDie:
                 if self.attributes.get("DW_AT_const_value"):
                     return self.attributes["DW_AT_const_value"].value
                 else:
+                    # Try to find address from symbol table
                     if self.name in self.cu.dwarf.parsed_elf.symbols:
-                        return self.cu.dwarf.parsed_elf.symbols[self.name][0]
+                        return self.cu.dwarf.parsed_elf.symbols[self.name]["value"]
                     else:
                         print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
         return addr
@@ -867,11 +869,11 @@ def decode_symbols(elf_file: ELFFile) -> dict[str, int]:
             for symbol in section.iter_symbols():
                 # Check if it's a label symbol
                 if symbol["st_info"]["type"] == "STT_NOTYPE" and symbol.name:
-                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
+                    symbols[symbol.name] = {"value": symbol["st_value"], "size": symbol["st_size"]}
                 elif symbol["st_info"]["type"] == "STT_FUNC":
-                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
+                    symbols[symbol.name] = {"value": symbol["st_value"], "size": symbol["st_size"]}
                 elif symbol["st_info"]["type"] == "STT_OBJECT":
-                    symbols[symbol.name] = [symbol["st_value"], symbol["st_size"]]
+                    symbols[symbol.name] = {"value": symbol["st_value"], "size": symbol["st_size"]}
     return symbols
 
 

--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -89,9 +89,10 @@ def strip_DW_(s):
 
 
 class ElfDwarf:
-    def __init__(self, dwarf: DWARFInfo):
+    def __init__(self, dwarf: DWARFInfo, parsed_elf: ParsedElfFile | ParsedElfFileWithOffset):
         self.dwarf = dwarf
         self._cus: dict[int, ElfCompileUnit] = {}
+        self.parsed_elf = parsed_elf
 
     @cached_property
     def range_lists(self):
@@ -549,7 +550,10 @@ class ElfDie:
                 if self.attributes.get("DW_AT_const_value"):
                     return self.attributes["DW_AT_const_value"].value
                 else:
-                    print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
+                    if self.name in self.cu.dwarf.elf.symbols:
+                        return self.cu.dwarf.elf.symbols[self.name]
+                    else:
+                        print(f"{CLR_RED}ERROR: Cannot find address for {self}{CLR_END}")
         return addr
 
     @cached_property


### PR DESCRIPTION
Extended default `mem_reader` to be able to read risc private memory using `read_riscv_memory` from lib. Now first we check if given address is from private memory range, if so we use `read_riscv_memory`, if not we default to `read_from_device`.