### PR TITLE
Moving to marshal serializer in pyro5

### DIFF
--- a/test/ttexalens/unit_tests/test_ttexalens_init.py
+++ b/test/ttexalens/unit_tests/test_ttexalens_init.py
@@ -68,7 +68,7 @@ class TestRemoteTTExaLens(unittest.TestCase):
             stream_content = stream.read(size).decode("utf-8")
             self.assertEqual(stream_content, "Hello, TTExaLens!")
 
-    def test_read_write_bytes(self):
+    def test_write_read_bytes(self):
         context = tt_exalens_init.init_ttexalens_remote()
         self.assertIsNotNone(context)
         self.assertIsInstance(context, Context)
@@ -84,6 +84,9 @@ class TestRemoteTTExaLens(unittest.TestCase):
 
         ret = lib.read_from_device(location, address, num_bytes=len(data), device_id=0, context=context)
         self.assertEqual(ret, data)
+
+        ret = lib.read_word_from_device(location, address, device_id=0, context=context)
+        self.assertEqual(ret, int.from_bytes(data, "little"))
 
 
 if __name__ == "__main__":

--- a/ttexalens/tt_exalens_ifc.py
+++ b/ttexalens/tt_exalens_ifc.py
@@ -110,7 +110,7 @@ class TTExaLensClientWrapper:
 
     def __getattr__(self, name):
         function = getattr(self.proxy, name)
-        return lambda *args, **kwargs: TTExaLensClientWrapper.convert_bytes(function(*args, **kwargs))
+        return lambda *args, **kwargs: function(*args, **kwargs)
 
     def get_binary(self, binary_path: str) -> io.BufferedIOBase:
         """
@@ -120,12 +120,6 @@ class TTExaLensClientWrapper:
         data = self.proxy.get_binary_content(binary_path)
         binary_data = serpent.tobytes(data)
         return io.BytesIO(binary_data)
-
-    @staticmethod
-    def convert_bytes(data):
-        if isinstance(data, dict) and data.get("encoding") == "base64" and "data" in data:
-            return base64.b64decode(data["data"])
-        return data
 
 
 def connect_to_server(server_host="localhost", port=5555) -> TTExaLensCommunicator:


### PR DESCRIPTION
Problem was that `bytes` were serialized as `dict`. When receiving from server, we could change result on client because it was result value. When sending to server, we cannot change all arguments on server side, so we switched to `marshal`.
This also solves `convert_bytes` from server as not needed...