### PR TITLE
Fixing wheel binary paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,13 +107,13 @@ class MyBuild(build_ext):
             "libs": {
                 "path": "build/lib",
                 "files": ["libdevice.so", get_pybind_filename()] + get_libjtag(),
-                "output": "build/lib",
+                "output": "ttexalens/lib",
                 "strip": True,
             },
             "gdb-client": {
                 "path": "build_riscv/sfpi/compiler/bin",
                 "files": ["riscv32-tt-elf-gdb"],
-                "output": "build_riscv/sfpi/compiler/bin",
+                "output": "ttexalens/sfpi/compiler/bin",
                 "strip": True,
             },
         }

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -397,9 +397,11 @@ def main_loop(args, context):
 
 def main():
     if len(sys.argv) > 1 and sys.argv[1] == "--gdb":
-        gdb_client_path = os.path.abspath(
-            util.application_path() + "/../build_riscv/sfpi/compiler/bin/riscv32-tt-elf-gdb"
-        )
+        gdb_client_path = os.path.abspath(util.application_path() + "/sfpi/compiler/bin/riscv32-tt-elf-gdb")
+        if not os.path.isfile(gdb_client_path):
+            gdb_client_path = os.path.abspath(
+                util.application_path() + "/../build_riscv/sfpi/compiler/bin/riscv32-tt-elf-gdb"
+            )
         gdb_client_args = sys.argv[2:]
 
         # Start gdb client with the specified arguments

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -11,8 +11,9 @@ import Pyro5.api
 from ttexalens import util as util
 
 
-ttexalens_pybind_path = util.application_path() + "/../build/lib"
-binary_path = util.application_path() + "/../build/bin"
+ttexalens_pybind_path = util.application_path() + "/lib"
+if not os.path.exists(ttexalens_pybind_path):
+    ttexalens_pybind_path = util.application_path() + "/../build/lib"
 sys.path.append(ttexalens_pybind_path)
 
 try:
@@ -58,7 +59,7 @@ class TTExaLensPybind(TTExaLensCommunicator):
             if device is None:
                 raise Exception("Failed to open simulation using pybind library")
         else:
-            device = open_device(binary_path, wanted_devices, init_jtag, initialize_with_noc1)
+            device = open_device(ttexalens_pybind_path, wanted_devices, init_jtag, initialize_with_noc1)
             if device is None:
                 raise Exception("Failed to open device using pybind library")
         self.device: TTExaLensImplementation = device


### PR DESCRIPTION
Wheel now packages non-python dependencies inside `ttexalens` directory.
Since python doesn't have a way to test if our code is running as part of wheel package, we must check both paths (with priority given to wheel path).

Closes #586.