### PR TITLE
Bug fix when using util with streams

### DIFF
--- a/ttexalens/util.py
+++ b/ttexalens/util.py
@@ -139,27 +139,27 @@ def FATAL(s, **kwargs):
 
 def ERROR(s, **kwargs):
     if Verbosity.supports(Verbosity.ERROR):
-        print(f"{CLR_ERR}{s}{CLR_END}", file=kwargs.get("file", None), **kwargs)
+        print(f"{CLR_ERR}{s}{CLR_END}", **kwargs)
 
 
 def WARN(s, **kwargs):
     if Verbosity.supports(Verbosity.WARN):
-        print(f"{CLR_WARN}{s}{CLR_END}", file=kwargs.get("file", None), **kwargs)
+        print(f"{CLR_WARN}{s}{CLR_END}", **kwargs)
 
 
 def DEBUG(s, **kwargs):
     if Verbosity.supports(Verbosity.DEBUG):
-        print(f"{CLR_DEBUG}{s}{CLR_END}", file=kwargs.get("file", None), **kwargs)
+        print(f"{CLR_DEBUG}{s}{CLR_END}", **kwargs)
 
 
 def INFO(s, **kwargs):
     if Verbosity.supports(Verbosity.INFO):
-        print(f"{CLR_INFO}{s}{CLR_END}", file=kwargs.get("file", None), **kwargs)
+        print(f"{CLR_INFO}{s}{CLR_END}", **kwargs)
 
 
 def VERBOSE(s, **kwargs):
     if Verbosity.supports(Verbosity.VERBOSE):
-        print(f"{CLR_VERBOSE}{s}{CLR_END}", file=kwargs.get("file", None), **kwargs)
+        print(f"{CLR_VERBOSE}{s}{CLR_END}", **kwargs)
 
 
 def trim_ascii_escape(input: Any) -> Any:


### PR DESCRIPTION
Forwarding both `file` argument from `kwargs` and `kwargs` to `print` function raises an exception.
This shows when using util with streams. We fix it here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove explicit `file` argument from `ERROR/WARN/INFO/DEBUG/VERBOSE` print wrappers to avoid conflicts when passing streams via `kwargs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27a80635647fb7413bb36aa6db49817b8281e01c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->