### PR TITLE
Remove virtual coords from exalens

### DIFF
--- a/docs/coordinates.md
+++ b/docs/coordinates.md
@@ -16,17 +16,14 @@ This document explains how we handle different coordinate systems on a chip. The
 4. **logical**
    - Abstracts physical details. Often used to reference Tensix cores (e.g., `t0,0`), Ethernet (`e0,0`), DRAM (`d0,0`), etc.
 
-5. **virtual**
-   - A “compressed” version of `noc0`, skipping harvested (disabled) rows.
-
-6. **translated**
+5. **translated**
    - A hardware-usable coordinate system offset by certain values (e.g., `(16,16)` on some chips), automatically accounting for harvesting.
 
 ## Class Overview
 
 ### `OnChipCoordinate`
 - Stores an internal `noc0` coordinate (`_noc0_coord`).
-- Converts from the input coordinate (die, noc0, noc1, logical, translated, virtual) to `noc0`.
+- Converts from the input coordinate (die, noc0, noc1, logical, translated) to `noc0`.
 - Provides a `.to(output_type)` method to translate to the desired system.
 - Offers helper string methods (`to_str`, `to_user_str`) for user-friendly representation.
 
@@ -78,7 +75,7 @@ print("Logical coords:", logical_coord)
    You can manually instantiate `OnChipCoordinate(x, y, input_type, device)` if you know the type (e.g., `"noc0"`).
 
 2. **Switching Types**
-   Use `.to("logical")`, `.to("noc0")`, `.to("virtual")`, etc., as needed.
+   Use `.to("logical")`, `.to("noc0")`, etc., as needed.
 
 ---
 

--- a/docs/ttexalens-app-docs.md
+++ b/docs/ttexalens-app-docs.md
@@ -285,8 +285,8 @@ Shows a device summary. When no argument is supplied, shows the status of the RI
 ### Arguments
 
 - `device-id`: ID of the device [default: all]
-- `axis-coordinate`: Coordinate system for the axis [default: logical-tensix] Supported: noc0, noc1, translated, virtual, die, logical-tensix, logical-eth, logical-dram
-- `cell-contents`: A comma separated list of the cell contents [default: riscv] Supported: riscv - show the status of the RISC-V ('R': running, '-': in reset), or block type if there are no RISC-V cores block - show the type of the block at that coordinate logical, noc0, noc1, translated, virtual, die - show coordinate noc0_id - show the NOC0 node ID (x-y) for the block noc1_id - show the NOC1 node ID (x-y) for the block
+- `axis-coordinate`: Coordinate system for the axis [default: logical-tensix] Supported: noc0, noc1, translated, die, logical-tensix, logical-eth, logical-dram
+- `cell-contents`: A comma separated list of the cell contents [default: riscv] Supported: riscv - show the status of the RISC-V ('R': running, '-': in reset), or block type if there are no RISC-V cores block - show the type of the block at that coordinate logical, noc0, noc1, translated, die - show coordinate noc0_id - show the NOC0 node ID (x-y) for the block noc1_id - show the NOC1 node ID (x-y) for the block
 
 
 ### Examples

--- a/docs/ttexalens-lib-docs.md
+++ b/docs/ttexalens-lib-docs.md
@@ -660,7 +660,6 @@ Constructor for the Coordinate class.
 - `- noc1`: NOC routing coordinate for NOC 1. (X-Y)
 - `- die`: Die coordinate, a location on the die grid. (X,Y)
 - `- logical`: Logical grid coordinate. Notation: qX,Y, where q represents first letter of the core type. If q is not present, it is considered as tensix core.
-- `- virtual`: Virtual NOC coordinate. Similar to noc0, but with the harvested rows removed, and the locations of functioning rows shifted down to fill in the gap. (X-Y)
 - `- translated`: Translated NOC coordinate. (X-Y)
 - `device`: The device object used for coordinate conversion.
 - `core_type` *(str, optional)*: The core_type used for coordinate conversion. Some coordinate systems require core_type as third dimension. Defaults to "any".

--- a/ttexalens/cli_commands/device-summary.py
+++ b/ttexalens/cli_commands/device-summary.py
@@ -8,12 +8,12 @@ Usage:
 Arguments:
   device-id            ID of the device [default: all]
   axis-coordinate      Coordinate system for the axis [default: logical-tensix]
-                       Supported: noc0, noc1, translated, virtual, die, logical-tensix, logical-eth, logical-dram
+                       Supported: noc0, noc1, translated, die, logical-tensix, logical-eth, logical-dram
   cell-contents        A comma separated list of the cell contents [default: riscv]
                        Supported:
                          riscv - show the status of the RISC-V ('R': running, '-': in reset), or block type if there are no RISC-V cores
                          block - show the type of the block at that coordinate
-                         logical, noc0, noc1, translated, virtual, die - show coordinate
+                         logical, noc0, noc1, translated, die - show coordinate
                          noc0_id - show the NOC0 node ID (x-y) for the block
                          noc1_id - show the NOC1 node ID (x-y) for the block
 

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -34,10 +34,8 @@ The following coordinate systems are available to represent a grid location on t
                     same coordinates with different core types. For example, (0,0) can be a tensix core, an eth core, or a dram core.
                     In order to differentiate between these, first letter is included in string coordinate. Examples:
                     e0,0 for eth core, t0,0 for tensix core, d0,0 for dram core. If you use 0,0, it will be considered as tensix core.
-  - virtual:        Virtual NOC coordinate. Similar to noc0, but with the harvested rows moved to the end, and the locations of
-                    functioning rows shifted down to fill in the gap. This coordinate system is used to communicate with
-                    the driver. Notation: X-Y.
-  - translated:     Translated NOC coordinate. Similar to virtual, but offset by 16 on wormhole. Notation: X-Y
+  - translated:     Translated NOC coordinate. Similar to noc0, but with the harvested rows moved to the end, and the locations of
+                    functioning rows shifted down to fill in the gap and offset by 16 on wormhole.
                     This system is used by the NOC hardware to account for harvesting. On wormhole, translated coordinates will
                     start at 16, 16. It is also constructed such that starting with (18,18) maps exactly to the logical tensix
                     grid. It is used by the NOC hardware and it is programmable ahead of time. Notation: X-Y
@@ -58,7 +56,6 @@ VALID_COORDINATE_TYPES = [
     "logical-tensix",
     "logical-eth",
     "logical-dram",
-    "virtual",
     "translated",
 ]
 
@@ -97,7 +94,6 @@ class OnChipCoordinate:
                 - noc1: NOC routing coordinate for NOC 1. (X-Y)
                 - die: Die coordinate, a location on the die grid. (X,Y)
                 - logical: Logical grid coordinate. Notation: qX,Y, where q represents first letter of the core type. If q is not present, it is considered as tensix core.
-                - virtual: Virtual NOC coordinate. Similar to noc0, but with the harvested rows removed, and the locations of functioning rows shifted down to fill in the gap. (X-Y)
                 - translated: Translated NOC coordinate. (X-Y)
             device: The device object used for coordinate conversion.
             core_type (str, optional): The core_type used for coordinate conversion. Some coordinate systems require core_type as third dimension. Defaults to "any".
@@ -112,8 +108,6 @@ class OnChipCoordinate:
         self._device = device
         if input_type == "noc0" or input_type == "physical":
             self._noc0_coord = (x, y)
-        elif input_type == "virtual":
-            self._noc0_coord = self._device.to_noc0((x, y), "virtual", core_type)
         elif input_type == "noc1":
             self._noc0_coord = self._device.to_noc0((x, y), "noc1", core_type)
         elif input_type == "die":
@@ -157,8 +151,6 @@ class OnChipCoordinate:
         """
         if output_type == "noc0" or output_type == "physical":
             return self._noc0_coord
-        elif output_type == "virtual":
-            return self._device.from_noc0(self._noc0_coord, "virtual")[0]
         elif output_type == "noc1":
             return self._device.from_noc0(self._noc0_coord, "noc1")[0]
         elif output_type == "die":
@@ -255,7 +247,7 @@ class OnChipCoordinate:
         return self.to_user_str()
 
     def full_str(self) -> str:
-        return f"noc0: {self.to_str('noc0')}, noc1: {self.to_str('noc1')}, die: {self.to_str('die')}, logical: {self.to_str('logical')}, translated: {self.to_str('translated')}, virtual: {self.to_str('virtual')}"
+        return f"noc0: {self.to_str('noc0')}, noc1: {self.to_str('noc1')}, die: {self.to_str('die')}, logical: {self.to_str('logical')}, translated: {self.to_str('translated')}"
 
     # == operator
     def __eq__(self, other):

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -144,8 +144,8 @@ class Device(TTObject):
         # Fill in coordinate maps from UMD coordinate manager
         self._from_noc0 = {}
         self._to_noc0 = {}
-        umd_supported_coordinates = ["noc1", "logical", "virtual", "translated"]
-        unique_coordinates = ["noc1", "virtual", "translated"]
+        umd_supported_coordinates = ["noc1", "logical", "translated"]
+        unique_coordinates = ["noc1", "translated"]
         for noc0_location, block_type in self._noc0_to_block_type.items():
             core_type = self.block_types[block_type]["core_type"]
             for coord_system in umd_supported_coordinates:

--- a/ttexalens/pybind/src/open_implementation.cpp
+++ b/ttexalens/pybind/src/open_implementation.cpp
@@ -396,8 +396,6 @@ std::optional<std::tuple<uint8_t, uint8_t>> open_implementation<BaseClass>::conv
 
     if (coord_system == "logical") {
         coord_system_enum = CoordSystem::LOGICAL;
-    } else if (coord_system == "virtual") {
-        coord_system_enum = CoordSystem::VIRTUAL;
     } else if (coord_system == "translated") {
         coord_system_enum = CoordSystem::TRANSLATED;
     } else if (coord_system == "noc0") {


### PR DESCRIPTION
**Description**

There is an ongoing task of removing the virtual coordinate system: https://github.com/tenstorrent/tt-umd/issues/797

This pull request removes support for the "virtual" coordinate system throughout the codebase and documentation. The changes ensure that only supported coordinate systems (such as "noc0", "noc1", "logical", "translated", and "die") are referenced, documented, and handled in code, improving clarity and reducing potential confusion.

**Documentation updates:**

* Removed all references and explanations of the "virtual" coordinate system from the user and developer documentation, including `docs/coordinates.md`, `docs/ttexalens-app-docs.md`, and `docs/ttexalens-lib-docs.md`. [[1]](diffhunk://#diff-c314ddfac006a4169e53d7ca9b77a0402012447412993450fd42307c383fafe1L19-R26) [[2]](diffhunk://#diff-c314ddfac006a4169e53d7ca9b77a0402012447412993450fd42307c383fafe1L81-R78) [[3]](diffhunk://#diff-3cfddbaf9fdb228282b517cf1dd9a2ab60c89c40284405814e35327317aa6429L288-R289) [[4]](diffhunk://#diff-54e4544a52e6d767f83471a2d04791b1ff36b348c429287a2bcf8238ba84b7d5L663)

**Code and CLI changes:**

* Updated CLI help and argument descriptions in `ttexalens/cli_commands/device-summary.py` to remove "virtual" as a supported coordinate system.
* Removed "virtual" from the list of supported coordinate types and from documentation strings in `ttexalens/coordinate.py`. [[1]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L37-R38) [[2]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L61) [[3]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L100)
* Deleted all code paths handling "virtual" as an input or output coordinate type in the `OnChipCoordinate` class, including the constructor and conversion methods. [[1]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L115-L116) [[2]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L160-L161) [[3]](diffhunk://#diff-9c41fdd78cda7684bbc3c3b96dd6a671420bb44b1ec178d1a4f8397f3f574938L258-R250)

**Backend and bindings:**

* Updated device initialization and coordinate system mapping in `ttexalens/device.py` to exclude "virtual" from supported and unique coordinate lists.
* Removed "virtual" coordinate system handling from the C++ bindings in `ttexalens/pybind/src/open_implementation.cpp`.