### PR TITLE
Reading private memory over NOC on blackhole

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -854,7 +854,7 @@ class TestARC(unittest.TestCase):
         {"location_desc": "FW0", "risc_name": "BRISC"},
         {"location_desc": "FW0", "risc_name": "TRISC0"},
         {"location_desc": "FW0", "risc_name": "TRISC1"},
-        # {"location_desc": "FW0", "risc_name": "TRISC2"}, - there is a bug on TRISC2: #266
+        {"location_desc": "FW0", "risc_name": "TRISC2"},
     ]
 )
 class TestCallStack(unittest.TestCase):

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from ttexalens import util
+from typing import Callable
 from ttexalens.hardware.baby_risc_debug import BabyRiscDebug
 from ttexalens.hardware.baby_risc_info import BabyRiscInfo
+from ttexalens.tt_exalens_lib import read_word_from_device
 from ttexalens.util import TTException
 
 
@@ -54,13 +55,22 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
     def read_memory(self, address: int):
         if self.enable_asserts:
             self.assert_not_in_reset()
-        self.assert_debug_hardware()
-        assert self.debug_hardware is not None, "Debug hardware is not initialized"
 
-        if self.risc_info.risc_name == "trisc2" and address % 16 > 4:
-            raise TTException(
-                f"Reading from trisc2 private memory address 0x{address:08x} does not work due to blackhole bug. For more information see issue #528 in tt-exalens repo."
-            )
+        read_memory: Callable[[int], int]
+        if self.risc_info.data_private_memory is not None and self.risc_info.data_private_memory.address.noc_address is not None and self.risc_info.data_private_memory.contains_private_address(address) and not self.is_in_reset():
+            # We can read from data memory directly if core is not in reset, but we need to update address to NOC address
+            assert self.risc_info.data_private_memory.address.private_address is not None
+            address = address - self.risc_info.data_private_memory.address.private_address + self.risc_info.data_private_memory.address.noc_address
+            read_memory = lambda addr: read_word_from_device(self.risc_info.noc_block.location, addr)
+        else:
+            self.assert_debug_hardware()
+            assert self.debug_hardware is not None, "Debug hardware is not initialized"
+
+            if self.risc_info.risc_name == "trisc2" and address % 16 > 4:
+                raise TTException(
+                    f"Reading from trisc2 private memory address 0x{address:08x} does not work due to blackhole bug. For more information see issue #528 in tt-exalens repo."
+                )
+            read_memory = self.debug_hardware.read_memory
 
         word_size_bytes = 4
         word_size_bits = word_size_bytes * 8
@@ -68,11 +78,11 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
         # We have to treat unaligned read separately due to blackhole bug
         if bytes_shifted == 0:
             # aligned read
-            return self.debug_hardware.read_memory(address)
+            return read_memory(address)
         else:
             # unaligned read
             bits_shifted = bytes_shifted * 8
-            word1 = self.debug_hardware.read_memory(address - bytes_shifted)
-            word2 = self.debug_hardware.read_memory(address + word_size_bytes - bytes_shifted)
+            word1 = read_memory(address - bytes_shifted)
+            word2 = read_memory(address + word_size_bytes - bytes_shifted)
             mask = (1 << (word_size_bits - bits_shifted)) - 1
             return ((word1 & mask) << bits_shifted) | (word2 >> (word_size_bits - bits_shifted))

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -57,10 +57,19 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
             self.assert_not_in_reset()
 
         read_memory: Callable[[int], int]
-        if self.risc_info.data_private_memory is not None and self.risc_info.data_private_memory.address.noc_address is not None and self.risc_info.data_private_memory.contains_private_address(address) and not self.is_in_reset():
+        if (
+            self.risc_info.data_private_memory is not None
+            and self.risc_info.data_private_memory.address.noc_address is not None
+            and self.risc_info.data_private_memory.contains_private_address(address)
+            and not self.is_in_reset()
+        ):
             # We can read from data memory directly if core is not in reset, but we need to update address to NOC address
             assert self.risc_info.data_private_memory.address.private_address is not None
-            address = address - self.risc_info.data_private_memory.address.private_address + self.risc_info.data_private_memory.address.noc_address
+            address = (
+                address
+                - self.risc_info.data_private_memory.address.private_address
+                + self.risc_info.data_private_memory.address.noc_address
+            )
             read_memory = lambda addr: read_word_from_device(self.risc_info.noc_block.location, addr)
         else:
             self.assert_debug_hardware()

--- a/ttexalens/hardware/blackhole/functional_worker_block.py
+++ b/ttexalens/hardware/blackhole/functional_worker_block.py
@@ -76,7 +76,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             code_start_address_register=None,  # We don't have a regsiter to override code start address
             data_private_memory=MemoryBlock(
                 size=8 * 1024,
-                address=DeviceAddress(private_address=0xFFB00000),
+                address=DeviceAddress(private_address=0xFFB00000, noc_address=0xFFB14000),
             ),
             code_private_memory=None,
             debug_hardware_present=True,
@@ -98,7 +98,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             code_start_address_enable_bit=0b001,
             data_private_memory=MemoryBlock(
                 size=4 * 1024,
-                address=DeviceAddress(private_address=0xFFB00000),
+                address=DeviceAddress(private_address=0xFFB00000, noc_address=0xFFB18000),
             ),
             code_private_memory=None,
             debug_hardware_present=True,
@@ -120,7 +120,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             code_start_address_enable_bit=0b010,
             data_private_memory=MemoryBlock(
                 size=4 * 1024,
-                address=DeviceAddress(private_address=0xFFB00000),
+                address=DeviceAddress(private_address=0xFFB00000, noc_address=0xFFB1A000),
             ),
             code_private_memory=None,
             debug_hardware_present=True,
@@ -142,7 +142,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             code_start_address_enable_bit=0b100,
             data_private_memory=MemoryBlock(
                 size=4 * 1024,
-                address=DeviceAddress(private_address=0xFFB00000),
+                address=DeviceAddress(private_address=0xFFB00000, noc_address=0xFFB1C000),
             ),
             code_private_memory=None,
             debug_hardware_present=True,
@@ -158,17 +158,13 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             reset_flag_shift=18,
             branch_prediction_register="DISABLE_RISC_BP_Disable_ncrisc",
             branch_prediction_mask=0x1,
-            default_code_start_address=0xFFC00000,
+            default_code_start_address=0x12000,
             code_start_address_register="NCRISC_RESET_PC_PC",
             code_start_address_enable_register="NCRISC_RESET_PC_OVERRIDE_Reset_PC_Override_en",
             code_start_address_enable_bit=0b1,
             data_private_memory=MemoryBlock(
-                size=4 * 1024,  # TODO #432: Check if this is correct
-                address=DeviceAddress(private_address=0xFFB00000),
-            ),
-            code_private_memory=MemoryBlock(
-                size=4 * 1024,  # TODO #432: This memory is removed on blackhole?!?
-                address=DeviceAddress(private_address=0xFFC00000),
+                size=8 * 1024,
+                address=DeviceAddress(private_address=0xFFB00000, noc_address=0xFFB16000),
             ),
             debug_hardware_present=False,
         )


### PR DESCRIPTION
Updating private memory location on blackhole that can be accessed over NOC.
Updating BlackholeBabyRiscDebug to use these addresses as there is a bug in debug hardware.
We needed to fix alignment issue for NOC reads as well.
Reenabling trisc2 tests (callstack) that were not working before.
Updating ncrisc parameters in functional_worker definition.