### PR TITLE
Add hash method to ElfVariable and rename get_bytes to read_bytes

### DIFF
--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -335,3 +335,14 @@ class TestDebugSymbols(unittest.TestCase):
         # Test that we didn't do any additional memory reads
         self.assertEqual(self.mem_reader.call_count, 0)
         self.assertEqual(self.mem_reader.total_bytes_transferred, 0)
+
+    def test_elf_variable_hash(self):
+        g_global_struct1 = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_reader)
+        g_global_struct2 = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_reader)
+        self.assertEqual(hash(g_global_struct1), hash(g_global_struct2))
+        self.assertEqual(hash(g_global_struct1.a), hash(g_global_struct2.a))
+        self.assertEqual(hash(g_global_struct1.b), hash(g_global_struct2.b))
+        self.assertEqual(hash(g_global_struct1.c[5]), hash(g_global_struct2.c[5]))
+        self.assertEqual(hash(g_global_struct1.f), hash(g_global_struct2.f))
+        self.assertEqual(hash(g_global_struct1.g), hash(g_global_struct2.g))
+        self.assertEqual(hash(g_global_struct1.h[3]), hash(g_global_struct2.h[3]))

--- a/ttexalens/elf/variable.py
+++ b/ttexalens/elf/variable.py
@@ -484,10 +484,16 @@ class ElfVariable:
             f"size={type_size}, address=0x{self.__address:x}{value_info}{length_info})"
         )
 
+    def __hash__(self):
+        try:
+            return hash(self.get_value())
+        except Exception:
+            return hash((self.__type_die.offset, self.__address))
+
     def get_address(self) -> int:
         return self.__address
 
-    def get_bytes(self) -> bytes:
+    def read_bytes(self) -> bytes:
         size = self.__type_die.size
         assert size is not None
         int_bytes = self.__mem_access_function(self.__address, size, size)
@@ -499,7 +505,7 @@ class ElfVariable:
             address = self.__mem_access_function(self.__address, self.__type_die.size, 1)[0]
             dereferenced_pointer = ElfVariable(self.__type_die.dereference_type, address, self.__mem_access_function)
             return dereferenced_pointer.read()
-        data = self.get_bytes()
+        data = self.read_bytes()
         address = self.__address
 
         def mem_access(addr: int, size_bytes: int, elements_to_read: int) -> list[int]:


### PR DESCRIPTION
Replacing all usages of `value()` in tt-triage caused it to fail with `ElfVariable` cannot be hashed.