### PR TITLE
Fixing release workflow

### DIFF
--- a/.github/workflows/release-latest.yml
+++ b/.github/workflows/release-latest.yml
@@ -32,6 +32,7 @@ jobs:
           pip3 install --upgrade build
           pip3 install --upgrade setuptools
           pip3 install wheel
+          pip3 install typing-extensions
       - name: "Build wheel"
         run: |
           make wheel


### PR DESCRIPTION
New dependency to nanobind.stubgen is not installed. We get nanobind.stubgen through CPM, so there isn't a pip install for it. This should fix the issue. Once we start using our docker image for release, this shouldn't happen...