### PR TITLE
Changed verbosity level of valid bit error from WARN to DEBUG

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -290,7 +290,7 @@ class BabyRiscDebugHardware:
 
         if self.enable_asserts:
             if not self.__is_read_valid():
-                util.WARN(f"Reading from RiscV debug registers failed (debug read valid bit is set to 0).")
+                util.DEBUG(f"Reading from RiscV debug registers failed (debug read valid bit is set to 0).")
         return self.__read(self.RISC_DBG_STATUS1)
 
     def enable_debug(self):


### PR DESCRIPTION
Changed verbosity level in valid bit is not set error in `__riscv_read` function from `WARN` to `DEBUG` to remove it from `tt-triage` output.