### PR TITLE
Ignoring decode exception when logging GDB server response

### DIFF
--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -166,6 +166,7 @@ class GdbServer(threading.Thread):
                     try:
                         util.VERBOSE(f"sent response to GDB: {writer.data.decode()}")
                     except:
+                        # We ignore error if we cannot decode message
                         pass
                     writer.send()
             except Exception as e:


### PR DESCRIPTION
Closes #585

While testing the GDB server, we encountered an issue where the server failed to decode the response. The resulting exception was mistakenly caught by a generic except block that was not intended for that part of the code. To avoid this unintended behavior, the decoding exception is now explicitly ignored.