### PR TITLE
Disabling DMA for simulation since it is not supported

### DIFF
--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -112,7 +112,7 @@ class UmdDevice:
 
     def __read_from_device_reg(self, coord_x: int, coord_y: int, address: int, size: int, dma_threshold: int) -> bytes:
         # Check if we can use DMA read
-        if size >= dma_threshold and self._is_mmio_capable:
+        if size >= dma_threshold and self._is_mmio_capable and not self._is_simulation:
             return self.__device.dma_read_from_device(coord_x, coord_y, address, size)
 
         # TODO: Until UMD implements timeout exception, we measure time here
@@ -134,7 +134,7 @@ class UmdDevice:
 
     def __write_to_device_reg(self, coord_x: int, coord_y: int, address: int, data: bytes, dma_threshold: int):
         # Check if we can use DMA write
-        if len(data) >= dma_threshold and self._is_mmio_capable:
+        if len(data) >= dma_threshold and self._is_mmio_capable and not self._is_simulation:
             return self.__device.dma_write_to_device(coord_x, coord_y, address, data)
 
         # TODO: Until UMD implements timeout exception, we measure time here


### PR DESCRIPTION
Disabling DMA for simulation since it is not supported and therefore breaks tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Disable DMA in simulation**
> 
> - Gate `dma_read_from_device` and `dma_write_to_device` behind `not self._is_simulation` in `ttexalens/umd_device.py` so simulation uses NOC paths instead of DMA
> - Read/write timeout checks and all other logic remain unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efe57a4f3e42c5e5e5b2e1cd8d8ff383eaafbdbe. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->