### PR TITLE
Reintroducing eth test workaround due to UMD revert

### DIFF
--- a/test/ttexalens/unit_tests/test_base.py
+++ b/test/ttexalens/unit_tests/test_base.py
@@ -61,7 +61,7 @@ def get_core_location(core_desc: str, device: Device) -> OnChipCoordinate:
         eth_blocks = device.idle_eth_blocks
         core_index = int(core_desc[3:])
         if len(eth_blocks) > core_index:
-            return eth_blocks[core_index].location
+            return eth_blocks[len(eth_blocks) - 1 - core_index].location
         raise ValueError(f"ETH core {core_index} not available on this platform")
 
     elif core_desc.startswith("FW"):


### PR DESCRIPTION
We are reintroducing workaround for eth test (running them on last idle eth instead of first) due to UMD reverting changes that made this workaround not needed. 

This will reopen this issue: #691 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reintroduces ETH test workaround by reversing ETH block selection in `get_core_location`.
> 
> - In `test_base.py`, `get_core_location("ETH...")` now maps indices from the end of `device.idle_eth_blocks` (`len-1-core_index`) instead of from the start, ensuring tests use the last idle ETH blocks
> - No other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb1499b2279583e6ce60a2f1989a269a021e2976. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->