### PR TITLE
Fix test remote communication

### DIFF
--- a/test/ttexalens/unit_tests/test_remote_communication.py
+++ b/test/ttexalens/unit_tests/test_remote_communication.py
@@ -11,7 +11,7 @@ class TestRemoteCommunication(unittest.TestCase):
     context: Context  # TTExaLens context
     local_devices: Device  # Local (PCIE) devices
     remote_device_id: int | None
-    tensix_core: "0,0"
+    tensix_core: str
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixing bug in `test_remote_communication.py` where we read from/write to local device instead of remote one. This resulted in test passing but active eth core was not changed. To test for that we now have assert that checks if active core changed.