### PR TITLE
Fixed symbol type bug 

### DIFF
--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -454,6 +454,11 @@ class ElfDie:
                 ):
                     return type_die.resolved_type
                 return type_die
+        elif "DW_AT_specification" in self.attributes:
+            dwarf_die = self.dwarf_die.get_DIE_from_attribute("DW_AT_specification")
+            die = self.cu.dwarf.get_die(dwarf_die)
+            if die is not None:
+                return die.resolved_type
         return self
 
     @cached_property


### PR DESCRIPTION
Added `DW_AT_specification` case to `resolved_type` function in `parse_elf` fixing symbol type bug which occurred in cases when type had to be resolved via specification attribute. 