### PR TITLE
Rename register functions

### DIFF
--- a/docs/ttexalens-lib-docs.md
+++ b/docs/ttexalens-lib-docs.md
@@ -427,10 +427,10 @@ Reads an ARC telemetry entry from the device.
 
 
 
-## read_register
+## read_tensix_register
 
 ```
-read_register(location, register, noc_id=0, neo_id=None, device_id=0, context=None) -> int
+read_tensix_register(location, register, noc_id=0, neo_id=None, device_id=0, context=None) -> int
 ```
 
 
@@ -456,16 +456,16 @@ ConfigurationRegisterDescription(id, mask, shift), DebugRegisterDescription(addr
 
 
 
-## write_register
+## write_tensix_register
 
 ```
-write_register(location, register, value, noc_id=0, neo_id=None, device_id=0, context=None) -> None
+write_tensix_register(location, register, value, noc_id=0, neo_id=None, device_id=0, context=None) -> None
 ```
 
 
 ### Description
 
-Writes value to a register on the core.
+Writes value to a register on the tensix core.
 
 
 ### Args

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -436,6 +436,66 @@ class TestReadWrite(unittest.TestCase):
         with self.assertRaises((util.TTException, ValueError)):
             lib.write_register(location, register, value, device_id)
 
+    @parameterized.expand(
+        [
+            ("0,0",),
+            ("1,1",),
+            ("2,2",),
+        ]
+    )
+    def test_read_write_cfg_register(self, location):
+        """Test reading and writing configuration registers using lib functions."""
+        if self.context.arch == "grayskull":
+            self.skipTest("Skipping the test on grayskull.")
+
+        cfg_reg_name = "ALU_FORMAT_SPEC_REG2_Dstacc"
+
+        # Store original value
+        original_value = lib.read_register(location, cfg_reg_name)
+
+        # Test writing and reading different values
+        lib.write_register(location, cfg_reg_name, 10)
+        assert lib.read_register(location, cfg_reg_name) == 10
+
+        lib.write_register(location, cfg_reg_name, 0)
+        assert lib.read_register(location, cfg_reg_name) == 0
+
+        lib.write_register(location, cfg_reg_name, 5)
+        assert lib.read_register(location, cfg_reg_name) == 5
+
+        # Restore original value
+        lib.write_register(location, cfg_reg_name, original_value)
+
+    @parameterized.expand(
+        [
+            ("0,0",),
+            ("1,1",),
+            ("2,2",),
+        ]
+    )
+    def test_read_write_dbg_register(self, location):
+        """Test reading and writing debug registers using lib functions."""
+        if self.context.arch == "grayskull":
+            self.skipTest("Skipping the test on grayskull.")
+
+        dbg_reg_name = "RISCV_DEBUG_REG_CFGREG_RD_CNTL"
+
+        # Store original value
+        original_value = lib.read_register(location, dbg_reg_name)
+
+        # Test writing and reading different values
+        lib.write_register(location, dbg_reg_name, 10)
+        assert lib.read_register(location, dbg_reg_name) == 10
+
+        lib.write_register(location, dbg_reg_name, 0)
+        assert lib.read_register(location, dbg_reg_name) == 0
+
+        lib.write_register(location, dbg_reg_name, 5)
+        assert lib.read_register(location, dbg_reg_name) == 5
+
+        # Restore original value
+        lib.write_register(location, dbg_reg_name, original_value)
+
     def write_program(self, location, addr, data):
         """Write program code data to L1 memory."""
         bytes_written = lib.write_words_to_device(location, addr, data, context=self.context)

--- a/test/ttexalens/unit_tests/test_tensix_debug.py
+++ b/test/ttexalens/unit_tests/test_tensix_debug.py
@@ -36,24 +36,6 @@ class TestTensixDebug(unittest.TestCase):
     def is_blackhole(self) -> bool:
         return self.context.devices[0]._arch == "blackhole"
 
-    def test_read_write_cfg_register(self):
-        cfg_reg_name = "ALU_FORMAT_SPEC_REG2_Dstacc"
-        self.tensix_debug.register_store.write_register(cfg_reg_name, 10)
-        assert self.tensix_debug.register_store.read_register(cfg_reg_name) == 10
-        self.tensix_debug.register_store.write_register(cfg_reg_name, 0)
-        assert self.tensix_debug.register_store.read_register(cfg_reg_name) == 0
-        self.tensix_debug.register_store.write_register(cfg_reg_name, 5)
-        assert self.tensix_debug.register_store.read_register(cfg_reg_name) == 5
-
-    def test_read_write_dbg_register(self):
-        dbg_reg_name = "RISCV_DEBUG_REG_CFGREG_RD_CNTL"
-        self.tensix_debug.register_store.write_register(dbg_reg_name, 10)
-        assert self.tensix_debug.register_store.read_register(dbg_reg_name) == 10
-        self.tensix_debug.register_store.write_register(dbg_reg_name, 0)
-        assert self.tensix_debug.register_store.read_register(dbg_reg_name) == 0
-        self.tensix_debug.register_store.write_register(dbg_reg_name, 5)
-        assert self.tensix_debug.register_store.read_register(dbg_reg_name) == 5
-
     @parameterized.expand(
         [
             1,

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -438,7 +438,7 @@ def read_register(
     context: Context | None = None,
 ) -> int:
     """
-    Reads the value of a register from the core.
+    Reads the value of a register from the noc location.
 
     Args:
         location (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location on chip in string format, or OnChipCoordinate object.
@@ -474,7 +474,7 @@ def write_register(
     context: Context | None = None,
 ) -> None:
     """
-    Writes value to a register on the core.
+    Writes value to a register on the noc location.
 
     Args:
         location (str | OnChipCoordinate): Either X-Y (noc0/translated) or X,Y (logical) location on chip in string format, or OnChipCoordinate object.


### PR DESCRIPTION
Rename register functions to read_register/write_register and remove TensixDebug wrappers.

Closes #422