### PR TITLE
Show download progress for SFPI during build

### DIFF
--- a/cmake/sfpi_release.cmake
+++ b/cmake/sfpi_release.cmake
@@ -1,18 +1,35 @@
+set(SFPI_DOWNLOAD_URL "https://github.com/tenstorrent/sfpi/releases/download/v6.11.1/sfpi-x86_64_Linux.txz")
+set(SFPI_MD5_HASH "14ade50b3fdf3fff5078195332edc15a")
+set(SFPI_LOCAL_FILE "${TTEXALENS_HOME}/build/sfpi-x86_64_Linux-v6.11.1.txz")
 set(SFPI_RELEASE_PATH "${TTEXALENS_HOME}/build/sfpi")
 
-if(NOT EXISTS "${SFPI_RELEASE_PATH}")
+if(NOT EXISTS "${SFPI_LOCAL_FILE}")
     message(STATUS "Downloading sfpi release")
+    file(DOWNLOAD
+        ${SFPI_DOWNLOAD_URL}
+        ${SFPI_LOCAL_FILE}
+        EXPECTED_MD5 ${SFPI_MD5_HASH}
+        SHOW_PROGRESS)
+else()
+    message(STATUS "Using sfpi release from ${SFPI_LOCAL_FILE}")
+endif()
 
-    include(FetchContent)
+include(FetchContent)
+
+if(${CMAKE_VERSION} VERSION_GREATER "3.24.1")
     FetchContent_Declare(
         sfpi
-        URL https://github.com/tenstorrent/sfpi/releases/download/v6.11.1/sfpi-x86_64_Linux.txz
-        URL_HASH MD5=14ade50b3fdf3fff5078195332edc15a
+        URL ${SFPI_LOCAL_FILE}
+        URL_HASH MD5=${SFPI_MD5_HASH}
         SOURCE_DIR ${SFPI_RELEASE_PATH}
-        # Uncomment once we move to CMake after 3.24.1
-        # DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
-    FetchContent_MakeAvailable(sfpi)
 else()
-    message(STATUS "Using sfpi release from ${SFPI_RELEASE_PATH}")
+    FetchContent_Declare(
+        sfpi
+        URL ${SFPI_LOCAL_FILE}
+        URL_HASH MD5=${SFPI_MD5_HASH}
+        SOURCE_DIR ${SFPI_RELEASE_PATH}
+    )
 endif()
+FetchContent_MakeAvailable(sfpi)


### PR DESCRIPTION
Currently, sometimes GitHub trotles downloads on release, so it looks like build is just stuck. This change shows download progress one can see it is actually making progress, just very slow.
Also fixing warning message when CMake version is above 4.0.