### PR TITLE
Expose ensure_halted_access and restricted_access to base MemoryAcccess

### DIFF
--- a/ttexalens/elf/variable.py
+++ b/ttexalens/elf/variable.py
@@ -37,8 +37,10 @@ class MemoryAccess(ABC):
         pass
 
     @staticmethod
-    def get(risc_debug: RiscDebug) -> "MemoryAccess":
-        return RiscDebugMemoryAccess(risc_debug)
+    def get(risc_debug: RiscDebug, ensure_halted_access: bool = True, restricted_access: bool = True) -> "MemoryAccess":
+        return RiscDebugMemoryAccess(
+            risc_debug, ensure_halted_access=ensure_halted_access, restricted_access=restricted_access
+        )
 
     @staticmethod
     def get_l1(location: OnChipCoordinate) -> "MemoryAccess":


### PR DESCRIPTION
When you call `MemoryAccess.get(risc_debug)` you get the underlying `RiscDebugMemoryAccess(risc_debug, true, true)` always. There should be an option to expose those two parameters to the getter above.