### PR TITLE
Add typing-extensions installation to wheel test script

### DIFF
--- a/test/wheel/wheel-test.sh
+++ b/test/wheel/wheel-test.sh
@@ -22,6 +22,7 @@ echo -e "Installing wheel ..."
 pip3 install --upgrade pip
 pip3 install --upgrade build
 pip3 install --upgrade setuptools
+pip3 install typing-extensions
 pip3 install wheel
 
 echo -e "Building TTExaLens ..."


### PR DESCRIPTION
Include installation of typing-extensions in the wheel test script to ensure compatibility during testing.