### PR TITLE
Enabling mypy for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test:
 .PHONY: mypy
 mypy:
 	@echo "Running mypy"
-	python3 -m mypy -p ttexalens
+	python3 -m mypy
 
 .PHONY: wheel
 wheel:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,11 @@
 ; Read https://mypy.readthedocs.io/en/stable/config_file.html for more details.
 [mypy]
 ; Files we want to check
-files = ./ttexalens
+files = ./
 
 ; Files and directories to exclude from type checking
 exclude_gitignore = True
-exclude = ^test/|^third_party/|^docs/|^setup.py$
+exclude = ^third_party/|^docs/|^setup.py$
 
 ; Auto generated stubs for pybind
 mypy_path = build/stubs
@@ -17,7 +17,6 @@ allow_untyped_globals = False
 check_untyped_defs = True
 disallow_any_unimported = True
 disallow_subclassing_any = True
-disallow_untyped_decorators = True
 follow_untyped_imports = True
 ignore_missing_imports = False
 implicit_optional = False
@@ -36,6 +35,7 @@ disallow_any_decorated = False
 disallow_any_explicit = False
 disallow_any_generics = False
 disallow_untyped_calls = False
+disallow_untyped_decorators = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 extra_checks = False

--- a/test/app/test_umd_ttexalens.py
+++ b/test/app/test_umd_ttexalens.py
@@ -17,11 +17,11 @@ class TTExaLensOutputVerifier:
 
     def verify_start(self, runner: "TTExaLensTestRunner", tester: unittest.TestCase):
         lines, prompt = runner.read_until_prompt()
+        assert prompt is not None
         self.verify_startup(lines, prompt, tester)
-        pass
 
     @abstractmethod
-    def is_prompt_line(self, line: str) -> str:
+    def is_prompt_line(self, line: str) -> bool:
         pass
 
     @abstractmethod
@@ -35,11 +35,11 @@ class UmdTTExaLensOutputVerifier(TTExaLensOutputVerifier):
     def __init__(self):
         self.server_temp_path = ""
 
-    def is_prompt_line(self, line: str) -> str:
-        return re.match(self.prompt_regex, line)
+    def is_prompt_line(self, line: str) -> bool:
+        return re.match(self.prompt_regex, line) is not None
 
     def verify_startup(self, lines: list, prompt: str, tester: unittest.TestCase):
-        test_regex = []
+        test_regex: list[str] = []
         skip_regex = [
             r"Verbosity level: \d+",
             r"Output directory \(output_dir\) was not supplied and cannot be determined automatically\. Continuing with limited functionality\.\.\.",
@@ -69,14 +69,12 @@ class UmdTTExaLensOutputVerifier(TTExaLensOutputVerifier):
             # Report an unexpected line
             tester.fail(f"Unexpected line: {line}, expected {test_regex[id]}")
 
-        return True
-
 
 class TTExaLensTestRunner:
     def __init__(self, verifier: TTExaLensOutputVerifier):
         self.interpreter_path = sys.executable
         self.ttexalens_py_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../..", "tt-exalens.py")
-        self.process: subprocess.Popen = None
+        self.process: subprocess.Popen | None = None
         self.verifier = verifier
 
     @property
@@ -87,6 +85,7 @@ class TTExaLensTestRunner:
 
     @property
     def returncode(self):
+        assert self.process is not None
         return self.process.returncode
 
     def invoke(self, args=None):
@@ -104,6 +103,7 @@ class TTExaLensTestRunner:
         self.verifier.verify_start(self, tester)
 
     def readline(self, timeoutSeconds: float = 5):
+        assert self.process is not None
         # Fast path for program that ended
         rlist, _, _ = select.select([self.process.stdout, self.process.stderr], [], [], 0)
         if len(rlist) == 0:
@@ -114,7 +114,7 @@ class TTExaLensTestRunner:
                 if not self.is_running:
                     return None
                 raise Exception(f"Hit timeout ({timeoutSeconds}s) while waiting for output from TTExaLens")
-        line = rlist[0].readline()
+        line = rlist[0].readline()  # type: ignore
         if line.endswith("\n"):
             line = line[:-1]
         elif not line:
@@ -123,12 +123,13 @@ class TTExaLensTestRunner:
         return line
 
     def writeline(self, line):
+        assert self.process is not None and self.process.stdin is not None
         self.process.stdin.write(line)
         self.process.stdin.write("\n")
         self.process.stdin.flush()
 
-    def read_until_prompt(self, readline_timeout: float = 5):
-        lines = []
+    def read_until_prompt(self, readline_timeout: float = 5) -> tuple[list[str], str | None]:
+        lines: list[str] = []
         while True:
             line = self.readline(readline_timeout)
             if line is None:
@@ -137,11 +138,13 @@ class TTExaLensTestRunner:
                 return (lines, line)
             lines.append(line)
 
-    def wait(self, timeoutSeconds: float = None):
+    def wait(self, timeoutSeconds: float | None = None):
+        assert self.process is not None
         self.process.wait(timeoutSeconds)
 
     def kill(self):
         try:
+            assert self.process is not None
             self.process.kill()
             self.process.wait()
         except:
@@ -150,6 +153,7 @@ class TTExaLensTestRunner:
     def execute(self, args=None, input=None, timeout=None):
         try:
             self.invoke(args)
+            assert self.process is not None
             stdout, stderr = self.process.communicate(input, timeout)
             return stdout.splitlines(), stderr.splitlines()
         except Exception as e:

--- a/test/ttexalens/unit_tests/core_simulator.py
+++ b/test/ttexalens/unit_tests/core_simulator.py
@@ -13,7 +13,12 @@ from ttexalens import (
 )
 from ttexalens.debug_bus_signal_store import DebugBusSignalStore
 from ttexalens.elf_loader import ElfLoader
-from ttexalens.hardware.baby_risc_debug import BabyRiscDebug, BabyRiscDebugHardware, get_register_index
+from ttexalens.hardware.baby_risc_debug import (
+    BabyRiscDebug,
+    BabyRiscDebugHardware,
+    BabyRiscDebugStatus,
+    get_register_index,
+)
 
 
 class RiscvCoreSimulator:
@@ -189,7 +194,7 @@ class RiscvCoreSimulator:
         """
         return get_register_index(reg_name)
 
-    def read_status(self):
+    def read_status(self) -> BabyRiscDebugStatus:
         return self.debug_hardware.read_status()
 
     def get_elf_path(self, app_name):

--- a/test/ttexalens/unit_tests/program_writer.py
+++ b/test/ttexalens/unit_tests/program_writer.py
@@ -11,7 +11,7 @@ class RiscvProgramWriter:
     def __init__(self, core_simulator: RiscvCoreSimulator):
         self.core_simulator = core_simulator
         self.start_address = core_simulator.program_base_address
-        self.instructions = []
+        self.instructions: list[int] = []
 
     @property
     def current_address(self) -> int:

--- a/test/ttexalens/unit_tests/test_debug_bus.py
+++ b/test/ttexalens/unit_tests/test_debug_bus.py
@@ -11,6 +11,7 @@ from test.ttexalens.unit_tests.test_base import get_core_location, init_cached_t
 from ttexalens.debug_bus_signal_store import DebugBusSignalDescription, DebugBusSignalStore
 from ttexalens.context import Context
 from ttexalens.cli_commands.debug_bus import parse_string
+from ttexalens.device import Device
 
 
 @parameterized_class(
@@ -30,6 +31,7 @@ class TestDebugBus(unittest.TestCase):
     context: Context  # TTExaLens context
     core_desc: str  # Core description ETH0, FW0, FW1 - being parametrized
     debug_bus: DebugBusSignalStore  # Debug bus signal store
+    device: Device
 
     @classmethod
     def setUpClass(cls):

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -6,7 +6,7 @@ import unittest
 from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from test.ttexalens.unit_tests.test_base import init_cached_test_context
 from ttexalens.context import Context
-from ttexalens.elf import ElfVariable
+from ttexalens.elf import ElfVariable, ParsedElfFile
 from ttexalens.memory_access import MemoryAccess, RestrictedMemoryAccessError
 
 
@@ -44,6 +44,8 @@ class MemoryAccessWrapper(MemoryAccess):
 class TestDebugSymbols(unittest.TestCase):
     context: Context  # TTExaLens context
     core_sim: RiscvCoreSimulator  # RISC-V core simulator instance
+    parsed_elf: ParsedElfFile
+    mem_access: MemoryAccessWrapper  # Wrapped memory access
 
     @classmethod
     def setUpClass(cls):

--- a/test/ttexalens/unit_tests/test_l1_mem_access.py
+++ b/test/ttexalens/unit_tests/test_l1_mem_access.py
@@ -8,6 +8,7 @@ from test.ttexalens.unit_tests.test_base import init_cached_test_context
 from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from test.ttexalens.unit_tests.program_writer import RiscvProgramWriter
 from ttexalens.context import Context
+from ttexalens.device import Device
 
 
 @parameterized_class(
@@ -50,6 +51,7 @@ class TestL1MemoryAccessFromRiscs(unittest.TestCase):
     context: Context  # TTExaLens context
     core_desc: str  # Core description ETH0, FW0, FW1 - being parametrized
     core_sim: RiscvCoreSimulator  # RISC-V core simulator instance
+    device: Device
 
     @classmethod
     def setUpClass(cls):

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -77,6 +77,8 @@ class TestAutoContext(unittest.TestCase):
 
 
 class TestReadWrite(unittest.TestCase):
+    context: Context
+
     @classmethod
     def setUpClass(cls):
         cls.context = init_cached_test_context()
@@ -141,15 +143,15 @@ class TestReadWrite(unittest.TestCase):
         lib.write_to_device(location, address, data, device_id)
 
         # Verify buffer as words
-        ret = lib.read_words_from_device(location, address, device_id, len(words))
-        self.assertEqual(ret, words)
+        read_words = lib.read_words_from_device(location, address, device_id, len(words))
+        self.assertEqual(read_words, words)
 
         # Write words
         lib.write_words_to_device(location, address, words, device_id)
 
         # Read buffer
-        ret = lib.read_from_device(location, address, device_id, num_bytes=len(data))
-        self.assertEqual(ret, data)
+        read_bytes = lib.read_from_device(location, address, device_id, num_bytes=len(data))
+        self.assertEqual(read_bytes, data)
 
     def test_write_read_words(self):
         """Test write words -- read words."""
@@ -556,6 +558,9 @@ class TestReadWrite(unittest.TestCase):
 
 
 class TestRunElf(unittest.TestCase):
+    context: Context
+    device: Device
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.context = init_cached_test_context()
@@ -699,7 +704,7 @@ class TestRunElf(unittest.TestCase):
         rdbg.debug_hardware.set_watchpoint_on_memory_write(4, testbyteaccess.get_address() + 4)
         rdbg.debug_hardware.set_watchpoint_on_memory_write(5, testbyteaccess.get_address() + 5)
 
-        mbox_val = 1
+        mbox_val: int = 1
         timeout_retries = 20
         while mbox_val >= 0 and mbox_val < 0xFF000000 and timeout_retries > 0:
             if rdbg.is_halted():
@@ -714,7 +719,7 @@ class TestRunElf(unittest.TestCase):
                     pass
                 else:
                     raise e
-            mbox_val = mailbox.read_value()
+            mbox_val = mailbox.read_value()  # type: ignore
             # Step 5b: Continue RISC
             timeout_retries -= 1
 
@@ -763,6 +768,9 @@ class TestRunElf(unittest.TestCase):
 
 
 class TestARC(unittest.TestCase):
+    context: Context
+    device: Device
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.context = init_cached_test_context()

--- a/test/ttexalens/unit_tests/test_remote_communication.py
+++ b/test/ttexalens/unit_tests/test_remote_communication.py
@@ -9,9 +9,9 @@ from ttexalens import Context, OnChipCoordinate, Device, read_word_from_device, 
 
 class TestRemoteCommunication(unittest.TestCase):
     context: Context  # TTExaLens context
-    local_devices: Device  # Local (PCIE) devices
+    local_device: Device  # Local (PCIE) device
     remote_device_id: int | None
-    tensix_core: str
+    tensix_loc: str
 
     @classmethod
     def setUpClass(cls):
@@ -45,6 +45,7 @@ class TestRemoteCommunication(unittest.TestCase):
         # Find eth core used for remote communication and halt it
         eth_core = self.context.umd_api.get_device(self.remote_device_id).get_remote_transfer_eth_core()
         self.assertIsNotNone(eth_core, "Could not find ETH core used for remote communication")
+        assert eth_core is not None
         coord_str = f"e{eth_core[0]},{eth_core[1]}"
         loc = OnChipCoordinate.create(coord_str, self.local_device)
         noc_block = self.local_device.get_block(loc)

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -8,6 +8,7 @@ from test.ttexalens.unit_tests.test_base import init_cached_test_context
 from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from test.ttexalens.unit_tests.program_writer import RiscvProgramWriter
 from ttexalens import Context, write_to_device
+from ttexalens.device import Device
 from ttexalens.hardware.baby_risc_debug import BabyRiscDebugWatchpointState, get_register_index
 from ttexalens.elf_loader import ElfLoader
 
@@ -50,6 +51,7 @@ class TestDebugging(unittest.TestCase):
     context: Context  # TTExaLens context
     core_desc: str  # Core description ETH0, FW0, FW1 - being parametrized
     core_sim: RiscvCoreSimulator  # RISC-V core simulator instance
+    device: Device
 
     @classmethod
     def setUpClass(cls):

--- a/test/ttexalens/unit_tests/test_tensix_debug.py
+++ b/test/ttexalens/unit_tests/test_tensix_debug.py
@@ -24,6 +24,7 @@ class TestTensixDebug(unittest.TestCase):
     context: Context
     location: OnChipCoordinate
     tensix_debug: TensixDebug
+    location_str: str
 
     @classmethod
     def setUpClass(cls):
@@ -66,9 +67,9 @@ class TestTensixDebug(unittest.TestCase):
         ret = self.tensix_debug.read_regfile(regfile, num_tiles)
         if value is None:
             assert len(ret) == len(data)
-            assert all(abs(a - b) < error_threshold for a, b in zip(ret, data))
+            assert all(abs(a - b) < error_threshold for a, b in zip(ret, data) if isinstance(a, float))
         elif math.isnan(value):
-            assert all(math.isnan(a) for a in ret)
+            assert all(math.isnan(a) for a in ret if isinstance(a, float))
         else:
             assert ret == data
 

--- a/test/ttexalens/unit_tests/test_ttexalens_init.py
+++ b/test/ttexalens/unit_tests/test_ttexalens_init.py
@@ -14,7 +14,7 @@ from ttexalens import (
     write_to_device,
 )
 from ttexalens.umd_api import local_init
-from ttexalens.server import start_server
+from ttexalens.server import TTExaLensServer, start_server
 from test.ttexalens.unit_tests.test_base import init_default_test_context
 
 
@@ -27,6 +27,8 @@ class TestLocalTTExaLensInit(unittest.TestCase):
 
 
 class TestRemoteTTExaLens(unittest.TestCase):
+    server: TTExaLensServer
+
     @classmethod
     def setUpClass(cls) -> None:
         cls.server = start_server(5555, init_default_test_context())

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -354,7 +354,7 @@ class TensixDebug:
         self.register_store.write_register("ALU_FORMAT_SPEC_REG2_Dstacc", df_to_write.value)
         self.direct_dest_write(data, df)
 
-    def write_regfile(self, regfile: int | str | REGFILE, data: list[int | float], df: TensixDataFormat) -> None:
+    def write_regfile(self, regfile: int | str | REGFILE, data: list[int] | list[float], df: TensixDataFormat) -> None:
         """
         Writes data to the register file.
         Writing is only supported for dest register and only for formats using 32 bit mode (Float32, Int32, UInt32, Int8, UInt8)

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -167,15 +167,17 @@ RISCV_REGISTER_INDEX_BY_NAME = {
 }
 
 
-def get_register_index(reg_index_or_name):
+def get_register_index(reg_index_or_name: int | str) -> int:
     if reg_index_or_name in RISCV_REGISTER_NAMES_BY_INDEX:
+        assert isinstance(reg_index_or_name, int)
         return reg_index_or_name
     if reg_index_or_name in RISCV_REGISTER_INDEX_BY_NAME:
+        assert isinstance(reg_index_or_name, str)
         return RISCV_REGISTER_INDEX_BY_NAME[reg_index_or_name]
     raise ValueError(f"Unknown register {reg_index_or_name}")
 
 
-def get_register_name(reg_index_or_name):
+def get_register_name(reg_index_or_name: int | str) -> str:
     index = get_register_index(reg_index_or_name)
     return RISCV_REGISTER_NAMES_BY_INDEX[index]
 
@@ -492,10 +494,10 @@ class BabyRiscDebug(RiscDebug):
     def __write(self, addr, data):
         self.location.noc_write32(addr, data)
 
-    def __read(self, addr):
+    def __read(self, addr) -> int:
         return self.location.noc_read32(addr)
 
-    def is_in_reset(self):
+    def is_in_reset(self) -> bool:
         reset_reg = self.__read(self.RISC_DBG_SOFT_RESET0)
         return ((reset_reg >> self.risc_info.reset_flag_shift) & 1) != 0
 

--- a/ttexalens/pack_unpack_regfile.py
+++ b/ttexalens/pack_unpack_regfile.py
@@ -224,5 +224,5 @@ def pack_value_direct_access(value: int | float, df: TensixDataFormat) -> int:
         raise ValueError(f"Unsupported data format {df} for packing.")
 
 
-def pack_data_direct_access(data: list[int | float], df: TensixDataFormat) -> list[int]:
+def pack_data_direct_access(data: list[int] | list[float], df: TensixDataFormat) -> list[int]:
     return [pack_value_direct_access(value, df) for value in data]


### PR DESCRIPTION
Enabling `mypy` for tests. This will not prevent running tests that will fail because of API change.