### PR TITLE
Caching ELFs in tests

### DIFF
--- a/test/ttexalens/unit_tests/core_simulator.py
+++ b/test/ttexalens/unit_tests/core_simulator.py
@@ -2,15 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from functools import cached_property
-from test.ttexalens.unit_tests.test_base import get_core_location
-from ttexalens import (
-    Context,
-    write_to_device,
-    write_words_to_device,
-    read_from_device,
-    read_word_from_device,
-    parse_elf,
-)
+from test.ttexalens.unit_tests.test_base import get_core_location, get_parsed_elf_file
+from ttexalens import Context, write_to_device, write_words_to_device, read_from_device, read_word_from_device
 from ttexalens.debug_bus_signal_store import DebugBusSignalStore
 from ttexalens.elf_loader import ElfLoader
 from ttexalens.hardware.baby_risc_debug import (
@@ -209,9 +202,8 @@ class RiscvCoreSimulator:
             return f"build/riscv-src/{arch}/{app_name}.{self.risc_name.lower()}.elf"
 
     def load_elf(self, app_name: str):
-        elf_path = self.get_elf_path(app_name)
-        self.loader.run_elf(elf_path)
+        self.loader.run_elf(self.parse_elf(app_name))
 
     def parse_elf(self, app_name: str):
         elf_path = self.get_elf_path(app_name)
-        return parse_elf(elf_path, self.context)
+        return get_parsed_elf_file(elf_path)

--- a/test/ttexalens/unit_tests/test_coverage.py
+++ b/test/ttexalens/unit_tests/test_coverage.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import unittest
-from test.ttexalens.unit_tests.test_base import init_cached_test_context
+from test.ttexalens.unit_tests.test_base import get_parsed_elf_file, init_cached_test_context
 from parameterized import parameterized, parameterized_class
 
 import os
 import tempfile
 
-from ttexalens import Context, OnChipCoordinate, Device, parse_elf, TTException
+from ttexalens import Context, OnChipCoordinate, Device, TTException
 from ttexalens.elf_loader import ElfLoader
 from ttexalens.hardware.risc_debug import RiscDebug
 from ttexalens.coverage import dump_coverage
@@ -94,16 +94,16 @@ class TestCoverage(unittest.TestCase):
 
     def test_no_coverage(self):
         elf_path = self.get_elf_name("callstack.release")
-        elf = parse_elf(elf_path, self.context)
-        self.loader.run_elf(elf_path)
+        elf = get_parsed_elf_file(elf_path)
+        self.loader.run_elf(elf)
         with self.assertRaises(TTException) as cm:
             dump_coverage(elf, self.location, "/tmp/callstack.release.gcda", "/tmp/callstack.release.gcno")
             self.assertIn("__coverage_start not found", str(cm.exception))
 
     def test_coverage_not_finished(self):
         elf_path = self.get_elf_name("callstack.coverage")
-        elf = parse_elf(elf_path, self.context)
-        self.loader.run_elf(elf_path)
+        elf = get_parsed_elf_file(elf_path)
+        self.loader.run_elf(elf)
         with self.assertRaises(TTException) as cm:
             dump_coverage(elf, self.location, "/tmp/callstack.release.gcda", "/tmp/callstack.release.gcno")
             self.assertIn("Kernel did not finish writing coverage data", str(cm.exception))
@@ -114,8 +114,8 @@ class TestCoverage(unittest.TestCase):
 
             # Run the ELF and save its coverage data.
             elf_path = self.get_elf_name(elf)
-            elf = parse_elf(elf_path, self.context)
-            self.loader.run_elf(elf_path)
+            elf = get_parsed_elf_file(elf_path)
+            self.loader.run_elf(elf)
 
             basename, _ = os.path.splitext(os.path.basename(elf_path))
             gcda = os.path.join(temp_root, f"{basename}.gcda")

--- a/test/ttexalens/unit_tests/test_tensix_debug.py
+++ b/test/ttexalens/unit_tests/test_tensix_debug.py
@@ -5,7 +5,6 @@ import math
 import unittest
 from parameterized import parameterized_class, parameterized
 from test.ttexalens.unit_tests.test_base import init_cached_test_context
-from ttexalens import tt_exalens_init
 
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -277,7 +277,7 @@ def write_to_device(
 
 @trace_api
 def load_elf(
-    elf_file: str,
+    elf_file: str | ParsedElfFile,
     location: str | OnChipCoordinate | list[str | OnChipCoordinate],
     risc_name: str,
     neo_id: int | None = None,
@@ -289,7 +289,7 @@ def load_elf(
     Loads the given ELF file into the specified RISC core. RISC core must be in reset before loading the ELF.
 
     Args:
-        elf_file (str): Path to the ELF file to run.
+        elf_file (str | ParsedElfFile): ELF file to be loaded.
         location (str | OnChipCoordinate | list[str | OnChipCoordinate]): One of the following:
             1. "all" to run the ELF on all cores;
             2. an X-Y (noc0/translated) or X,Y (logical) location of a core in string format;
@@ -320,7 +320,7 @@ def load_elf(
     else:
         locations = [convert_coordinate(location, device_id, context)]
 
-    if not os.path.exists(elf_file):
+    if isinstance(elf_file, str) and not os.path.exists(elf_file):
         raise TTException(f"ELF file {elf_file} does not exist.")
 
     assert locations, "No valid core locations provided."
@@ -340,7 +340,7 @@ def load_elf(
 
 @trace_api
 def run_elf(
-    elf_file: str,
+    elf_file: str | ParsedElfFile,
     location: str | OnChipCoordinate | list[str | OnChipCoordinate],
     risc_name: str,
     neo_id: int | None = None,
@@ -351,7 +351,7 @@ def run_elf(
     Loads the given ELF file into the specified RISC core and executes it. Similar to load_elf, but RISC core is taken out of reset after load.
 
     Args:
-        elf_file (str): Path to the ELF file to run.
+        elf_file (str | ParsedElfFile): ELF file to be run.
         location (str | OnChipCoordinate | list[str | OnChipCoordinate]): One of the following:
             1. "all" to run the ELF on all cores;
             2. an X-Y (noc0/translated) or X,Y (logical) location of a core in string format;
@@ -381,7 +381,7 @@ def run_elf(
     else:
         locations = [convert_coordinate(location, device_id, context)]
 
-    if not os.path.exists(elf_file):
+    if isinstance(elf_file, str) and not os.path.exists(elf_file):
         raise TTException(f"ELF file {elf_file} does not exist.")
 
     assert locations, "No valid core locations provided."


### PR DESCRIPTION
Caching parsed ELF files in tests to speed them up.
Not executing multiple versions of the same tests (`test_top_callstack`/`test_callstack`) as they are already fully tested in `_with_parsing` counter parts.