### PR TITLE
Disabling write timeout

### DIFF
--- a/ttexalens/pybind/src/umd_implementation.cpp
+++ b/ttexalens/pybind/src/umd_implementation.cpp
@@ -59,15 +59,7 @@ void read_from_device_reg(tt::umd::Cluster* cluster, void* temp, uint8_t chip_id
 void write_to_device_reg(tt::umd::Cluster* cluster, const void* temp, uint32_t size, uint8_t chip_id,
                          tt::umd::CoreCoord tensix_core, uint64_t addr,
                          std::chrono::milliseconds timeout = std::chrono::milliseconds(200)) {
-    // Disabled timeout since we have no way to verify for writes of large sizes.
-    // auto start_time = std::chrono::steady_clock::now();
     cluster->write_to_device_reg(temp, size, chip_id, tensix_core, addr);
-    // auto end_time = std::chrono::steady_clock::now();
-    // auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
-    // if (cluster->get_cluster_description()->is_chip_mmio_capable(chip_id) && elapsed_time > timeout) {
-    //     tensix_core = cluster->get_soc_descriptor(chip_id).translate_coord_to(tensix_core, CoordSystem::LOGICAL);
-    //     throw TimeoutDeviceRegisterException(chip_id, tensix_core, addr, size, false);
-    // }
 }
 
 // Find working active eth core and configure it for remote communication


### PR DESCRIPTION
Commenting out write timeout since we have no way of accounting for extra time needed to read large amount of data.

Also now only throwing timeout for mmio devices since remote access can take long time in valid scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disable write timeouts and restrict read timeout to MMIO devices with a corrected end-of-buffer check.
> 
> - **Timeout handling in `ttexalens/pybind/src/umd_implementation.cpp`**:
>   - `write_to_device_reg`: Disable timeout measurement and exception for writes.
>   - `read_from_device_reg`: Only throw timeout for MMIO-capable chips and fix last-word sentinel check to `*((uint32_t*)temp + size / 4 - 1) == 0xFFFFFFFF`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36a76e3823a35e48b3d78acedccbad2d056c62c4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->