### PR TITLE
Enhancing ElfVariable API

### DIFF
--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -11,6 +11,42 @@ from ttexalens.firmware import ELF
 from ttexalens.parse_elf import mem_access
 
 
+class MemoryReaderWrapper:
+    """
+    Wrapper around ELF memory reader that collects basic statistics about memory access.
+    Maintains the same interface as the original memory reader.
+    """
+
+    def __init__(self, mem_reader):
+        self._mem_reader = mem_reader
+        self.call_count = 0
+        self.total_bytes_transferred = 0
+
+    def __call__(self, address: int, size_bytes: int, elements_to_read: int) -> list[int]:
+        """
+        Call the underlying memory reader and collect statistics.
+
+        Args:
+            address: Memory address to read from
+            size_bytes: Total number of bytes to read
+            elements_to_read: Number of elements to read
+
+        Returns:
+            List of integers read from memory
+        """
+        # Update statistics
+        self.call_count += 1
+        self.total_bytes_transferred += size_bytes
+
+        # Call the actual memory reader
+        return self._mem_reader(address, size_bytes, elements_to_read)
+
+    def reset_stats(self):
+        """Reset all statistics counters."""
+        self.call_count = 0
+        self.total_bytes_transferred = 0
+
+
 class TestDebugSymbols(unittest.TestCase):
     context: Context  # TTExaLens context
     core_sim: RiscvCoreSimulator  # RISC-V core simulator instance
@@ -27,9 +63,13 @@ class TestDebugSymbols(unittest.TestCase):
         )
         cls.core_sim.load_elf("globals_test.release")
         cls.parsed_elf = cls.core_sim.parse_elf("globals_test.release")
-        cls.mem_reader = ELF.get_mem_reader(
+
+        # Create the memory reader wrapper
+        original_mem_reader = ELF.get_mem_reader(
             risc_debug.risc_location.location, risc_debug.risc_location.risc_name, risc_debug.risc_location.neo_id
         )
+        cls.mem_reader = MemoryReaderWrapper(original_mem_reader)
+
         assert not cls.core_sim.is_in_reset()
 
     @classmethod
@@ -70,35 +110,62 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(0, self.mem_access("g_global_struct.u.words[0]"))
         self.assertEqual(16128, self.mem_access("g_global_struct.u.words[1]"))
 
-    def verify_global_struct(self, g_global_struct):
-        self.assertEqual(0x11223344, g_global_struct.a.value())
-        self.assertEqual(0x5566778899AABBCC, g_global_struct.b.value())
+    def verify_global_struct_low_level(self, g_global_struct):
+        self.assertEqual(0x11223344, g_global_struct.a.get_value())
+        self.assertEqual(0x5566778899AABBCC, g_global_struct.b.get_value())
         self.assertEqual(16, len(g_global_struct.c))
         for i in range(16):
-            self.assertEqual(i, g_global_struct.c[i].value())
+            self.assertEqual(i, g_global_struct.c[i].get_value())
         self.assertEqual(4, len(g_global_struct.d))
         for i in range(4):
-            self.assertEqual(i * 2, g_global_struct.d[i].x.value())
-            self.assertEqual(i * 2 + 1, g_global_struct.d[i].y.value())
-        self.assertEqual(2, g_global_struct.f.value())
-        self.assertEqual(2.718281828459, g_global_struct.g.value())
+            self.assertEqual(i * 2, g_global_struct.d[i].x.get_value())
+            self.assertEqual(i * 2 + 1, g_global_struct.d[i].y.get_value())
+        self.assertEqual(2, g_global_struct.f.get_value())
+        self.assertEqual(2.718281828459, g_global_struct.g.get_value())
         self.assertEqual(8, len(g_global_struct.h))
         for i in range(8):
-            self.assertEqual(i % 2 == 0, g_global_struct.h[i].value())
-        self.assertEqual(2 * 2, g_global_struct.p.x.value())
-        self.assertEqual(2 * 2 + 1, g_global_struct.p.y.value())
-        self.assertEqual(1056964608, g_global_struct.u.u32.value())
-        self.assertEqual(0.5, g_global_struct.u.f32.value())
-        self.assertEqual(0, g_global_struct.u.bytes[0].value())
-        self.assertEqual(0, g_global_struct.u.bytes[1].value())
-        self.assertEqual(0, g_global_struct.u.bytes[2].value())
-        self.assertEqual(63, g_global_struct.u.bytes[3].value())
-        self.assertEqual(0, g_global_struct.u.words[0].value())
-        self.assertEqual(16128, g_global_struct.u.words[1].value())
-        self.assertEqual(0x12345678, g_global_struct.msg.test.value())
-        self.assertEqual(0xAABBCCDD, g_global_struct.msg.packed.value())
-        self.assertEqual(0xAA, g_global_struct.msg.signal.value())
-        self.assertEqual(0x87654321, g_global_struct.msg.test2.value())
+            self.assertEqual(i % 2 == 0, g_global_struct.h[i].get_value())
+        self.assertEqual(2 * 2, g_global_struct.p.x.get_value())
+        self.assertEqual(2 * 2 + 1, g_global_struct.p.y.get_value())
+        self.assertEqual(1056964608, g_global_struct.u.u32.get_value())
+        self.assertEqual(0.5, g_global_struct.u.f32.get_value())
+        self.assertEqual(0, g_global_struct.u.bytes[0].get_value())
+        self.assertEqual(0, g_global_struct.u.bytes[1].get_value())
+        self.assertEqual(0, g_global_struct.u.bytes[2].get_value())
+        self.assertEqual(63, g_global_struct.u.bytes[3].get_value())
+        self.assertEqual(0, g_global_struct.u.words[0].get_value())
+        self.assertEqual(16128, g_global_struct.u.words[1].get_value())
+        self.assertEqual(0x12345678, g_global_struct.msg.test.get_value())
+        self.assertEqual(0xAABBCCDD, g_global_struct.msg.packed.get_value())
+        self.assertEqual(0xAA, g_global_struct.msg.signal.get_value())
+        self.assertEqual(0x87654321, g_global_struct.msg.test2.get_value())
+
+    def verify_global_struct(self, g_global_struct):
+        self.assertEqual(0x11223344, g_global_struct.a)
+        self.assertEqual(0x5566778899AABBCC, g_global_struct.b)
+        self.assertEqual([i for i in range(16)], g_global_struct.c)
+        self.assertEqual(4, len(g_global_struct.d))
+        for i in range(4):
+            self.assertEqual(i * 2, g_global_struct.d[i].x)
+            self.assertEqual(i * 2 + 1, g_global_struct.d[i].y)
+        self.assertEqual(2, g_global_struct.f)
+        self.assertEqual(2.718281828459, g_global_struct.g)
+        self.assertEqual([i % 2 == 0 for i in range(8)], g_global_struct.h)
+        self.assertEqual(2 * 2, g_global_struct.p.x)
+        self.assertEqual(2 * 2 + 1, g_global_struct.p.y)
+        self.assertEqual(1056964608, g_global_struct.u.u32)
+        self.assertEqual(0.5, g_global_struct.u.f32)
+        self.assertEqual([0, 0, 0, 63], g_global_struct.u.bytes)
+        self.assertEqual([0, 16128], g_global_struct.u.words)
+        self.assertEqual(0x12345678, g_global_struct.msg.test)
+        self.assertEqual(0xAABBCCDD, g_global_struct.msg.packed)
+        self.assertEqual(0xAA, g_global_struct.msg.signal)
+        self.assertEqual(0x87654321, g_global_struct.msg.test2)
+
+    def test_elf_variable_low_level(self):
+        variable_die = self.parsed_elf.variables["g_global_struct"]
+        g_global_struct = ElfVariable(variable_die.resolved_type, variable_die.address, TestDebugSymbols.mem_reader)
+        self.verify_global_struct_low_level(g_global_struct)
 
     def test_elf_variable(self):
         variable_die = self.parsed_elf.variables["g_global_struct"]
@@ -111,23 +178,160 @@ class TestDebugSymbols(unittest.TestCase):
         self.verify_global_struct(g_global_struct.read())
 
     def test_elf_global_variable(self):
+        self.mem_reader.reset_stats()
         g_global_struct = self.parsed_elf.get_global("g_global_struct", TestDebugSymbols.mem_reader)
         self.verify_global_struct(g_global_struct)
+        self.assertGreater(self.mem_reader.call_count, 1)
 
     def test_read_elf_global_variable(self):
+        self.mem_reader.reset_stats()
         g_global_struct = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_reader)
         self.verify_global_struct(g_global_struct)
+        self.assertEqual(self.mem_reader.call_count, 1)
 
     def test_elf_const_global_variable(self):
         g_global_struct = self.parsed_elf.get_global("g_global_const_struct_ptr", TestDebugSymbols.mem_reader)
         self.verify_global_struct(g_global_struct)
 
     def test_read_elf_const_global_variable(self):
+        self.mem_reader.reset_stats()
         g_global_struct = self.parsed_elf.read_global("g_global_const_struct_ptr", TestDebugSymbols.mem_reader)
         self.verify_global_struct(g_global_struct)
+        self.assertEqual(self.mem_reader.call_count, 1)
 
     def test_elf_variable_constants(self):
         self.assertEqual(0x11223344, self.parsed_elf.get_constant("c_uint32_t"))
         self.assertEqual(0x5566778899AABBCC, self.parsed_elf.get_constant("c_uint64_t"))
         self.assertEqual(0.5, self.parsed_elf.get_constant("c_float"))
         self.assertEqual(2.718281828459, self.parsed_elf.get_constant("c_double"))
+
+    def test_elf_variable_array_iteration(self):
+        variable_die = self.parsed_elf.variables["g_global_struct"]
+        g_global_struct = ElfVariable(variable_die.resolved_type, variable_die.address, TestDebugSymbols.mem_reader)
+        c_values = [var.get_value() for var in g_global_struct.c]
+        self.assertEqual(list(range(16)), c_values)
+        d_x_values = [var.x.get_value() for var in g_global_struct.d]
+        d_y_values = [var.y.get_value() for var in g_global_struct.d]
+        self.assertEqual([i * 2 for i in range(4)], d_x_values)
+        self.assertEqual([i * 2 + 1 for i in range(4)], d_y_values)
+        h_values = [var.get_value() for var in g_global_struct.h]
+        self.assertEqual([i % 2 == 0 for i in range(8)], h_values)
+
+    def test_elf_variable_array_as_list(self):
+        variable_die = self.parsed_elf.variables["g_global_struct"]
+        g_global_struct = ElfVariable(variable_die.resolved_type, variable_die.address, TestDebugSymbols.mem_reader)
+        c_values = [var.get_value() for var in g_global_struct.c.as_list()]
+        self.assertEqual(list(range(16)), c_values)
+        d_x_values = [var.x.get_value() for var in g_global_struct.d.as_list()]
+        d_y_values = [var.y.get_value() for var in g_global_struct.d.as_list()]
+        self.assertEqual([i * 2 for i in range(4)], d_x_values)
+        self.assertEqual([i * 2 + 1 for i in range(4)], d_y_values)
+        h_values = [var.get_value() for var in g_global_struct.h.as_list()]
+        self.assertEqual([i % 2 == 0 for i in range(8)], h_values)
+
+    def test_elf_variable_array_as_value_list(self):
+        variable_die = self.parsed_elf.variables["g_global_struct"]
+        g_global_struct = ElfVariable(variable_die.resolved_type, variable_die.address, TestDebugSymbols.mem_reader)
+        c_values = g_global_struct.c.as_value_list()
+        self.assertEqual(list(range(16)), c_values)
+        d_x_values = [var.x.get_value() for var in g_global_struct.d.as_list()]
+        d_y_values = [var.y.get_value() for var in g_global_struct.d.as_list()]
+        self.assertEqual([i * 2 for i in range(4)], d_x_values)
+        self.assertEqual([i * 2 + 1 for i in range(4)], d_y_values)
+        h_values = g_global_struct.h.as_value_list()
+        self.assertEqual([i % 2 == 0 for i in range(8)], h_values)
+
+    def test_elf_variable_operators(self):
+        """Test arithmetic, bitwise, and comparison operators"""
+        self.mem_reader.reset_stats()
+
+        g_global_struct = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_reader)
+
+        # Test that we didn't do any additional memory reads
+        self.assertEqual(self.mem_reader.call_count, 1)
+
+        # Reset memory reader stats
+        self.mem_reader.reset_stats()
+
+        # Test comparison operators with integers
+        self.assertTrue(g_global_struct.a == g_global_struct.a)
+        self.assertTrue(0x11223344 == g_global_struct.a)
+        self.assertTrue(0x12345678 != g_global_struct.a)
+        self.assertTrue(g_global_struct.a == 0x11223344)
+        self.assertTrue(g_global_struct.a != 0x12345678)
+        self.assertTrue(g_global_struct.c[5] < 10)
+        self.assertTrue(g_global_struct.c[5] <= 5)
+        self.assertTrue(g_global_struct.c[10] > 5)
+        self.assertTrue(g_global_struct.c[10] >= 10)
+
+        # Test comparison operators with floats
+        self.assertTrue(g_global_struct.f < 3.0)
+        self.assertTrue(g_global_struct.f >= 2.0)
+        self.assertTrue(g_global_struct.g > 2.7)
+        self.assertTrue(g_global_struct.g <= 2.8)
+
+        # Test arithmetic operators
+        self.assertEqual(g_global_struct.c[5] + 10, 15)  # 5 + 10
+        self.assertEqual(g_global_struct.c[8] - 3, 5)  # 8 - 3
+        self.assertEqual(g_global_struct.c[4] * 3, 12)  # 4 * 3
+        self.assertEqual(g_global_struct.c[6] / 2, 3.0)  # 6 / 2
+        self.assertEqual(g_global_struct.c[7] // 2, 3)  # 7 // 2
+        self.assertEqual(g_global_struct.c[9] % 4, 1)  # 9 % 4
+        self.assertEqual(g_global_struct.c[2] ** 3, 8)  # 2 ** 3
+
+        # Test reverse arithmetic operators
+        self.assertEqual(20 - g_global_struct.c[3], 17)  # 20 - 3
+        self.assertEqual(2 * g_global_struct.c[6], 12)  # 2 * 6
+        self.assertEqual(100 / g_global_struct.c[4], 25.0)  # 100 / 4
+
+        # Test bitwise operators with integers
+        self.assertEqual(g_global_struct.a & 0xFF, 0x44)  # 0x11223344 & 0xFF
+        self.assertEqual(g_global_struct.c[1] | 0xF0, 0xF1)  # 1 | 0xF0
+        self.assertEqual(g_global_struct.c[5] ^ 0x0F, 0x0A)  # 5 ^ 0x0F
+        self.assertEqual(g_global_struct.c[2] << 2, 8)  # 2 << 2
+        self.assertEqual(g_global_struct.c[8] >> 1, 4)  # 8 >> 1
+
+        # Test reverse bitwise operators
+        self.assertEqual(0xFF & g_global_struct.a, 0x44)  # 0xFF & 0x11223344
+        self.assertEqual(0xF0 | g_global_struct.c[1], 0xF1)  # 0xF0 | 1
+        self.assertEqual(0x0F ^ g_global_struct.c[5], 0x0A)  # 0x0F ^ 5
+
+        # Test bitwise operators with booleans
+        self.assertTrue(g_global_struct.h[0] & True)  # True & True
+        self.assertFalse(g_global_struct.h[1] & True)  # False & True
+        self.assertTrue(g_global_struct.h[1] | True)  # False | True
+        self.assertTrue(g_global_struct.h[0] ^ False)  # True ^ False
+
+        # Test unary operators
+        self.assertEqual(-g_global_struct.c[5], -5)  # -5
+        self.assertEqual(+g_global_struct.c[7], 7)  # +7
+        self.assertEqual(abs(-g_global_struct.c[3]), 3)  # abs(-3) = 3
+        self.assertEqual(~g_global_struct.c[0], -1)  # ~0 = -1
+        self.assertEqual(~g_global_struct.h[0], -2)  # ~True = ~1 = -2
+
+        # Test __index__ operator (ElfVariable as index)
+        test_list = [10, 20, 30, 40, 50]
+        self.assertEqual(test_list[g_global_struct.c[2]], 30)  # test_list[2]
+        self.assertEqual(test_list[g_global_struct.c[4]], 50)  # test_list[4]
+
+        # Test string representation
+        self.assertEqual(str(g_global_struct.c[5]), "5")
+        self.assertEqual(str(g_global_struct.f), "2.0")
+        self.assertEqual(str(g_global_struct.h[0]), "True")
+        self.assertEqual(str(g_global_struct.h[1]), "False")
+
+        # Test array equality
+        self.assertEqual(g_global_struct.c, list(range(16)))
+        self.assertEqual(g_global_struct.h, [i % 2 == 0 for i in range(8)])
+        self.assertEqual(g_global_struct.u.get_member("bytes"), [0, 0, 0, 63])
+        self.assertEqual(g_global_struct.u.words, [0, 16128])
+
+        # Test dictionary-style access
+        self.assertEqual(g_global_struct["a"], 0x11223344)
+        self.assertEqual(g_global_struct["c"][5], 5)
+        self.assertEqual(g_global_struct["u"]["u32"], 1056964608)
+        self.assertEqual(g_global_struct["u"].get_member("bytes")[3], 63)
+
+        # Test that we didn't do any additional memory reads
+        self.assertEqual(self.mem_reader.call_count, 0)
+        self.assertEqual(self.mem_reader.total_bytes_transferred, 0)

--- a/ttexalens/elf/variable.py
+++ b/ttexalens/elf/variable.py
@@ -12,29 +12,42 @@ if TYPE_CHECKING:
 
 class ElfVariable:
     def __init__(self, type_die: ElfDie, address: int, mem_access_function: Callable[[int, int, int], list[int]]):
-        self.type_die = type_die
-        self.address = address
-        self.mem_access_function = mem_access_function
+        self.__type_die = type_die
+        self.__address = address
+        self.__mem_access_function = mem_access_function
 
     def __getattr__(self, member_name) -> "ElfVariable":
-        if self.type_die.tag_is("pointer_type"):
-            assert self.type_die.size is not None
-            address = self.mem_access_function(self.address, self.type_die.size, 1)[0]
-            dereferenced_pointer = ElfVariable(self.type_die.dereference_type, address, self.mem_access_function)
-            return getattr(dereferenced_pointer, member_name)
+        # __getattr__ is only called when the attribute is not found through normal lookup
+        # This means if we get here, the member_name is not a method/attribute of this class
+        return self.get_member(member_name)
+
+    def get_member(self, member_name: str) -> "ElfVariable":
+        """
+        Explicitly get a struct/union member by name, bypassing method name collisions.
+        Use this when you have a struct field with the same name as a class method.
+
+        Example: var.get_member('bytes') instead of var.bytes
+        """
+        if self.__type_die.tag_is("pointer_type"):
+            assert self.__type_die.size is not None
+            address = self.__mem_access_function(self.__address, self.__type_die.size, 1)[0]
+            dereferenced_pointer = ElfVariable(self.__type_die.dereference_type, address, self.__mem_access_function)
+            return dereferenced_pointer.get_member(member_name)
         offset = 0
-        child_die = self.type_die.get_child_by_name(member_name)
-        if not child_die:
-            offset, child_die = ElfVariable._resolve_unnamed_struct_union_member(self.type_die, member_name)
-        if not child_die:
-            assert self.type_die.path is not None
-            member_path = self.type_die.path + "::" + member_name
+        child_die = self.__type_die.get_child_by_name(member_name)
+        if child_die is None:
+            offset, child_die = ElfVariable._resolve_unnamed_struct_union_member(self.__type_die, member_name)
+        if child_die is None or offset is None:
+            assert self.__type_die.path is not None
+            member_path = self.__type_die.path + "::" + member_name
             raise Exception(f"ERROR: Cannot find {member_path}")
-        assert self.address is not None and child_die.address is not None
-        return ElfVariable(child_die.resolved_type, self.address + child_die.address + offset, self.mem_access_function)
+        assert self.__address is not None and child_die.address is not None
+        return ElfVariable(
+            child_die.resolved_type, self.__address + child_die.address + offset, self.__mem_access_function
+        )
 
     @staticmethod
-    def _resolve_unnamed_struct_union_member(type_die: ElfDie, member_name: str):
+    def _resolve_unnamed_struct_union_member(type_die: ElfDie, member_name: str) -> tuple[int | None, ElfDie | None]:
         """
         Given a die that contains an unnamed union of type type_die, and a member path
         represening a member of the unnamed union, return the die of the unnamed union.
@@ -50,63 +63,444 @@ class ElfVariable:
                     return address + child.address, member
         return None, None
 
-    def __getitem__(self, index: int) -> "ElfVariable":
-        if not self.type_die.tag_is("array_type") and not self.type_die.tag_is("pointer_type"):
-            raise Exception(f"ERROR: {self.type_die.name} is not an array or pointer")
+    def __getitem__(self, key: str | int) -> "ElfVariable":
+        # Handle string keys for struct/union member access
+        if isinstance(key, str):
+            return self.get_member(key)
 
-        if self.type_die.tag_is("pointer_type"):
-            array_element_type = self.type_die.dereference_type
-        else:
-            array_element_type = self.type_die.array_element_type
+        # Handle integer keys for array/pointer indexing
+        if isinstance(key, int):
+            if not self.__type_die.tag_is("array_type") and not self.__type_die.tag_is("pointer_type"):
+                raise Exception(f"ERROR: {self.__type_die.name} is not an array or pointer")
 
-        new_address = self.address + index * array_element_type.size
-        return ElfVariable(array_element_type, new_address, self.mem_access_function)
+            if self.__type_die.tag_is("pointer_type"):
+                array_element_type = self.__type_die.dereference_type
+            else:
+                array_element_type = self.__type_die.array_element_type
 
-    def __len__(self):
+            new_address = self.__address + key * array_element_type.size
+            return ElfVariable(array_element_type, new_address, self.__mem_access_function)
+
+        # Handle other types that might be used as indices (like ElfVariable with __index__)
+        try:
+            index = int(key)
+            return self[index]  # Recursive call with the converted integer
+        except (TypeError, ValueError):
+            raise TypeError(f"ElfVariable indices must be integers or strings, not {type(key).__name__}")
+
+    def __len__(self) -> int:
         """
         Return the number of elements in the array
         """
-        if not self.type_die.tag_is("array_type"):
-            raise Exception(f"ERROR: {self.type_die.name} is not an array")
+        if not self.__type_die.tag_is("array_type"):
+            raise Exception(f"ERROR: {self.__type_die.name} is not an array")
 
         # For arrays, calculate total number of elements in the first dimension
-        for child in self.type_die.iter_children():
+        for child in self.__type_die.iter_children():
             if "DW_AT_upper_bound" in child.attributes:
                 upper_bound = child.attributes["DW_AT_upper_bound"].value
                 return upper_bound + 1  # Return first dimension size
 
         # If no upper bound found, this might be a flexible array member
-        raise Exception(f"ERROR: Cannot determine length of array {self.type_die.name}")
+        raise Exception(f"ERROR: Cannot determine length of array {self.__type_die.name}")
 
-    def value(self):
+    def __iter__(self):
+        """
+        Enable iteration over array elements
+        """
+        length = len(self)
+        for i in range(length):
+            yield self[i]
+
+    def as_list(self) -> list["ElfVariable"]:
+        """
+        Return the array elements as a list
+        """
+        return [self[i] for i in range(len(self))]
+
+    def as_value_list(self) -> list[int | float | bool]:
+        """
+        Return the array elements as a list of values
+        """
+        return [self[i].get_value() for i in range(len(self))]
+
+    def get_value(self) -> int | float | bool:
         # Check that type_die is a basic type
-        if not self.type_die.tag_is("base_type"):
-            raise Exception(f"ERROR: {self.type_die.name} is not a base type")
+        if not self.__type_die.tag_is("base_type"):
+            raise Exception(f"ERROR: {self.__type_die.name} is not a base type")
 
         # Read the value from memory
-        assert self.type_die.size is not None
-        value = self.mem_access_function(self.address, self.type_die.size, 1)[0]
+        assert self.__type_die.size is not None
+        value = self.__mem_access_function(self.__address, self.__type_die.size, 1)[0]
 
         # Convert the value to the appropriate type
-        if self.type_die.name == "float":
+        if self.__type_die.name == "float":
             return struct.unpack("f", struct.pack("I", value))[0]
-        elif self.type_die.name == "double":
+        elif self.__type_die.name == "double":
             return struct.unpack("d", struct.pack("Q", value))[0]
-        elif self.type_die.name == "bool":
+        elif self.__type_die.name == "bool":
             return bool(value)
         else:
             return value
 
-    def read(self):
-        if self.type_die.tag_is("pointer_type"):
-            assert self.type_die.size is not None
-            address = self.mem_access_function(self.address, self.type_die.size, 1)[0]
-            dereferenced_pointer = ElfVariable(self.type_die.dereference_type, address, self.mem_access_function)
+    def __eq__(self, other) -> bool:
+        """
+        Compare the ElfVariable's value with another value.
+        For base types, compares the actual value.
+        For arrays, compares element-by-element with the other sequence.
+        """
+        try:
+            # Try to get the value for base types
+            return self.get_value() == other
+        except Exception:
+            # If get_value() fails, check if this is an array and other is a sequence
+            try:
+                if self.__type_die.tag_is("array_type"):
+                    # Check if other is a sequence (list, tuple, etc.)
+                    if hasattr(other, "__len__") and hasattr(other, "__getitem__"):
+                        # Compare lengths first for efficiency
+                        if len(self) != len(other):
+                            return False
+                        # Compare each element
+                        for i in range(len(self)):
+                            if self[i] != other[i]:
+                                return False
+                        return True
+            except Exception:
+                pass
+            # If neither value comparison nor array comparison worked, return False
+            return False
+
+    def __lt__(self, other) -> bool:
+        """
+        Less than comparison. Works with base types only.
+        """
+        try:
+            return self.get_value() < other
+        except Exception:
+            return NotImplemented
+
+    def __le__(self, other) -> bool:
+        """Less than or equal comparison."""
+        return self < other or self == other
+
+    def __gt__(self, other) -> bool:
+        """
+        Greater than comparison. Works with base types only.
+        """
+        try:
+            return self.get_value() > other
+        except Exception:
+            return NotImplemented
+
+    def __ge__(self, other) -> bool:
+        """Greater than or equal comparison."""
+        return self > other or self == other
+
+    # Arithmetic operators
+    def __add__(self, other):
+        """Addition operator."""
+        try:
+            return self.get_value() + other
+        except Exception:
+            return NotImplemented
+
+    def __radd__(self, other):
+        """Reverse addition operator."""
+        try:
+            return other + self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __sub__(self, other):
+        """Subtraction operator."""
+        try:
+            return self.get_value() - other
+        except Exception:
+            return NotImplemented
+
+    def __rsub__(self, other):
+        """Reverse subtraction operator."""
+        try:
+            return other - self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __mul__(self, other):
+        """Multiplication operator."""
+        try:
+            return self.get_value() * other
+        except Exception:
+            return NotImplemented
+
+    def __rmul__(self, other):
+        """Reverse multiplication operator."""
+        try:
+            return other * self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __truediv__(self, other):
+        """Division operator."""
+        try:
+            return self.get_value() / other
+        except Exception:
+            return NotImplemented
+
+    def __rtruediv__(self, other):
+        """Reverse division operator."""
+        try:
+            return other / self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __floordiv__(self, other):
+        """Floor division operator."""
+        try:
+            return self.get_value() // other
+        except Exception:
+            return NotImplemented
+
+    def __rfloordiv__(self, other):
+        """Reverse floor division operator."""
+        try:
+            return other // self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __mod__(self, other):
+        """Modulo operator."""
+        try:
+            return self.get_value() % other
+        except Exception:
+            return NotImplemented
+
+    def __rmod__(self, other):
+        """Reverse modulo operator."""
+        try:
+            return other % self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __pow__(self, other):
+        """Power operator."""
+        try:
+            return self.get_value() ** other
+        except Exception:
+            return NotImplemented
+
+    def __rpow__(self, other):
+        """Reverse power operator."""
+        try:
+            return other ** self.get_value()
+        except Exception:
+            return NotImplemented
+
+    # Bitwise operators (for integers and booleans)
+    def __and__(self, other):
+        """Bitwise AND operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return value & other
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __rand__(self, other):
+        """Reverse bitwise AND operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return other & value
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __or__(self, other):
+        """Bitwise OR operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return value | other
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __ror__(self, other):
+        """Reverse bitwise OR operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return other | value
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __xor__(self, other):
+        """Bitwise XOR operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return value ^ other
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __rxor__(self, other):
+        """Reverse bitwise XOR operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return other ^ value
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __lshift__(self, other):
+        """Left shift operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, int):
+                return value << other
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __rlshift__(self, other):
+        """Reverse left shift operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, int):
+                return other << value
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __rshift__(self, other):
+        """Right shift operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, int):
+                return value >> other
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __rrshift__(self, other):
+        """Reverse right shift operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, int):
+                return other >> value
+        except Exception:
+            pass
+        return NotImplemented
+
+    # Unary operators
+    def __neg__(self):
+        """Unary negation operator."""
+        try:
+            return -self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __pos__(self):
+        """Unary positive operator."""
+        try:
+            return +self.get_value()
+        except Exception:
+            return NotImplemented
+
+    def __abs__(self):
+        """Absolute value operator."""
+        try:
+            return abs(self.get_value())
+        except Exception:
+            return NotImplemented
+
+    def __invert__(self):
+        """Bitwise inversion operator."""
+        try:
+            value = self.get_value()
+            if isinstance(value, (int, bool)):
+                return ~value
+        except Exception:
+            pass
+        return NotImplemented
+
+    def __index__(self) -> int:
+        """
+        Allow ElfVariable to be used as an index in sequences (lists, tuples, etc.)
+        This enables usage like: a[elf_var] instead of a[elf_var.value()]
+        """
+        try:
+            value = self.get_value()
+            if isinstance(value, int):
+                return value
+            elif isinstance(value, bool):
+                return int(value)  # Convert bool to int (True -> 1, False -> 0)
+            elif isinstance(value, float):
+                if value.is_integer():
+                    return int(value)
+        except:
+            pass
+        raise TypeError(f"ElfVariable '{self}' cannot be used as an index")
+
+    def __str__(self) -> str:
+        """
+        String representation of the ElfVariable's value
+        This enables usage like: str(elf_var) instead of str(elf_var.value())
+        """
+        try:
+            return str(self.get_value())
+        except Exception:
+            # If get_value() fails (e.g., not a base type), fall back to __repr__
+            return self.__repr__()
+
+    def __repr__(self) -> str:
+        """
+        Detailed string representation for debugging purposes
+        Shows internal state including type, address, and other relevant information
+        """
+        type_name = getattr(self.__type_die, "name", "Unknown")
+        type_tag = getattr(self.__type_die, "tag", "Unknown")
+        type_size = getattr(self.__type_die, "size", "Unknown")
+
+        # Try to get the value for additional context
+        try:
+            value_info = f", value={self.get_value()!r}"
+        except Exception:
+            value_info = ""
+
+        # Try to get the length for arrays
+        try:
+            length_info = f", length={len(self)}"
+        except Exception:
+            length_info = ""
+
+        return (
+            f"ElfVariable(type_name='{type_name}', type_tag='{type_tag}', "
+            f"size={type_size}, address=0x{self.__address:x}{value_info}{length_info})"
+        )
+
+    def get_address(self) -> int:
+        return self.__address
+
+    def get_bytes(self) -> bytes:
+        size = self.__type_die.size
+        assert size is not None
+        int_bytes = self.__mem_access_function(self.__address, size, size)
+        return bytes(int_bytes)
+
+    def read(self) -> "ElfVariable":
+        if self.__type_die.tag_is("pointer_type"):
+            assert self.__type_die.size is not None
+            address = self.__mem_access_function(self.__address, self.__type_die.size, 1)[0]
+            dereferenced_pointer = ElfVariable(self.__type_die.dereference_type, address, self.__mem_access_function)
             return dereferenced_pointer.read()
-        assert self.type_die.size is not None
-        int_bytes = self.mem_access_function(self.address, self.type_die.size, self.type_die.size)
-        data = bytes(int_bytes)
-        address = self.address
+        data = self.get_bytes()
+        address = self.__address
 
         def mem_access(addr: int, size_bytes: int, elements_to_read: int) -> list[int]:
             if elements_to_read == 0:
@@ -120,6 +514,6 @@ class ElfVariable:
                     int.from_bytes(bytes_data[i * element_size : (i + 1) * element_size], byteorder="little")
                     for i in range(elements_to_read)
                 ]
-            return self.mem_access_function(addr, size_bytes, elements_to_read)
+            return self.__mem_access_function(addr, size_bytes, elements_to_read)
 
-        return ElfVariable(self.type_die, self.address, mem_access)
+        return ElfVariable(self.__type_die, self.__address, mem_access)


### PR DESCRIPTION
Enhance the robustness of API interactions with ElfVariable.
Implementing many Python operators which makes it convinient to use ElfVariable very similar to any python variable.
Because of name collision, added method `get_member` and also upgraded `__getitem__` to support getting members that are hidden with implemented methods of ElfVariable class.

Added tests to cover new changes.
Also verifying that once you `read` variable, code won't trigger additional reads.

In comparisson, when running tests with `get_global` there are 52 reads happening to test all values. When using `read_global` single read fetches all the data. This solves performance of variable querying and both solves taking snapshots of the variable memory... One could take snapshots over time and compare them...