### PR TITLE
Renaming configuration registers to tensix to align with new changes

### DIFF
--- a/ttexalens/cli_commands/dump-tensix-reg.py
+++ b/ttexalens/cli_commands/dump-tensix-reg.py
@@ -15,10 +15,10 @@ Description:
   Prints the tensix register group of the given name, at the specified location and device.
 
 Examples:
-  tensix              # Prints all configuration registers for current device and core
-  tensix -d 0         # Prints all configuration registers for device with id 0 and current core
-  tensix -l 0,0       # Pirnts all configuration registers for current device and core at location 0,0
-  tensix all          # Prints all configuration registers for current device and core
+  tensix              # Prints all tensix registers for current device and core
+  tensix -d 0         # Prints all tensix registers for device with id 0 and current core
+  tensix -l 0,0       # Prints all tensix registers for current device and core at location 0,0
+  tensix all          # Prints all tensix registers for current device and core
   tensix alu          # Prints alu configuration registers for current device and core
   tensix pack         # Prints packer's configuration registers for current device and core
   tensix unpack       # Prints unpacker's configuration registers for current device and core
@@ -51,7 +51,7 @@ from ttexalens.util import (
     dict_list_to_table,
 )
 
-possible_registers = ["all", "alu", "pack", "unpack", "gpr"]
+possible_register_groups = ["all", "alu", "pack", "unpack", "gpr"]
 
 # Creates list of column names for configuration register table
 def create_column_names(num_of_columns):
@@ -94,12 +94,14 @@ def run(cmd_text, context, ui_state: UIState):
         argv=cmd_text.split()[1:],
     )
     reg_group = dopt.args["<reg-group>"] if dopt.args["<reg-group>"] else "all"
-    if reg_group not in possible_registers:
-        raise ValueError(f"Invalid configuration register: {reg_group}. Possible values: {possible_registers}")
+    if reg_group not in possible_register_groups:
+        raise ValueError(
+            f"Invalid tensix register group name: {reg_group}. Possible values: {possible_register_groups}"
+        )
 
     device: Device
     for device in dopt.for_each("--device", context, ui_state):
-        conf_reg_desc = device.get_tensix_configuration_registers_description()
+        conf_reg_desc = device.get_tensix_registers_description()
         for loc in dopt.for_each("--loc", context, ui_state, device=device):
             INFO(f"Tensix registers for location {loc} on device {device.id()}")
 

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -259,7 +259,7 @@ class Device(TTObject):
         return [self.get_block(location) for location in self.idle_eth_block_locations]
 
     @abstractmethod
-    def get_tensix_configuration_registers_description(self) -> TensixRegisterDescription:
+    def get_tensix_registers_description(self) -> TensixRegisterDescription:
         pass
 
     def get_block_locations(self, block_type="functional_workers") -> list[OnChipCoordinate]:

--- a/ttexalens/hw/tensix/blackhole/blackhole.py
+++ b/ttexalens/hw/tensix/blackhole/blackhole.py
@@ -78,5 +78,5 @@ class BlackholeDevice(Device):
             return BlackholeSecurityBlock(location)
         raise ValueError(f"Unsupported block type: {block_type}")
 
-    def get_tensix_configuration_registers_description(self) -> TensixRegisterDescription:
+    def get_tensix_registers_description(self) -> TensixRegisterDescription:
         return configuration_registers_descriptions

--- a/ttexalens/hw/tensix/quasar/quasar.py
+++ b/ttexalens/hw/tensix/quasar/quasar.py
@@ -37,5 +37,5 @@ class QuasarDevice(Device):
             return QuasarFunctionalWorkerBlock(location)
         raise ValueError(f"Unsupported block type: {block_type}")
 
-    def get_tensix_configuration_registers_description(self) -> TensixRegisterDescription:
+    def get_tensix_registers_description(self) -> TensixRegisterDescription:
         raise NotImplementedError("Quasar does not have a Tensix configuration registers description yet.")

--- a/ttexalens/hw/tensix/wormhole/wormhole.py
+++ b/ttexalens/hw/tensix/wormhole/wormhole.py
@@ -69,7 +69,7 @@ class WormholeDevice(Device):
             return WormholeRouterOnlyBlock(location)
         raise ValueError(f"Unsupported block type: {block_type}")
 
-    def get_tensix_configuration_registers_description(self) -> TensixRegisterDescription:
+    def get_tensix_registers_description(self) -> TensixRegisterDescription:
         return configuration_registers_descriptions
 
 


### PR DESCRIPTION
After recent changes to `dump-config-reg` command to be `dump-tensix-reg` there where some outdated comments/names referencing registers as configuration instead of tensix. This PR fixes that.