### PR TITLE
Added exception type failed to halt error

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -12,7 +12,13 @@ from ttexalens.debug_bus_signal_store import DebugBusSignalDescription
 from ttexalens.device import Device
 from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 from ttexalens.hardware.memory_block import MemoryBlock
-from ttexalens.hardware.risc_debug import RiscDebug, RiscLocation, RiscDebugStatus, RiscDebugWatchpointState, RiscHaltError
+from ttexalens.hardware.risc_debug import (
+    RiscDebug,
+    RiscLocation,
+    RiscDebugStatus,
+    RiscDebugWatchpointState,
+    RiscHaltError,
+)
 from ttexalens.register_store import RegisterDescription, RegisterStore
 from ttexalens.hardware.noc_block import NocBlock
 

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -17,8 +17,10 @@ class RiscHaltError(Exception):
     """
     Raised when we failed to halt RISC core.
     """
+
     def __init__(self, risc_name: str, location: OnChipCoordinate):
         super().__init__(f"Failed to halt {risc_name} core at {location.to_user_str()} on device {location.device_id}")
+
 
 @dataclass
 class RiscLocation:


### PR DESCRIPTION
Closes #842 
Made special exception type for Failed to halt error to avoid needing to parse error message to determine that this error was raised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a dedicated exception for halt failures and updates halt flow to use it.
> 
> - Define `RiscHaltError` in `hardware/risc_debug.py` with detailed location/device info
> - In `hardware/baby_risc_debug.py`, change `halt()` to raise `RiscHaltError` when `is_halted()` remains false after issuing halt, replacing an `assert`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2998549f601bf575929ac6cd473391049ca9a81a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->