### PR TITLE
Add more info in device command

### DIFF
--- a/test/ttexalens/unit_tests/test_remote_communication.py
+++ b/test/ttexalens/unit_tests/test_remote_communication.py
@@ -18,7 +18,7 @@ class TestRemoteCommunication(unittest.TestCase):
         cls.context = init_default_test_context()
 
         cls.local_device = cls.context.devices[0]
-        assert cls.local_device._has_mmio, "Could not find local device"
+        assert cls.local_device.is_local, "Could not find local device"
         cls.remote_device_id = cls.context.devices[1].id if len(cls.context.devices) > 1 else None
         cls.tensix_loc = "0,0"
 

--- a/ttexalens/cli_commands/device_summary.py
+++ b/ttexalens/cli_commands/device_summary.py
@@ -121,9 +121,13 @@ def run(cmd_text: str, context: Context, ui_state: UIState):
     for device in dopt.for_each(CommonCommandOptions.Device, context, ui_state):
         jtag_prompt = "JTAG" if ui_state.current_device._has_jtag else ""
         device_id_str = f"{device.id}"
+        device_unique_id_str = ""
         if device.unique_id is not None:
-            device_id_str += f" [0x{device.unique_id:x}]"
-        util.INFO(f"==== Device {jtag_prompt}{device_id_str}")
+            device_unique_id_str += f"0x{device.unique_id:x}"
+        local_remote = "local" if device.is_local else f"remote({device.local_device.id})"
+        util.INFO(
+            f"==== Device {jtag_prompt}{device_id_str} [{device.board_type} / {local_remote}] (Unique ID: {device_unique_id_str})"
+        )
 
         # What to render in each cell
         cell_contents_array = [s.strip() for s in cell_contents.split(",")]

--- a/ttexalens/cli_commands/interfaces.py
+++ b/ttexalens/cli_commands/interfaces.py
@@ -38,7 +38,7 @@ def run(cmd_text: str, context: Context, ui_state: UIState):
 
     for device_id in devices_list:
         # mmio chips
-        if context.devices[device_id]._has_mmio:
+        if context.devices[device_id].is_local:
             device = context.devices[device_id]
             unique_id_str = f"0x{device.unique_id:x}" if device.unique_id is not None else "{}"
             if device._has_jtag:

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -128,9 +128,19 @@ class Device:
         self._context = context
         self._umd_device = umd_device
         self._soc_descriptor = umd_device.soc_descriptor
-        self._has_mmio = umd_device.is_mmio_capable
         self._has_jtag = umd_device.is_jtag_capable
+        self.is_local = umd_device.is_mmio_capable
         self._init_coordinate_systems()
+
+    @property
+    def local_device(self) -> "Device":
+        if self.is_local:
+            return self
+        local_tt_device = self._umd_device.get_local_tt_device()
+        for device in self._context.devices.values():
+            if device.is_local and device._umd_device.get_local_tt_device() == local_tt_device:
+                return device
+        raise RuntimeError("Local device not found in context devices")
 
     @property
     def board_type(self) -> tt_umd.BoardType:

--- a/ttexalens/hardware/blackhole/arc_block.py
+++ b/ttexalens/hardware/blackhole/arc_block.py
@@ -81,7 +81,7 @@ class BlackholeArcBlock(ArcBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(location, block_type="arc")
 
-        if self.device._has_mmio:
+        if self.device.is_local:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_local, self.location)
         else:

--- a/ttexalens/hardware/wormhole/arc_block.py
+++ b/ttexalens/hardware/wormhole/arc_block.py
@@ -80,7 +80,7 @@ class WormholeArcBlock(ArcBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(location, block_type="arc")
 
-        if self.device._has_mmio:
+        if self.device.is_local:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_local, self.location)
         else:

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -389,3 +389,9 @@ class UmdDevice:
             tt_umd.CoordSystem.LOGICAL,
         )
         return (logical_coord.x, logical_coord.y)
+
+    def get_local_tt_device(self) -> tt_umd.TTDevice:
+        if self._is_mmio_capable:
+            return self.__device
+        remote_communication = self.__device.get_remote_communication()
+        return remote_communication.get_local_device()


### PR DESCRIPTION
Now one can see board type, local/remove chip, etc.
<img width="939" height="917" alt="image" src="https://github.com/user-attachments/assets/238bf046-464b-4552-852a-b2a21e40008a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds clearer device context in CLI and unifies local/remote handling across the codebase.
> 
> - device summary now shows `board_type`, `local` vs `remote(<local_id>)`, and `(Unique ID: ...)` in header
> - `interfaces` command now identifies PCI/JTAG using `device.is_local`
> - Introduces `Device.is_local` (from UMD `is_mmio_capable`) and `Device.local_device` to resolve a remote device’s corresponding local device
> - Adds `UmdDevice.get_local_tt_device()` to support `Device.local_device`
> - Replaces `_has_mmio` checks with `is_local` across code and tests; updates ARC block init (wormhole/blackhole) to choose register stores based on locality
> - Updates unit test to assert `is_local` for the local device
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 062a45adbb09cfbe88223f646dc218687e7d701e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->