### PR TITLE
Reposition NOC hang warning message

### DIFF
--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -161,10 +161,11 @@ class Device:
 
                 failed_noc = noc_queue.pop(0)
                 noc_queue.append(failed_noc)
-                util.WARN(f"Device {self.id}: NOC{failed_noc} hung, switching over to NOC{noc_queue[0]}.")
 
                 if noc_queue[0] == first_used:
                     raise  # Exhausted all NOCs, raise Timeout
+
+                util.WARN(f"Device {self.id}: NOC{failed_noc} hung, switching over to NOC{noc_queue[0]}.")
 
     @property
     def board_type(self) -> tt_umd.BoardType:


### PR DESCRIPTION
Reposition warning message for NOC switch to ensure it is logged after the queue update.

Causing confusing outputs on failovers:
Device 16: NOC0 hung, switching over to NOC1.
Device 16: NOC1 hung, switching over to NOC0.
Device 16: NOC0 hung, switching over to NOC1.
Device 16: NOC1 hung, switching over to NOC0.

Does this mean NOC0 recovered, or NOC1 recovered at some point? It's not possible to answer with current reorder