### PR TITLE
`ebreak` callstack unwinding

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -1019,7 +1019,7 @@ class TestCallStack(unittest.TestCase):
         self.assertEqual(len(callstack), 1)
         self.assertEqual(callstack[0].function_name, "halt")
 
-    @parameterized.expand([(1, 1), (10, 9), (50, 49)])
+    @parameterized.expand([(1, 1), (10, 10), (50, 50)])
     def test_callstack_optimized(self, recursion_count, expected_f1_on_callstack_count):
 
         if self.is_wormhole() and self.is_eth_block():
@@ -1032,11 +1032,12 @@ class TestCallStack(unittest.TestCase):
             self.core_loc, elf_path, None, self.risc_name, None, 100, True, False, 0, self.context
         )
 
-        self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
-        for i in range(0, expected_f1_on_callstack_count):
+        self.assertEqual(len(callstack), expected_f1_on_callstack_count + 3)
+        self.assertEqual(callstack[0].function_name, "halt")
+        for i in range(1, expected_f1_on_callstack_count):
             self.assertEqual(callstack[i].function_name, "f1")
-        self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
-        self.assertEqual(callstack[expected_f1_on_callstack_count + 1].function_name, "main")
+        self.assertEqual(callstack[1 + expected_f1_on_callstack_count + 0].function_name, "recurse")
+        self.assertEqual(callstack[1 + expected_f1_on_callstack_count + 1].function_name, "main")
 
     @parameterized.expand([(1, 1)])
     def test_top_callstack_optimized(self, recursion_count: int, expected_f1_on_callstack_count: int):

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -380,6 +380,11 @@ class RiscDebug:
             # Reading the program counter from risc register
             pc = self.read_gpr(32)
 
+            # if ebreak was hit, pc will point to the instruction after it
+            if self.is_ebreak_hit():
+                # rewind pc to unwind callstack from the ebreak instruction
+                pc -= 4
+
             # Choose the elf which is referenced by the program counter
             elf, frame_description = RiscDebug._find_elf_and_frame_description(elfs, pc, self)
 


### PR DESCRIPTION
Rewind PC before unwinding callstack if the core is halted using `ebreak`. Currently, because PC points to the instruction after the `ebreak`, the callstack can sometimes show the wrong info