### PR TITLE
Adding warm reset after ETH tests

### DIFF
--- a/test/ttexalens/unit_tests/test_coverage.py
+++ b/test/ttexalens/unit_tests/test_coverage.py
@@ -42,10 +42,20 @@ class TestCoverage(unittest.TestCase):
     loader: ElfLoader
     risc_debug: RiscDebug
 
-    def setUp(self):
-        self.context = init_default_test_context()
-        self.device = self.context.devices[0]
+    @classmethod
+    def setUpClass(cls):
+        cls.context = init_default_test_context()
+        cls.device = cls.context.devices[0]
 
+    @classmethod
+    def tearDownClass(cls):
+        if (cls.device.is_wormhole() and cls.risc_name.lower() == "erisc") or (
+            cls.device.is_blackhole() and cls.risc_name.lower() not in ("erisc0", "erisc1")
+        ):
+            cls.context.server_ifc.warm_reset()
+            cls.context = init_default_test_context()
+
+    def setUp(self):
         # Arch is needed to know the ELF path
         if not self.context.arch:
             self.skipTest(f"Undefined architecture")
@@ -130,8 +140,3 @@ class TestCoverage(unittest.TestCase):
 
             # Most important test: checksum. It's very unlikely that a gcda is malformed if its checksum matches the gcno.
             self.assertEqual(gcda_header[8:12], gcno_header[8:12], f"{gcda}: checksum mismatch with {gcno}")
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.context.server_ifc.warm_reset()
-        cls.context = init_default_test_context()

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -899,6 +899,14 @@ class TestCallStack(unittest.TestCase):
         cls.gdb_server = GdbServer(cls.context, server)
         cls.gdb_server.start()
 
+    @classmethod
+    def tearDownClass(cls):
+        if (cls.device.is_wormhole() and cls.risc_name.lower() == "erisc") or (
+            cls.device.is_blackhole() and cls.risc_name.lower() not in ("erisc0", "erisc1")
+        ):
+            cls.context.server_ifc.warm_reset()
+            cls.context = init_default_test_context()
+
     def setUp(self):
         # Convert location_desc to location
         if self.location_desc.startswith("ETH"):
@@ -1100,8 +1108,3 @@ class TestCallStack(unittest.TestCase):
         # Check for invalid location
         with self.assertRaises((util.TTException, ValueError, FileNotFoundError)):
             lib.callstack(location, elf_paths, offsets, risc_name, None, max_depth, True, device_id, self.context)
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.context.server_ifc.warm_reset()
-        cls.context = init_default_test_context()

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -57,6 +57,14 @@ class TestDebugging(unittest.TestCase):
         cls.context = init_default_test_context()
         cls.device = cls.context.devices[0]
 
+    @classmethod
+    def tearDownClass(cls):
+        if (cls.device.is_wormhole() and cls.risc_name.lower() == "erisc") or (
+            cls.device.is_blackhole() and cls.risc_name.lower() not in ("erisc0", "erisc1")
+        ):
+            cls.context.server_ifc.warm_reset()
+            cls.context = init_default_test_context()
+
     def setUp(self):
         try:
             self.core_sim = RiscvCoreSimulator(self.context, self.core_desc, self.risc_name, self.neo_id)
@@ -1657,8 +1665,3 @@ class TestDebugging(unittest.TestCase):
             f"Unknown signal name '{signal_name}' on {self.core_sim.location.to_user_str()} for device {self.device._id}.",
             str(cm.exception),
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.context.server_ifc.warm_reset()
-        cls.context = init_default_test_context()


### PR DESCRIPTION
Closes #691 

Adding warm reset in `tearDownClass` in `TestCallstack` in `test_lib`, `TestDebugging` in `test_risc_debug` and `TestCoverage` in `test_coverage` to prevent breaking communication with remote devices.

With this we majorly increase time needed to execute tests (from 25s to 75s on `t3000`).