### PR TITLE
Bump CMake required version to 3.27

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -53,8 +53,13 @@ RUN pip install wheel build setuptools
 # Install build tools
 RUN apt-get update && apt-get install -y \
     ccache \
-    cmake \
     ninja-build
+
+# Install CMake 3.27 from official releases
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.27.9/cmake-3.27.9-linux-x86_64.sh && \
+    chmod +x cmake-3.27.9-linux-x86_64.sh && \
+    ./cmake-3.27.9-linux-x86_64.sh --skip-license --prefix=/usr/local && \
+    rm cmake-3.27.9-linux-x86_64.sh
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.16)
-cmake_policy(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
+cmake_policy(VERSION 3.27)
 
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/umd/CMakeLists.txt")

--- a/riscv-src/CMakeLists.txt
+++ b/riscv-src/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.16)
-cmake_policy(VERSION 3.16)
+cmake_minimum_required(VERSION 3.27)
+cmake_policy(VERSION 3.27)
 
 project(RISCVProject LANGUAGES CXX ASM)
 


### PR DESCRIPTION
This pull request updates the project's minimum required CMake version to 3.27 and ensures that the CI environment uses this specific version. The changes help maintain compatibility and leverage newer CMake features across the codebase.

CMake version upgrade:

* Updated `cmake_minimum_required` and `cmake_policy` to version 3.27 in both the main `CMakeLists.txt` and `riscv-src/CMakeLists.txt` files, replacing the previous requirement of version 3.16. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R2) [[2]](diffhunk://#diff-bd52460121a7c4f67634bcb48be50bc1a8d6b9469535cda32595a0ada76a8998L1-R2)

CI environment update:

* Modified `.github/Dockerfile.ci` to install CMake 3.27.9 directly from the official releases, instead of using the system package manager, ensuring the CI uses the correct CMake version.