### PR TITLE
Revert "Bump CMake required version to 3.27 (#645)"

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -53,13 +53,8 @@ RUN pip install wheel build setuptools
 # Install build tools
 RUN apt-get update && apt-get install -y \
     ccache \
+    cmake \
     ninja-build
-
-# Install CMake 3.27 from official releases
-RUN wget https://github.com/Kitware/CMake/releases/download/v3.27.9/cmake-3.27.9-linux-x86_64.sh && \
-    chmod +x cmake-3.27.9-linux-x86_64.sh && \
-    ./cmake-3.27.9-linux-x86_64.sh --skip-license --prefix=/usr/local && \
-    rm cmake-3.27.9-linux-x86_64.sh
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.27)
-cmake_policy(VERSION 3.27)
+cmake_minimum_required(VERSION 3.16)
+cmake_policy(VERSION 3.16)
 
 # Sanity check, forgetting to clone submodules is a common omission and results in a poor error message
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/third_party/umd/CMakeLists.txt")

--- a/riscv-src/CMakeLists.txt
+++ b/riscv-src/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.27)
-cmake_policy(VERSION 3.27)
+cmake_minimum_required(VERSION 3.16)
+cmake_policy(VERSION 3.16)
 
 project(RISCVProject LANGUAGES CXX ASM)
 


### PR DESCRIPTION
Revert changes, as tt-metal requires a lower minimal version, and a workaround for UMD will be found.