### PR TITLE
Disable nanobind leak warnings in the bindings module

### DIFF
--- a/ttexalens/pybind/src/bindings.cpp
+++ b/ttexalens/pybind/src/bindings.cpp
@@ -161,6 +161,9 @@ std::unique_ptr<TTExaLensImplementation> open_simulation(const std::string &simu
 }
 
 NB_MODULE(ttexalens_pybind, m) {
+    // Disable nanobind leak warnings
+    nanobind::set_leak_warnings(false);
+
     // Bind the TTExaLensImplementation class
     nanobind::class_<TTExaLensImplementation>(m, "TTExaLensImplementation")
         .def("pci_read32", &TTExaLensImplementation::pci_read32, "Reads 4 bytes from PCI address", "noc_id"_a,

--- a/ttexalens/pybind/src/bindings.cpp
+++ b/ttexalens/pybind/src/bindings.cpp
@@ -162,6 +162,8 @@ std::unique_ptr<TTExaLensImplementation> open_simulation(const std::string &simu
 
 NB_MODULE(ttexalens_pybind, m) {
     // Disable nanobind leak warnings
+    // We are creating single instance of ttexalens_pybind.TTExaLensImplementation, but nanobind thinks it is a leak
+    // because we are not explicitly deleting it. However, we want to keep it alive for the entire program duration.
     nanobind::set_leak_warnings(false);
 
     // Bind the TTExaLensImplementation class


### PR DESCRIPTION
After syncing to latest main in Metal, running tt-triage causes this output:
```
nanobind: leaked 2 instances!
 - leaked instance 0x7f5905ca3fd8 of type "ttexalens.tt_exalens_ifc.TTExaLensPybind"
 - leaked instance 0x55dd4b66f730 of type "ttexalens_pybind.TTExaLensImplementation"
nanobind: leaked 1 types!
 - leaked type "ttexalens_pybind.TTExaLensImplementation"
nanobind: leaked 19 functions!
 - leaked function "pci_write"
 - leaked function "get_device_ids"
 - leaked function "pci_write32"
 - leaked function "get_device_arch"
 - leaked function "pci_read32_raw"
 - leaked function "jtag_read32_axi"
 - leaked function "arc_msg"
 - leaked function "pci_read32"
 - leaked function "pci_read"
 - leaked function "get_device_soc_description"
 - leaked function "jtag_write32"
 - leaked function "pci_read_tile"
 - leaked function "pci_write32_raw"
 - leaked function "get_cluster_description"
 - leaked function "jtag_write32_axi"
 - leaked function "dma_buffer_read32"
 - leaked function "jtag_read32"
 - leaked function "read_arc_telemetry_entry"
 - leaked function "convert_from_noc0"
nanobind: this is likely caused by a reference counting issue in the binding code.
See https://nanobind.readthedocs.io/en/latest/refleaks.html
```

This is printed when program exits. As this number is very low, I would say it is safe to just disable this warning (we are not creating new bindings all over the place, but are reusing the same one)... We initialize context only once in tt-triage...