### PR TITLE
Ignoring DW_TAG_label

### DIFF
--- a/ttexalens/parse_elf.py
+++ b/ttexalens/parse_elf.py
@@ -400,6 +400,7 @@ class ElfDie:
             or self.tag == "DW_TAG_GNU_template_parameter_pack"
             or self.tag == "DW_TAG_GNU_formal_parameter_pack"
             or self.tag == "DW_TAG_inheritance"
+            or self.tag == "DW_TAG_label"
         ):
             return None
         else:


### PR DESCRIPTION
Closes #610 

Ignoring `DW_TAG_label` when assigning category.