### PR TITLE
Restore PC on Wormhole Erisc when PC is in code private memory

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -683,7 +683,7 @@ class BabyRiscDebug(RiscDebug):
         debug_bus_pc_signal = self.debug_bus_pc_signal
         if debug_bus_pc_signal is not None and self.risc_info.noc_block.debug_bus is not None:
             pc = self.risc_info.noc_block.debug_bus.read_signal(debug_bus_pc_signal)
-            if self.risc_info.risc_name == "ncrisc" and pc & 0xF0000000 == 0x70000000:
+            if (self.risc_info.risc_name in ["ncrisc", "erisc"]) and pc & 0xF0000000 == 0x70000000:
                 pc = pc | 0x80000000  # Turn the topmost bit on as it was lost on debug bus
             return pc
 


### PR DESCRIPTION
Similarly with NCRISC on Wormhole, with ERISC, the PC can end up in its IRAM (starting from `0xFFC00000`), when that happens the actual address of the PC read from the debug bus is truncated by the highest bit (as from debug bus PCs we read only 31 bits instead of 32, for something like the real address `0xFFC01234` we get `0x7FC01234`) so we need to restore it with the highest bit flipped. 

This issue causes side effects in dumping callstacks and lightweight asserts in triage and reads garbage memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct PC value when ERISC executes from code private memory, mirroring existing NCRISC behavior.
> 
> - In `baby_risc_debug.py#get_pc`, apply MSB restore (`pc |= 0x80000000`) when debug-bus PC has `0x70000000` high nibble for both `ncrisc` and `erisc`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09b12c713927592f4e73544b927107f6e027ffb4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->