### PR TITLE
Enabling reading 32 bit formats from dest on blackhole

### DIFF
--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -45,11 +45,9 @@ from ttexalens.debug_tensix import TILE_SIZE
 
 
 def print_regfile(data: list[int | float | str]):
-    tile_id = 0
     for i in range(len(data)):
         if i % TILE_SIZE == 0:
-            INFO(f"TILE ID: {tile_id}")
-            tile_id += 1
+            INFO(f"TILE ID: {i // TILE_SIZE}")
         print(data[i], end="\t")
         if i % 32 == 31:
             print()

--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -40,10 +40,16 @@ from docopt import docopt
 from ttexalens.uistate import UIState
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.debug_tensix import TensixDebug
+from ttexalens.util import INFO
+from ttexalens.debug_tensix import TILE_SIZE
 
 
 def print_regfile(data: list[int | float | str]):
+    tile_id = 0
     for i in range(len(data)):
+        if i % TILE_SIZE == 0:
+            INFO(f"TILE ID: {tile_id}")
+            tile_id += 1
         print(data[i], end="\t")
         if i % 32 == 31:
             print()

--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -3,14 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Usage:
-  dump_regfile <core-loc> <regfile> [-d <D>...]
+  dump_regfile <core-loc> <regfile> [-d <D>...] [-t <num-tiles>] [-a <dest-accumulation>]
 
 Arguments:
   core-loc     Either X-Y or R,C location of a core
   regfile      Register file to read from (0: SRCA, 1: SRCB, 2: DSTACC)
 
 Options:
-  -d <D>       Device ID. Optional and repeatable. Default: current device
+  -d <D>                    Device ID. Optional and repeatable. Default: current device
+  -t <num-tiles>            Number of tiles to read. Only effective for 32 bit formats on blackhole.
+  -a <dest-accumulation> Flag for whether dest accumulation is turned on. Determines maximum number of tiles.
 
 Description:
   Prints specified regfile (SRCA/DSTACC) at core-loc location of the current chip.
@@ -51,8 +53,12 @@ def print_regfile(data: list[int | float | str]):
 def run(cmd_text, context, ui_state: UIState = None):
     args = docopt(__doc__, argv=cmd_text.split()[1:])
 
+    print(args)
+
     core_loc_str = args["<core-loc>"]
     regfile = args["<regfile>"]
+    num_tiles = int(args["-t"]) if args["-t"] else None
+    dest_accumulation = bool(args["-a"]) if args["-a"] else False
 
     current_device_id = ui_state.current_device_id
     device_ids = args["-d"] if args["-d"] else [f"{current_device_id}"]
@@ -65,7 +71,7 @@ def run(cmd_text, context, ui_state: UIState = None):
         core_loc = OnChipCoordinate.create(core_loc_str, device=current_device)
 
         debug_tensix = TensixDebug(core_loc, device_id, context)
-        data = debug_tensix.read_regfile(regfile)
+        data = debug_tensix.read_regfile(regfile, num_tiles, dest_accumulation)
         print_regfile(data)
 
     return None

--- a/ttexalens/cli_commands/dump_regfile.py
+++ b/ttexalens/cli_commands/dump_regfile.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Usage:
-  dump_regfile <core-loc> <regfile> [-d <D>...] [-t <num-tiles>] [-a <dest-accumulation>]
+  dump_regfile <core-loc> <regfile> [-d <D>...] [-t <num-tiles>]
 
 Arguments:
   core-loc     Either X-Y or R,C location of a core
@@ -12,7 +12,6 @@ Arguments:
 Options:
   -d <D>                    Device ID. Optional and repeatable. Default: current device
   -t <num-tiles>            Number of tiles to read. Only effective for 32 bit formats on blackhole.
-  -a <dest-accumulation> Flag for whether dest accumulation is turned on. Determines maximum number of tiles.
 
 Description:
   Prints specified regfile (SRCA/DSTACC) at core-loc location of the current chip.
@@ -53,12 +52,9 @@ def print_regfile(data: list[int | float | str]):
 def run(cmd_text, context, ui_state: UIState = None):
     args = docopt(__doc__, argv=cmd_text.split()[1:])
 
-    print(args)
-
     core_loc_str = args["<core-loc>"]
     regfile = args["<regfile>"]
     num_tiles = int(args["-t"]) if args["-t"] else None
-    dest_accumulation = bool(args["-a"]) if args["-a"] else False
 
     current_device_id = ui_state.current_device_id
     device_ids = args["-d"] if args["-d"] else [f"{current_device_id}"]
@@ -71,7 +67,7 @@ def run(cmd_text, context, ui_state: UIState = None):
         core_loc = OnChipCoordinate.create(core_loc_str, device=current_device)
 
         debug_tensix = TensixDebug(core_loc, device_id, context)
-        data = debug_tensix.read_regfile(regfile, num_tiles, dest_accumulation)
+        data = debug_tensix.read_regfile(regfile, num_tiles)
         print_regfile(data)
 
     return None

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -176,7 +176,7 @@ class TensixDebug:
         return num_tiles
 
     def _is_32_bit_format(self, df: TensixDataFormat) -> bool:
-        return df in [TensixDataFormat.Float32, TensixDataFormat.Int32]
+        return df in (TensixDataFormat.Float32, TensixDataFormat.Int32)
 
     def _direct_dest_read_enabled(self, df: TensixDataFormat) -> bool:
         return type(self.device) == BlackholeDevice and self._is_32_bit_format(df)

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -273,7 +273,7 @@ class TensixDebug:
         regfile = convert_regfile(regfile)
         df = TensixDataFormat(self.read_tensix_register("ALU_FORMAT_SPEC_REG2_Dstacc"))
 
-        if not self._direct_dest_read_enabled(df) and num_tiles is not None:
+        if regfile == REGFILE.DSTACC and not self._direct_dest_read_enabled(df) and num_tiles is not None:
             WARN("num_tiles argument only has effect for 32 bit formats on blackhole.")
 
         # Directly reading dest does not require complex unpacking so we return it right away
@@ -304,7 +304,7 @@ class TensixDebug:
             data = upper + lower
             WARN("The previous contents of DSTACC have been lost and should not be relied upon.")
         else:
-            data = self.read_regfile_data(regfile, df)
+            data = self.read_regfile_data(regfile)
 
         try:
             return unpack_data(data, df)


### PR DESCRIPTION
Closes #517 

Implemented reading dest directly from memory (`0xFFBD8000`) for 32 bit formats (`int32` and `float32`). In this case to get correct values reordering is not necessary (`int32` is printed as-is, `float32` is just unpacked).

Added option for number of tiles to print in `dump_regfile` command. We also now print `TILE ID` between tiles.  