### PR TITLE
Fix get_callstack breaking risc

### DIFF
--- a/ttexalens/elf/frame.py
+++ b/ttexalens/elf/frame.py
@@ -42,7 +42,7 @@ class FrameDescription:
             if address is not None:
                 l1 = self.risc_debug.get_l1()
                 private_data = self.risc_debug.get_data_private_memory()
-                if (l1 is not None and l1.contains_noc_address(address)) or (
+                if (l1 is not None and l1.contains_private_address(address)) or (
                     private_data is not None and private_data.contains_private_address(address)
                 ):
                     return self.risc_debug.read_memory(address)

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -505,6 +505,8 @@ class RiscDebug:
                 cfa = frame_pointer
                 return_address = frame_description.read_register(1, cfa)
                 frame_pointer = frame_description.read_previous_cfa(cfa)
+                if return_address is None:
+                    break
                 pc = return_address
                 frame_inspection = FrameInspection(self, elf.loaded_offset, frame_description, cfa)
                 frame_description = elf.frame_info.get_frame_description(pc, self)


### PR DESCRIPTION
Resolution of CFA could lead to reading addresses that are not valid. This causes risc to go into invalid state. Here we limit it to reading only L1 and data private memory.

Improves #783.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Constrain frame register recovery to read from L1/data-private memory only and allow None returns to avoid invalid accesses.
> 
> - **Debug/Frame handling (`ttexalens/elf/frame.py`)**:
>   - Update `FrameDescription.read_register` to return `int | None` and gate memory reads to valid regions: only read when address is in `L1` or data private memory; otherwise return `None`.
>   - Preserve fallback to `read_gpr` when no rule-derived address is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc2f877881639e0e8d6d4139843b06d2ecb854b4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->