### PR TITLE
Addning NOC_NODE_ID to mitigate tt-triage errors

### DIFF
--- a/ttexalens/hardware/blackhole/niu_registers.py
+++ b/ttexalens/hardware/blackhole/niu_registers.py
@@ -95,6 +95,7 @@ niu_register_map = {
     "NOC_L1_ACC_AT_INSTRN_CB0": NocControlRegisterDescription(offset=0x30),
     "NOC_SEC_CTRL_CB0": NocControlRegisterDescription(offset=0x34),
     "NOC_CMD_CTRL_CB0": NocControlRegisterDescription(offset=0x40),
+    "NOC_NODE_ID": NocControlRegisterDescription(offset=0x44),
     "NOC_NODE_ID_CB0": NocControlRegisterDescription(offset=0x44),
     "NOC_ENDPOINT_ID_CB0": NocControlRegisterDescription(offset=0x48),
     # Command buffer 1 registers (base offset 0x800)

--- a/ttexalens/hardware/quasar/niu_registers.py
+++ b/ttexalens/hardware/quasar/niu_registers.py
@@ -95,6 +95,7 @@ niu_register_map = {
     "NOC_L1_ACC_AT_INSTRN_CB0": NocControlRegisterDescription(offset=0x30),
     "NOC_SEC_CTRL_CB0": NocControlRegisterDescription(offset=0x34),
     "NOC_CMD_CTRL_CB0": NocControlRegisterDescription(offset=0x40),
+    "NOC_NODE_ID": NocControlRegisterDescription(offset=0x44),
     "NOC_NODE_ID_CB0": NocControlRegisterDescription(offset=0x44),
     "NOC_ENDPOINT_ID_CB0": NocControlRegisterDescription(offset=0x48),
     # Command buffer 1 registers (base offset 0x800)

--- a/ttexalens/hardware/wormhole/niu_registers.py
+++ b/ttexalens/hardware/wormhole/niu_registers.py
@@ -75,6 +75,7 @@ niu_register_map = {
     "NOC_AT_LEN_BE_CB0": NocControlRegisterDescription(offset=0x20),
     "NOC_AT_DATA_CB0": NocControlRegisterDescription(offset=0x24),
     "NOC_CMD_CTRL_CB0": NocControlRegisterDescription(offset=0x28),
+    "NOC_NODE_ID": NocControlRegisterDescription(offset=0x2C),
     "NOC_NODE_ID_CB0": NocControlRegisterDescription(offset=0x2C),
     "NOC_ENDPOINT_ID_CB0": NocControlRegisterDescription(offset=0x30),
     # Command buffer 1 registers (base offset 0x400)


### PR DESCRIPTION
TT-triage is using NOC_NODE_ID and after changing name to NOC_NODE_ID_CB0, it regressed triage. This change adds NOC_NODE_ID again to the list of noc register names.