### PR TITLE
Fix prompt regex in UmdTTExaLensOutputVerifier and reenable test_startup_and_exit_just_return_code

### DIFF
--- a/test/app/test_umd_ttexalens.py
+++ b/test/app/test_umd_ttexalens.py
@@ -127,7 +127,7 @@ class TTExaLensTestRunner:
         self.process.stdin.write("\n")
         self.process.stdin.flush()
 
-    def read_until_prompt(self, readline_timeout: float = 1):
+    def read_until_prompt(self, readline_timeout: float = 2):
         lines = []
         while True:
             line = self.readline(readline_timeout)


### PR DESCRIPTION
Closes #129.