### PR TITLE
Updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,12 @@ pip install --extra-index-url https://test.pypi.org/simple/ tt-exalens
 Or specific version with:
 ```
 pip install --extra-index-url https://test.pypi.org/simple/ tt-exalens=="x.y.z"
+```
 
 Alternatively, the wheel can be installed directly from GitHub with:
 ```
 pip install git+https://github.com/tenstorrent/tt-exalens.git
 ```
-
-Alternatively, you can install latest published version with:
-
 
 The CLI application can be run by invoking `tt-exalens` command after installing the wheel.
 
@@ -109,7 +107,7 @@ Or specific version with:
 pip install --extra-index-url https://test.pypi.org/simple/ tt-exalens=="x.y.z"
 ```
 
-Or you can simply run this in project root:
+Or you can simply run following in root directory:
 ```
 pip install .
 ```


### PR DESCRIPTION
Updating readme:
Adding command for installing latest published `tt-exalens` version from `test pypi`.
Removing command for submodule init since we no longer have `umd` as submodule.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **README updates**
> 
> - Adds alternative installation via Test PyPI (`pip install --extra-index-url https://test.pypi.org/simple/ tt-exalens`).
> - Removes submodule initialization instructions since no submodules are required.
> - Updates build requirements to include `cmake` (alongside `ninja-build`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2caa6bbac2d4356ad41230a7a98e0f033c60728. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->