### PR TITLE
Fixing how we handle pointer variable in ElfVariable

### DIFF
--- a/riscv-src/globals_test.cc
+++ b/riscv-src/globals_test.cc
@@ -75,6 +75,8 @@ struct GlobalStruct : public BaseStruct, public BaseStruct2 {
     InnerStruct* p;
     UnionTest u;
     go_msg_t msg;
+    uint32_t uint_array[4];
+    uint32_t* uint_pointer;
 };
 
 GlobalStruct g_global_struct;
@@ -112,6 +114,11 @@ void update_struct(GlobalStruct* gs) {
     gs->msg.test = 0x12345678;
     gs->msg.packed = 0xAABBCCDD;
     gs->msg.test2 = 0x87654321;
+    gs->uint_array[0] = 0x11111111;
+    gs->uint_array[1] = 0x22222222;
+    gs->uint_array[2] = 0x33333333;
+    gs->uint_array[3] = 0x44444444;
+    gs->uint_pointer = &gs->uint_array[0];
 }
 
 int main() {

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -112,6 +112,15 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(0xAABBCCDD, g_global_struct.msg.packed.read_value())
         self.assertEqual(0xAA, g_global_struct.msg.signal.read_value())
         self.assertEqual(0x87654321, g_global_struct.msg.test2.read_value())
+        self.assertEqual(4, len(g_global_struct.uint_array))
+        self.assertEqual(0x11111111, g_global_struct.uint_array[0].read_value())
+        self.assertEqual(0x22222222, g_global_struct.uint_array[1].read_value())
+        self.assertEqual(0x33333333, g_global_struct.uint_array[2].read_value())
+        self.assertEqual(0x44444444, g_global_struct.uint_array[3].read_value())
+        self.assertNotEqual(0, g_global_struct.uint_pointer.read_value())
+        self.assertEqual(0x11111111, g_global_struct.uint_pointer.dereference().read_value())
+        self.assertEqual(0x11111111, g_global_struct.uint_pointer[0].read_value())
+        self.assertEqual(0x22222222, g_global_struct.uint_pointer[1].read_value())
 
     def verify_global_struct(self, g_global_struct):
         self.assertEqual(0xAA, g_global_struct.base_field1)
@@ -150,6 +159,15 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(0xAABBCCDD, g_global_struct.msg.packed)
         self.assertEqual(0xAA, g_global_struct.msg.signal)
         self.assertEqual(0x87654321, g_global_struct.msg.test2)
+        self.assertEqual(4, len(g_global_struct.uint_array))
+        self.assertEqual(0x11111111, g_global_struct.uint_array[0])
+        self.assertEqual(0x22222222, g_global_struct.uint_array[1])
+        self.assertEqual(0x33333333, g_global_struct.uint_array[2])
+        self.assertEqual(0x44444444, g_global_struct.uint_array[3])
+        self.assertNotEqual(0, g_global_struct.uint_pointer)
+        self.assertEqual(0x11111111, g_global_struct.uint_pointer.dereference())
+        self.assertEqual(0x11111111, g_global_struct.uint_pointer[0])
+        self.assertEqual(0x22222222, g_global_struct.uint_pointer[1])
 
     def test_elf_variable_low_level(self):
         variable_die = self.parsed_elf.variables["g_global_struct"]


### PR DESCRIPTION
ElfVariable is created from address and type. If type is pointer, address is not pointer that we want to dereference, but address where pointer is stored. Before we continue with resolution of pointer, we first need to dereference it (read pointer from the address).

Closes #715.