### PR TITLE
Fixing search for base address when dealing with relative address ranges

### DIFF
--- a/ttexalens/elf/die.py
+++ b/ttexalens/elf/die.py
@@ -232,6 +232,8 @@ class ElfDie:
         addr = None
         if "DW_AT_data_member_location" in self.attributes:
             addr = self.attributes["DW_AT_data_member_location"].value
+        elif "DW_AT_low_pc" in self.attributes:
+            addr = self.attributes["DW_AT_low_pc"].value
         else:
             location_attribute = self.attributes.get("DW_AT_location")
             location_parser = self.cu.dwarf.location_parser
@@ -359,6 +361,7 @@ class ElfDie:
                 (
                     self.attributes["DW_AT_low_pc"].value,
                     self.attributes["DW_AT_low_pc"].value + self.attributes["DW_AT_high_pc"].value,
+                    True,
                 )
             ]
         elif "DW_AT_ranges" in self.attributes:
@@ -366,6 +369,14 @@ class ElfDie:
             ranges = self.cu.dwarf.range_lists.get_range_list_at_offset(self.attributes["DW_AT_ranges"].value)
             address_ranges = []
             base_address = None
+            parent = self
+            while parent is not None:
+                if "DW_AT_low_pc" in parent.attributes:
+                    base_address = parent.attributes["DW_AT_low_pc"].value
+                    break
+                parent = parent.parent
+            if base_address is None:
+                base_address = self.cu.top_DIE.address
             for r in ranges:
                 if isinstance(r, BaseAddressEntry):
                     base_address = r.base_address
@@ -381,14 +392,7 @@ class ElfDie:
             child_ranges = []
             for child in self.iter_children():
                 child_ranges.extend(child.address_ranges)
-
-            if child_ranges:
-                # Compute the overall range
-                min_address = min(r[0] for r in child_ranges)
-                max_address = max(r[1] for r in child_ranges)
-                return [(min_address, max_address)]
-
-        return []
+            return child_ranges
 
     @cached_property
     def decl_file_info(self):


### PR DESCRIPTION
Previous callstack fix was partial.
NCRISC kernels were impacted with even more compression.

DWARF v5 documentation says when there is no `BaseAddressEntry` in `DW_AT_ranges` then `DW_AT_low_pc` should be used of parent that has it, or compilation unit address otherwise ([DWARF5](https://dwarfstd.org/doc/DWARF5.pdf) section 2.17.3).

I don't know how to force compiler to generate symbols like this, so no tests in our repo actually cover this case...