### PR TITLE
Change build system to have debug and release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ core
 *.pkl
 
 .cpmcache
-/build
+/build*
 
 __pycache__
 .venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,18 @@ set(UMD_HOME "${PROJECT_SOURCE_DIR}/third_party/umd")
 # Third party dependencies
 add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/umd)
 
+# Handle symlinks: build should point to build_debug or build_release,
+# and build_*/riscv-src should point to build_elfs
+set(BUILD_SYMLINK "${CMAKE_SOURCE_DIR}/build")
+set(ELF_SYMLINK "${CMAKE_BINARY_DIR}/riscv-src")
+file(MAKE_DIRECTORY "build_elfs")
+
+# Refresh the symlinks
+file(REMOVE "${BUILD_SYMLINK}")
+file(CREATE_LINK "${CMAKE_BINARY_DIR}" "${BUILD_SYMLINK}" SYMBOLIC)
+file(REMOVE "${ELF_SYMLINK}")
+file(CREATE_LINK "../build_elfs" "${ELF_SYMLINK}" SYMBOLIC)
+
 # Check for SFPI release
 include(${PROJECT_SOURCE_DIR}/cmake/sfpi_release.cmake)
 
@@ -72,4 +84,4 @@ include(${PROJECT_SOURCE_DIR}/cmake/pybind.cmake)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttexalens)
 add_subdirectory(${PROJECT_SOURCE_DIR}/utils)
 add_subdirectory(${PROJECT_SOURCE_DIR}/test)
-add_subdirectory(${PROJECT_SOURCE_DIR}/riscv-src)
+add_subdirectory(${PROJECT_SOURCE_DIR}/riscv-src ${CMAKE_BINARY_DIR}/riscv-build)

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,30 @@
 CONFIG ?= Debug
 JTAG ?= OFF
+BUILD_DIR ?= build_$(shell echo $(CONFIG) | tr '[:upper:]' '[:lower:]') # build_debug or build_release
 
 .PHONY: build
 build:
 	@echo "Building"
-	@if [ ! -f build/build.ninja ] || ! grep -iq "CMAKE_BUILD_TYPE:STRING=$(CONFIG)" build/CMakeCache.txt; then \
+	@if [ ! -f $(BUILD_DIR)/build.ninja ] || ! grep -iq "CMAKE_BUILD_TYPE:STRING=$(CONFIG)" $(BUILD_DIR)/CMakeCache.txt; then \
 		if which ccache > /dev/null; then \
-			cmake -B build -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+			cmake -B $(BUILD_DIR) -G Ninja -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
 		else \
-			cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
+			cmake -B $(BUILD_DIR) -G Ninja -DCMAKE_BUILD_TYPE=$(CONFIG) -DDOWNLOAD_TTEXALENS_PRIVATE=$(JTAG) -DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
 		fi \
 	fi
-	@ninja -C build
+	@ninja -C $(BUILD_DIR)
+
+.PHONY: debug
+debug: CONFIG=Debug
+debug: build
+
+.PHONY: release
+release: CONFIG=Release
+release: build
 
 .PHONY: clean
 clean:
-	@rm -rf build/
+	@rm -rf build build_debug build_release build_elfs
 
 .PHONY: test
 test:
@@ -36,7 +45,7 @@ wheel_develop:
 
 .PHONY: wheel
 wheel:
-	STRIP_SYMBOLS=1 CONFIG=Release pip wheel --no-deps --no-cache-dir . --wheel-dir build/ttexalens_wheel
+	STRIP_SYMBOLS=1 CONFIG=Release pip wheel --no-deps --no-cache-dir . --wheel-dir build_release/ttexalens_wheel
 
 .PHONY: ttexalens_server_unit_tests_run_only
 ttexalens_server_unit_tests_run_only:

--- a/riscv-src/CMakeLists.txt
+++ b/riscv-src/CMakeLists.txt
@@ -26,7 +26,7 @@ set(GCOV_FLAGS -fprofile-arcs -ftest-coverage -fprofile-info-section -DCOVERAGE)
 
 # Define project paths: source files, ELFs, and object files
 set(RISCV_SOURCE "${CMAKE_CURRENT_LIST_DIR}")
-set(RISCV_OUTPUT "${CMAKE_BINARY_DIR}/riscv-src")
+set(RISCV_OUTPUT "${CMAKE_SOURCE_DIR}/build_elfs")
 set(RISCV_OBJECT "${CMAKE_BINARY_DIR}/obj/riscv-src")
 
 # Define architectures, applications, and cores
@@ -34,9 +34,8 @@ set(RISCV_ARCHITECTURES "wormhole" "blackhole")
 set(RISCV_CORES "brisc" "trisc0" "trisc1" "trisc2" "ncrisc")
 set(RISCV_APPS "sample" "run_elf_test" "callstack" "cov_test")
 
-# Create output directories
+# Create the object file output directory
 file(MAKE_DIRECTORY ${RISCV_OBJECT})
-file(MAKE_DIRECTORY ${RISCV_OUTPUT})
 
 # Helper function to add object files for each source
 function(add_riscv_object OBJECT_NAME SOURCE_FILE BUILD_TYPE)
@@ -135,11 +134,19 @@ function(create_riscv_target ARCH APP CORE BUILD_TYPE)
     add_dependencies("${ARCH}_${APP}_${CORE}_${BUILD_TYPE}_target" "${ARCH}_${APP}_${CORE}_${BUILD_TYPE}_dump_dis")
 endfunction()
 
+# On Debug builds, build every ELF variant (for tests etc.)
+# On Release builds, only build release ELFs
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(BUILD_TYPES debug release coverage)
+else()
+    set(BUILD_TYPES release)
+endif()
+
 # Create targets for all architectures, applications, and cores
 foreach(CORE ${RISCV_CORES})
     foreach(APP ${RISCV_APPS})
         foreach(ARCH ${RISCV_ARCHITECTURES})
-            foreach(BUILD_TYPE debug release coverage)
+            foreach(BUILD_TYPE ${BUILD_TYPES})
                 create_riscv_target(${ARCH} ${APP} ${CORE} ${BUILD_TYPE})
             endforeach()
         endforeach()


### PR DESCRIPTION
#569 
Created `make debug` and `make release` options. They create `build_debug`/`build_release` and symlink `build` to that directory. Also created `build_elfs` and made `build/riscv-src` symlink to that.