### PR TITLE
Add atexit so that cleanup doesn't result in nanobind leaks

### DIFF
--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -95,15 +95,17 @@ def set_active_context(context: Context | None) -> None:
     global GLOBAL_CONTEXT
     GLOBAL_CONTEXT = context
 
+
 def _cleanup_global_context():
     """
-    Clears the global context reference to allow C++ destructors 
+    Clears the global context reference to allow C++ destructors
     to run before the nanobind runtime shuts down.
     """
     global GLOBAL_CONTEXT
     if GLOBAL_CONTEXT is not None:
         # Dropping this reference allows the RefCount to hit 0
         GLOBAL_CONTEXT = None
+
 
 # Register the cleanup to run automatically on script exit
 atexit.register(_cleanup_global_context)


### PR DESCRIPTION
This pull request introduces an automatic cleanup mechanism for the global context in `ttexalens/tt_exalens_init.py`. The key change is the addition of a cleanup function that ensures the global context is cleared at program exit, which helps C++ destructors run properly before the nanobind runtime shuts down.

Resource management improvements:

* Added an `_cleanup_global_context` function to clear the `GLOBAL_CONTEXT` reference, allowing C++ destructors to execute before the nanobind runtime terminates. This function is registered to run automatically at script exit using the `atexit` module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change that only affects interpreter shutdown behavior by clearing a global reference.
> 
> **Overview**
> Adds an `atexit`-registered cleanup hook in `ttexalens/tt_exalens_init.py` that clears `GLOBAL_CONTEXT` on interpreter shutdown.
> 
> This is intended to drop the last Python reference early so underlying C++/nanobind-backed resources can be destructed before the nanobind runtime teardown, reducing shutdown-time leaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8ad16019844d44934f753decb5a0ba4f67e5f14. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->