### PR TITLE
Add RISCV_DEBUG_REG_DEST_CG_CTRL to blackhole

### DIFF
--- a/ttexalens/hardware/blackhole/functional_worker_registers.py
+++ b/ttexalens/hardware/blackhole/functional_worker_registers.py
@@ -469,6 +469,7 @@ register_map: dict[str, RegisterDescription] = {
         offset=0x23C, mask=0x1
     ),  # Old name from configuration register
     "RISCV_DEBUG_REG_NCRISC_RESET_PC_OVERRIDE": DebugRegisterDescription(offset=0x23C, mask=0x1),  # New name
+    "RISCV_DEBUG_REG_DEST_CG_CTRL": DebugRegisterDescription(offset=0x240),
 }
 
 


### PR DESCRIPTION
LLK test infra is looking to move away from using brisc for device setup and use either exalens or trisc, one of the jobs of brisc on blackhole is setting `RISCV_DEBUG_REG_DEST_CG_CTRL` to 0, for exalens to do the same we need the register definition in `ttexalens/hardware/blackhole/functional_worker_registers.py` this PR adds that.