### PR TITLE
Enable noc-accessible addresses on RiscDebugMemoryAccess

### DIFF
--- a/ttexalens/hardware/memory_block.py
+++ b/ttexalens/hardware/memory_block.py
@@ -28,3 +28,6 @@ class MemoryBlock:
         if not self.contains_private_address(address):
             return None
         return self.address.noc_address + (address - self.address.private_address)
+
+    def exposed_through_noc(self) -> bool:
+        return self.address.noc_address is not None


### PR DESCRIPTION
Closes #745

NCRISC private memory is available on NOC.
In RiscDebugMemoryAccess we check if risc_debug supports debugging (which is not true for NCRISC), but we can still read its private memory if it is not in reset on blackhole.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow `RiscDebugMemoryAccess` to access memory via NOC when debugging isn’t available, with access gating and reset checks.
> 
> - **Elf/Debug Access**:
>   - `RiscDebugMemoryAccess`:
>     - Initialize `private_memory` directly and introduce `can_access` (true if private memory exists and `can_debug()` or `exposed_through_noc()` is true).
>     - `read`/`write`:
>       - Early-exit when `can_access` is false; return early if RISC is in reset for non-private paths.
>       - Gate private-memory operations on `can_debug()`; otherwise fall back to device I/O.
> - **Hardware**:
>   - `MemoryBlock`: add `exposed_through_noc()` helper to indicate NOC exposure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8566f4e137870b44d4d474a69f7f4a6a9e9448bf. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->