### PR TITLE
UMD bump + new interface for arc telemetry + adapting tests

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -782,18 +782,20 @@ class TestARC(unittest.TestCase):
 
     fw_file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../..", "fw/arc/arc_bebaceca.hex")
 
-    def test_read_arc_telemetry(self):
-        """Test reading ARC telemetry entries of known values"""
+    def test_arc_heartbeat(self):
+        """Test reading ARC heartbeat"""
         device_id = 0
         if not self.is_wormhole() and not self.is_blackhole():
             self.skipTest("ARC telemetry is not supported for this architecture")
 
+        tag = "TAG_HEARTBEAT"
+
         # Check if heartbeat is increasing
         import time
 
-        heartbeat1 = lib.read_arc_telemetry_entry(device_id, "TAG_HEARTBEAT")
+        heartbeat1 = lib.read_arc_telemetry_entry(device_id, tag)
         time.sleep(0.1)
-        heartbeat2 = lib.read_arc_telemetry_entry(device_id, "TAG_HEARTBEAT")
+        heartbeat2 = lib.read_arc_telemetry_entry(device_id, tag)
         self.assertGreater(heartbeat2, heartbeat1)
 
     @parameterized.expand(
@@ -806,14 +808,13 @@ class TestARC(unittest.TestCase):
         ]
     )
     def test_read_arc_telemetry_entry(self, tag_name, tag_id):
-        """Test reading ARC telemetry entry by tag name and tag ID"""
+        """Test if reading ARC telemetry entry by tag name and tag ID gives the same result"""
 
         if not self.is_wormhole() and not self.is_blackhole():
             self.skipTest("ARC telemetry is not supported for this architecture")
 
         device_id = 0
 
-        # Check if reading by tag name and tag ID gives the same result
         ret_from_name = lib.read_arc_telemetry_entry(device_id, tag_name)
         ret_from_id = lib.read_arc_telemetry_entry(device_id, tag_id)
         self.assertEqual(ret_from_name, ret_from_id)

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -785,52 +785,37 @@ class TestARC(unittest.TestCase):
     def test_read_arc_telemetry(self):
         """Test reading ARC telemetry entries of known values"""
         device_id = 0
-        if self.is_wormhole():
-            # Check vendor ID
-            expected_vendor_id = 0x1E52
-            vendor_id = lib.read_arc_telemetry_entry(device_id, "TAG_DEVICE_ID") & 0xFFFF
-            self.assertEqual(vendor_id, expected_vendor_id)
-
-            # Check if heartbeat is increasing
-            import time
-
-            heartbeat1 = lib.read_arc_telemetry_entry(device_id, "TAG_ARC0_HEALTH")
-            time.sleep(0.1)
-            heartbeat2 = lib.read_arc_telemetry_entry(device_id, "TAG_ARC0_HEALTH")
-            self.assertGreater(heartbeat2, heartbeat1)
-        elif self.is_blackhole():
-            # Check if heartbeat is increasing
-            import time
-
-            heartbeat1 = lib.read_arc_telemetry_entry(device_id, "TAG_TIMER_HEARTBEAT")
-            time.sleep(0.1)
-            heartbeat2 = lib.read_arc_telemetry_entry(device_id, "TAG_TIMER_HEARTBEAT")
-            self.assertGreater(heartbeat2, heartbeat1)
-        else:
+        if not self.is_wormhole() and not self.is_blackhole():
             self.skipTest("ARC telemetry is not supported for this architecture")
+
+        # Check if heartbeat is increasing
+        import time
+
+        heartbeat1 = lib.read_arc_telemetry_entry(device_id, "TAG_HEARTBEAT")
+        time.sleep(0.1)
+        heartbeat2 = lib.read_arc_telemetry_entry(device_id, "TAG_HEARTBEAT")
+        self.assertGreater(heartbeat2, heartbeat1)
 
     @parameterized.expand(
         [
-            ("TAG_BOARD_ID_HIGH", (4, 1)),
-            ("TAG_BOARD_ID_LOW", (5, 2)),
-            ("TAG_AICLK", (24, 14)),
-            ("TAG_AXICLK", (25, 15)),
-            ("TAG_ARCCLK", (26, 16)),
+            ("TAG_BOARD_ID", 1),
+            ("TAG_AICLK", 2),
+            ("TAG_AXICLK", 3),
+            ("TAG_ARCCLK", 4),
+            ("TAG_HEARTBEAT", 5),
         ]
     )
     def test_read_arc_telemetry_entry(self, tag_name, tag_id):
         """Test reading ARC telemetry entry by tag name and tag ID"""
 
-        index = 0 if self.is_wormhole() else 1 if self.is_blackhole() else None
-
-        if index is None:
+        if not self.is_wormhole() and not self.is_blackhole():
             self.skipTest("ARC telemetry is not supported for this architecture")
 
         device_id = 0
 
         # Check if reading by tag name and tag ID gives the same result
         ret_from_name = lib.read_arc_telemetry_entry(device_id, tag_name)
-        ret_from_id = lib.read_arc_telemetry_entry(device_id, tag_id[index])
+        ret_from_id = lib.read_arc_telemetry_entry(device_id, tag_id)
         self.assertEqual(ret_from_name, ret_from_id)
 
     def test_load_arc_fw(self):

--- a/ttexalens/hardware/arc_block.py
+++ b/ttexalens/hardware/arc_block.py
@@ -8,8 +8,19 @@ from ttexalens.debug_bus_signal_store import DebugBusSignalStore
 from ttexalens.hardware.noc_block import NocBlock
 
 
+telemetry_tags_map: dict[str, int] = {
+    "TAG_BOARD_ID": 1,
+    "TAG_AICLK": 2,
+    "TAG_AXICLK": 3,
+    "TAG_ARCCLK": 4,
+    "TAG_HEARTBEAT": 5,
+}
+
+
 class ArcBlock(NocBlock):
-    def __init__(self, location: OnChipCoordinate, block_type: str, telemetry_tags: dict[str, int]):
+    def __init__(
+        self, location: OnChipCoordinate, block_type: str, telemetry_tags: dict[str, int] = telemetry_tags_map
+    ):
         super().__init__(location, block_type)
 
         self.telemetry_tags = telemetry_tags

--- a/ttexalens/hardware/blackhole/arc_block.py
+++ b/ttexalens/hardware/blackhole/arc_block.py
@@ -16,73 +16,6 @@ from ttexalens.register_store import (
 )
 
 
-telemetry_tags_map = {
-    "TAG_BOARD_ID_HIGH": 1,
-    "TAG_BOARD_ID_LOW": 2,
-    "TAG_ASIC_ID": 3,
-    "TAG_HARVESTING_STATE": 4,
-    "TAG_UPDATE_TELEM_SPEED": 5,
-    "TAG_VCORE": 6,
-    "TAG_TDP": 7,
-    "TAG_TDC": 8,
-    "TAG_VDD_LIMITS": 9,
-    "TAG_THM_LIMIT_SHUTDOWN": 10,
-    "TAG_THM_LIMITS": 10,  # Same as TAG_THM_LIMIT_SHUTDOWN
-    "TAG_ASIC_TEMPERATURE": 11,
-    "TAG_VREG_TEMPERATURE": 12,
-    "TAG_BOARD_TEMPERATURE": 13,
-    "TAG_AICLK": 14,
-    "TAG_AXICLK": 15,
-    "TAG_ARCCLK": 16,
-    "TAG_L2CPUCLK0": 17,
-    "TAG_L2CPUCLK1": 18,
-    "TAG_L2CPUCLK2": 19,
-    "TAG_L2CPUCLK3": 20,
-    "TAG_ETH_LIVE_STATUS": 21,
-    "TAG_GDDR_STATUS": 22,
-    "TAG_GDDR_SPEED": 23,
-    "TAG_ETH_FW_VERSION": 24,
-    "TAG_GDDR_FW_VERSION": 25,
-    "TAG_BM_APP_FW_VERSION": 26,
-    "TAG_BM_BL_FW_VERSION": 27,
-    "TAG_FLASH_BUNDLE_VERSION": 28,
-    "TAG_CM_FW_VERSION": 29,
-    "TAG_L2CPU_FW_VERSION": 30,
-    "TAG_FAN_SPEED": 31,
-    "TAG_TIMER_HEARTBEAT": 32,
-    "TAG_TELEM_ENUM_COUNT": 33,
-    "TAG_ENABLED_TENSIX_COL": 34,
-    "TAG_ENABLED_ETH": 35,
-    "TAG_ENABLED_GDDR": 36,
-    "TAG_ENABLED_L2CPU": 37,
-    "TAG_PCIE_USAGE": 38,
-    "TAG_INPUT_CURRENT": 39,
-    "TAG_NOC_TRANSLATION": 40,
-    "TAG_FAN_RPM": 41,
-    "TAG_GDDR_0_1_TEMP": 42,
-    "TAG_GDDR_2_3_TEMP": 43,
-    "TAG_GDDR_4_5_TEMP": 44,
-    "TAG_GDDR_6_7_TEMP": 45,
-    "TAG_GDDR_0_1_CORR_ERRS": 46,
-    "TAG_GDDR_2_3_CORR_ERRS": 47,
-    "TAG_GDDR_4_5_CORR_ERRS": 48,
-    "TAG_GDDR_6_7_CORR_ERRS": 49,
-    "TAG_GDDR_UNCORR_ERRS": 50,
-    "TAG_MAX_GDDR_TEMP": 51,
-    "TAG_ASIC_LOCATION": 52,
-    "TAG_AICLK_LIMIT_MAX": 53,
-    "TAG_TDP_LIMIT_MAX": 54,
-    "TAG_TDC_LIMIT_MAX": 55,
-    "TAG_THM_LIMIT_THROTTLE": 56,
-    "TAG_FW_BUILD_DATE": 57,
-    "TAG_TT_FLASH_VERSION": 58,
-    "TAG_ENABLED_TENSIX_ROW": 59,
-    "TAG_THERM_TRIP_COUNT": 61,
-    "TAG_ASIC_ID_HIGH": 62,
-    "TAG_ASIC_ID_LOW": 63,
-}
-
-
 register_map = {
     "ARC_RESET_ARC_MISC_CNTL": ArcResetRegisterDescription(offset=0x100),
     "ARC_RESET_ARC_MISC_STATUS": ArcResetRegisterDescription(offset=0x104),
@@ -142,7 +75,7 @@ register_store_noc1_initialization_remote = RegisterStore.create_initialization(
 
 class BlackholeArcBlock(ArcBlock):
     def __init__(self, location: OnChipCoordinate):
-        super().__init__(location, block_type="arc", telemetry_tags=telemetry_tags_map)
+        super().__init__(location, block_type="arc")
 
         if self.device._has_mmio:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)

--- a/ttexalens/hardware/wormhole/arc_block.py
+++ b/ttexalens/hardware/wormhole/arc_block.py
@@ -15,60 +15,6 @@ from ttexalens.register_store import (
     RegisterStore,
 )
 
-
-telemetry_tags_map: dict[str, int] = {
-    "TAG_ENUM_VERSION": 0,
-    "TAG_DEVICE_ID": 1,
-    "TAG_ASIC_RO": 2,
-    "TAG_ASIC_IDD": 3,
-    "TAG_BOARD_ID_HIGH": 4,
-    "TAG_BOARD_ID_LOW": 5,
-    "TAG_ARC0_FW_VERSION": 6,
-    "TAG_ARC1_FW_VERSION": 7,
-    "TAG_ARC2_FW_VERSION": 8,
-    "TAG_ARC3_FW_VERSION": 9,
-    "TAG_SPIBOOTROM_FW_VERSION": 10,
-    "TAG_ETH_FW_VERSION": 11,
-    "TAG_M3_BL_FW_VERSION": 12,
-    "TAG_M3_APP_FW_VERSION": 13,
-    "TAG_DDR_STATUS": 14,
-    "TAG_ETH_STATUS0": 15,
-    "TAG_ETH_STATUS1": 16,
-    "TAG_PCIE_STATUS": 17,
-    "TAG_FAULTS": 18,
-    "TAG_ARC0_HEALTH": 19,
-    "TAG_ARC1_HEALTH": 20,
-    "TAG_ARC2_HEALTH": 21,
-    "TAG_ARC3_HEALTH": 22,
-    "TAG_FAN_SPEED": 23,
-    "TAG_AICLK": 24,
-    "TAG_AXICLK": 25,
-    "TAG_ARCCLK": 26,
-    "TAG_THROTTLER": 27,
-    "TAG_VCORE": 28,
-    "TAG_ASIC_TEMPERATURE": 29,
-    "TAG_VREG_TEMPERATURE": 30,
-    "TAG_BOARD_TEMPERATURE": 31,
-    "TAG_TDP": 32,
-    "TAG_TDC": 33,
-    "TAG_VDD_LIMITS": 34,
-    "TAG_THM_LIMITS": 35,
-    "TAG_WH_FW_DATE": 36,
-    "TAG_ASIC_TMON0": 37,
-    "TAG_ASIC_TMON1": 38,
-    "TAG_MVDDQ_POWER": 39,
-    "TAG_GDDR_TRAIN_TEMP0": 40,
-    "TAG_GDDR_TRAIN_TEMP1": 41,
-    "TAG_BOOT_DATE": 42,
-    "TAG_RT_SECONDS": 43,
-    "TAG_ETH_DEBUG_STATUS0": 44,
-    "TAG_ETH_DEBUG_STATUS1": 45,
-    "TAG_TT_FLASH_VERSION": 46,
-    "TAG_ETH_LOOPBACK_STATUS": 47,
-    "TAG_ETH_LIVE_STATUS": 48,
-    "TAG_FW_BUNDLE_VERSION": 49,
-}
-
 register_map = {
     "ARC_RESET_ARC_MISC_CNTL": ArcResetRegisterDescription(offset=0x100),
     "ARC_RESET_ARC_MISC_STATUS": ArcResetRegisterDescription(offset=0x104),
@@ -132,7 +78,7 @@ register_store_noc1_initialization_remote = RegisterStore.create_initialization(
 
 class WormholeArcBlock(ArcBlock):
     def __init__(self, location: OnChipCoordinate):
-        super().__init__(location, block_type="arc", telemetry_tags=telemetry_tags_map)
+        super().__init__(location, block_type="arc")
 
         if self.device._has_mmio:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)

--- a/ttexalens/pybind/inc/umd_implementation.h
+++ b/ttexalens/pybind/inc/umd_implementation.h
@@ -42,13 +42,13 @@ class umd_implementation : public ttexalens_implementation {
 
    private:
     bool is_chip_mmio_capable(uint8_t chip_id);
-    tt::umd::ArcTelemetryReader* get_arc_telemetry_reader(uint8_t chip_id);
+    tt::umd::FirmwareInfoProvider* get_firmware_info_provider(uint8_t chip_id);
 
     tt::umd::Cluster* cluster = nullptr;
     std::string cluster_descriptor_path;
 
-    std::vector<std::unique_ptr<tt::umd::ArcTelemetryReader>> cached_arc_telemetry_readers;
-    std::mutex cached_arc_telemetry_readers_mutex;
+    std::vector<std::unique_ptr<tt::umd::FirmwareInfoProvider>> cached_firmware_info_providers;
+    std::mutex cached_firmware_info_providers_mutex;
 };
 
 }  // namespace tt::exalens

--- a/ttexalens/pybind/src/umd_implementation.cpp
+++ b/ttexalens/pybind/src/umd_implementation.cpp
@@ -7,8 +7,8 @@
 #include <tuple>
 
 #include "read_tile.hpp"
-#include "umd/device/arc/arc_telemetry_reader.hpp"
 #include "umd/device/cluster.h"
+#include "umd/device/firmware/firmware_info_provider.hpp"
 
 namespace tt::exalens {
 
@@ -225,19 +225,6 @@ std::optional<std::tuple<int, uint32_t, uint32_t>> umd_implementation::arc_msg(u
     uint32_t return_4 = 0;
     int return_code = cluster->arc_msg(chip_id, msg_code, wait_for_done, arg0, arg1, timeout, &return_3, &return_4);
     return std::make_tuple(return_code, return_3, return_4);
-}
-
-tt::umd::ArcTelemetryReader* umd_implementation::get_arc_telemetry_reader(uint8_t chip_id) {
-    auto& cached_arc_telemetry_reader = cached_arc_telemetry_readers[chip_id];
-
-    if (!cached_arc_telemetry_reader) {
-        std::lock_guard<std::mutex> lock(cached_arc_telemetry_readers_mutex);
-        if (!cached_arc_telemetry_reader) {
-            cached_arc_telemetry_reader =
-                tt::umd::ArcTelemetryReader::create_arc_telemetry_reader(cluster->get_tt_device(chip_id));
-        }
-    }
-    return cached_arc_telemetry_reader.get();
 }
 
 tt::umd::FirmwareInfoProvider* umd_implementation::get_firmware_info_provider(uint8_t chip_id) {


### PR DESCRIPTION
`UMD` bump

`UMD` introduced a new interface for reading ARC telemetry entries, so I updated our side to align with it. At the moment, we support only five entries (`BOARD_ID`, `AICLK`, `AXICLK`, `ARCCLK`, and `HEARTBEAT`), which covers everything we currently use. The setup can be easily extended if needed.

This is a temporary solution until UMD provides their own bound functions.

Tests have been updated to reflect these changes.