### PR TITLE
Fixing ND fail in test_arc_hearbeat

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -823,7 +823,7 @@ class TestARC(unittest.TestCase):
         import time
 
         heartbeat1 = lib.read_arc_telemetry_entry(self.device._id, tag)
-        time.sleep(0.1)
+        time.sleep(0.2)
         heartbeat2 = lib.read_arc_telemetry_entry(self.device._id, tag)
         self.assertGreater(heartbeat2, heartbeat1)
 


### PR DESCRIPTION
Increased sleep time from 100 to 200 ms to avoid ND fails. Heartbeat counter should increase by 1 every 100 ms, but for that exact sleep time it sometimes fails to do so.