### PR TITLE
Upgrading CLI app state

### DIFF
--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Usage:
-  tt-exalens [--commands=<cmds>] [--start-gdb=<gdb_port>] [--devices=<devices>] [--verbosity=<verbosity>] [--test] [--jtag] [--use-noc1]
-  tt-exalens --server [--port=<port>] [--devices=<devices>] [--test] [--jtag] [-s=<simulation_directory>] [--background] [--initialize-with-noc1]
+  tt-exalens [--commands=<cmds>] [--start-server=<server_port>] [--start-gdb=<gdb_port>] [--devices=<devices>] [-s=<simulation_directory>] [--verbosity=<verbosity>] [--test] [--jtag] [--use-noc1]
+  tt-exalens --server [--port=<port>] [--devices=<devices>] [--test] [--jtag] [-s=<simulation_directory>] [--background] [--use-noc1]
   tt-exalens --remote [--remote-address=<ip:port>] [--commands=<cmds>] [--start-gdb=<gdb_port>] [--verbosity=<verbosity>] [--test]
   tt-exalens --gdb [gdb_args...]
   tt-exalens -h | --help
@@ -18,14 +18,14 @@ Options:
   --remote-address=<ip:port>      Address of the remote TTExaLens server, in the form of ip:port, or just :port, if ip is localhost. If not specified, defaults to localhost:5555. [default: localhost:5555]
   --commands=<cmds>               Execute a list of semicolon-separated commands.
   --start-gdb=<gdb_port>          Start a gdb server on the specified port.
+  --start-server=<server_port>    Start a tt-exalens server on the specified port.
   --devices=<devices>             Comma-separated list of devices to load. If not supplied, all devices will be loaded.
   --background                    Start the server in the background detached from console (doesn't require ENTER button for exit, but exit.server file to be created).
-  --initialize-with-noc1          Initialize the device with NOC1.
   -s=<simulation_directory>       Specifies build output directory of the simulator.
   --verbosity=<verbosity>         Choose output verbosity. 1: ERROR, 2: WARN, 3: INFO, 4: VERBOSE, 5: DEBUG. [default: 3]
   --test                          Exits with non-zero exit code on any exception.
   --jtag                          Initialize JTAG interface.
-  --use-noc1                      Use NOC1 for communication with the device.
+  --use-noc1                      Initialize with NOC1 and use NOC1 for communication with the device.
   --gdb                           Start RISC-V gdb client with the specified arguments.
 
 Description:
@@ -238,10 +238,14 @@ def main_loop(args, context):
 
     navigation_suggestions = None
 
+    # Check if we need to start server
+    if args["--start-server"]:
+        port = int(args["--start-server"])
+        ui_state.start_server(port)
+
     # Check if we need to start gdb server
     if args["--start-gdb"]:
         port = int(args["--start-gdb"])
-        print(f"Starting gdb server on port {port}")
         ui_state.start_gdb(port)
 
     # These commands will be executed right away (before allowing user input)
@@ -265,6 +269,9 @@ def main_loop(args, context):
 
                     def get_dynamic_prompt() -> HTML:
                         my_prompt = ""
+                        if ui_state.ttexalens_server is not None:
+                            server_status = f"{util.CLR_PROMPT}{ui_state.ttexalens_server.port}{util.CLR_PROMPT_END}"
+                            my_prompt += f"server:{server_status} "
                         if ui_state.gdb_server is not None:
                             gdb_status = f"{util.CLR_PROMPT}{ui_state.gdb_server.server.port}{util.CLR_PROMPT_END}"
                             if ui_state.gdb_server.is_connected:
@@ -348,6 +355,10 @@ def main_loop(args, context):
     finally:
         # Do best effort cleanup before exiting
         try:
+            ui_state.stop_server()
+        except:
+            pass
+        try:
             ui_state.stop_gdb()
         except:
             pass
@@ -384,28 +395,30 @@ def main():
 
     # Try to start the server. If already running, exit with error.
     if args["--server"]:
-        communicator = tt_exalens_ifc.init_pybind(
-            wanted_devices,
-            init_jtag=args["--jtag"],
-            initialize_with_noc1=args["--initialize-with-noc1"],
-            simulation_directory=args["-s"],
-        )
-        ttexalens_server = tt_exalens_server.start_server(port=int(args["--port"]), communicator=communicator)
         if args["--background"]:
+            communicator = tt_exalens_ifc.init_pybind(
+                wanted_devices=wanted_devices,
+                init_jtag=args["--jtag"],
+                initialize_with_noc1=args["--use-noc1"],
+                simulation_directory=args["-s"],
+            )
+            ttexalens_server = tt_exalens_server.start_server(port=int(args["--port"]), communicator=communicator)
+
             util.INFO("The debug server is running in the background.")
             util.INFO("To stop the server, use the command: touch exit.server")
-            os.remove("exit.server")
+            if os.path.exists("exit.server"):
+                os.remove("exit.server")
             try:
-                while os.path.isfile("exit.server"):
+                while not os.path.isfile("exit.server"):
                     import time
 
                     time.sleep(1)
             except KeyboardInterrupt:
                 pass
+            ttexalens_server.stop()
+            return
         else:
-            input("Press Enter to exit server...")
-        ttexalens_server.stop()
-        return
+            args["--start-server"] = args["--port"]
 
     if args["--remote"]:
         address = args["--remote-address"].split(":")
@@ -414,7 +427,12 @@ def main():
         util.INFO(f"Connecting to TTExaLens server at {server_ip}:{server_port}")
         context = tt_exalens_init.init_ttexalens_remote(server_ip, int(server_port))
     else:
-        context = tt_exalens_init.init_ttexalens(wanted_devices, args["--jtag"], args["--use-noc1"])
+        context = tt_exalens_init.init_ttexalens(
+            wanted_devices=wanted_devices,
+            init_jtag=args["--jtag"],
+            use_noc1=args["--use-noc1"],
+            simulation_directory=args["-s"],
+        )
 
     # Main function
     exit_code = main_loop(args, context)

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -277,6 +277,12 @@ def main_loop(args, context):
                             if ui_state.gdb_server.is_connected:
                                 gdb_status += "(connected)"
                             my_prompt += f"gdb:{gdb_status} "
+                        noc_prompt = "1" if ui_state.context.use_noc1 else "0"
+                        if (
+                            ui_state.current_device._arch == "blackhole"
+                            or ui_state.current_device._arch == "wormhole_b0"
+                        ):
+                            my_prompt += f"noc:{util.CLR_PROMPT}{noc_prompt}{util.CLR_PROMPT_END} "
                         jtag_prompt = "JTAG" if ui_state.current_device._has_jtag else ""
                         my_prompt += (
                             f"device:{util.CLR_PROMPT}{jtag_prompt}{ui_state.current_device_id}{util.CLR_PROMPT_END} "

--- a/ttexalens/cli_commands/go.py
+++ b/ttexalens/cli_commands/go.py
@@ -3,15 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """
 Usage:
-  go [ -d <device> ] [ -l <loc> ]
+    go [-n <noc>] [ -d <device> ] [ -l <loc> ]
 
 Description:
-  Sets the current device/location.
+    Sets the current device/location.
 
 Examples:
-  go -d 0 -l 0,0
+    go -n 1 -d 0 -l 0,0
 """
 from ttexalens import command_parser
+import ttexalens.util as util
+from ttexalens.uistate import UIState
+from ttexalens.context import Context
 
 command_metadata = {
     "short": "go",
@@ -22,12 +25,19 @@ command_metadata = {
 }
 
 
-def run(cmd_text, context, ui_state=None):
+def run(cmd_text: str, context: Context, ui_state: UIState):
     dopt = command_parser.tt_docopt(
         command_metadata["description"],
         argv=cmd_text.split()[1:],
         common_option_names=command_metadata["common_option_names"],
     )
+
+    if dopt.args["-n"] and dopt.args["<noc>"] is not None:
+        noc = int(dopt.args["<noc>"])
+        if noc not in [0, 1]:
+            util.ERROR("NOC must be 0 or 1")
+            return
+        ui_state.context.use_noc1 = noc == 1
 
     for device in dopt.for_each("--device", context, ui_state):
         ui_state.current_device_id = device.id()

--- a/ttexalens/cli_commands/server.py
+++ b/ttexalens/cli_commands/server.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+"""
+Usage:
+  server start [--port <port>]
+  server stop
+
+Description:
+  Starts or stops tt-exalens server.
+
+Examples:
+  server start --port 5555
+  server stop
+"""
+
+from ttexalens.uistate import UIState
+from ttexalens import command_parser, util as util
+
+command_metadata = {
+    "short": "server",
+    "type": "high-level",
+    "description": __doc__,
+    "context": ["limited", "metal"],
+}
+
+
+def run(cmd_text, context, ui_state: UIState):
+    dopt = command_parser.tt_docopt(
+        command_metadata["description"],
+        argv=cmd_text.split()[1:],
+    )
+
+    if dopt.args["start"]:
+        try:
+            port = int(dopt.args["<port>"]) if dopt.args["<port>"] else None
+            ui_state.start_server(port)
+        except:
+            util.ERROR("Invalid port number")
+    elif dopt.args["stop"]:
+        ui_state.stop_server()
+    else:
+        util.ERROR("Invalid command")

--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -21,19 +21,22 @@ def init_ttexalens(
     wanted_devices: list | None = None,
     init_jtag: bool = False,
     use_noc1: bool = False,
+    simulation_directory: str | None = None,
 ) -> Context:
     """Initializes TTExaLens internals by creating the device interface and TTExaLens context.
     Interfacing device is local, through pybind.
 
     Args:
-            wanted_devices (list, optional): List of device IDs we want to connect to. If None, connect to all available devices.
-            caching_path (str, optional): Path to the cache file to write. If None, caching is disabled.
+        wanted_devices (list, optional): List of device IDs we want to connect to. If None, connect to all available devices.
+        init_jtag (bool): Whether to initialize JTAG interface. Default is False.
+        use_noc1 (bool): Whether to initialize with NOC1 and use NOC1 for communication with the device. Default is False.
+        simulation_directory (str, optional): If specified, starts the simulator from the given build output directory.
 
     Returns:
-            Context: TTExaLens context object.
+        Context: TTExaLens context object.
     """
 
-    lens_ifc = tt_exalens_ifc.init_pybind(wanted_devices, init_jtag, use_noc1)
+    lens_ifc = tt_exalens_ifc.init_pybind(wanted_devices, init_jtag, use_noc1, simulation_directory)
 
     return load_context(lens_ifc, use_noc1)
 
@@ -48,7 +51,6 @@ def init_ttexalens_remote(
     Args:
             ip_address (str): IP address of the TTExaLens server. Default is 'localhost'.
             port (int): Port number of the TTExaLens server interface. Default is 5555.
-            cache_path (str, optional): Path to the cache file to write. If None, caching is disabled.
 
     Returns:
             Context: TTExaLens context object.

--- a/ttexalens/tt_exalens_server.py
+++ b/ttexalens/tt_exalens_server.py
@@ -25,6 +25,7 @@ class TTExaLensServer:
 
     def stop(self):
         if self.daemon:
+            self.daemon.unregister(self.communicator)
             self.daemon.shutdown()
         if self.thread:
             self.thread.join()

--- a/ttexalens/uistate.py
+++ b/ttexalens/uistate.py
@@ -13,6 +13,7 @@ from prompt_toolkit.patch_stdout import patch_stdout
 from ttexalens.context import Context
 from ttexalens.gdb.gdb_server import GdbServer, ServerSocket
 from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.tt_exalens_server import TTExaLensServer, start_server
 
 
 class TTExaLensCompleter(Completer):
@@ -67,6 +68,7 @@ class UIState:
         self.current_location = OnChipCoordinate.create("0,0", self.current_device)  # Currently selected core
         self.current_prompt = ""  # Based on the current x,y
         self.gdb_server: GdbServer | None = None
+        self.ttexalens_server: TTExaLensServer | None = None  # TTExaLens server object
 
         # Create prompt object.
         self.is_prompt_session = sys.stdin.isatty()
@@ -104,3 +106,15 @@ class UIState:
         if self.gdb_server is not None:
             self.gdb_server.stop()
         self.gdb_server = None
+
+    def start_server(self, port: int | None = None):
+        if self.ttexalens_server is not None:
+            self.ttexalens_server.stop()
+        if port is None:
+            port = 5555
+        self.ttexalens_server = start_server(port, self.context.server_ifc)
+
+    def stop_server(self):
+        if self.ttexalens_server is not None:
+            self.ttexalens_server.stop()
+        self.ttexalens_server = None


### PR DESCRIPTION
We can now start server even after we start CLI app.
We can switch which noc we are using as default communication with device using `go -n 0|1`.
We can start simulator and then start exalens server if needed.
Fixed small bug with running server in the background.