### PR TITLE
Add simpler method for global context cleanup

### DIFF
--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -96,16 +96,14 @@ def set_active_context(context: Context | None) -> None:
     GLOBAL_CONTEXT = context
 
 
-def _cleanup_global_context():
+def cleanup_global_context():
     """
     Clears the global context reference to allow C++ destructors
     to run before the nanobind runtime shuts down.
     """
     global GLOBAL_CONTEXT
-    if GLOBAL_CONTEXT is not None:
-        # Dropping this reference allows the RefCount to hit 0
-        GLOBAL_CONTEXT = None
+    GLOBAL_CONTEXT = None
 
 
 # Register the cleanup to run automatically on script exit
-atexit.register(_cleanup_global_context)
+atexit.register(cleanup_global_context)


### PR DESCRIPTION
This pull request refactors the global context cleanup logic in `ttexalens/tt_exalens_init.py` to improve clarity and ensure proper resource management. The main change is renaming the cleanup function and updating its registration for script exit.

Cleanup function refactor:

* Renamed `_cleanup_global_context` to `cleanup_global_context` and updated the `atexit.register` call to use the new function name, ensuring the global context is cleared correctly on script exit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor limited to module shutdown cleanup; behavior is effectively equivalent aside from making the function public and unconditionally setting `GLOBAL_CONTEXT = None`.
> 
> **Overview**
> Renames the global context teardown helper from `_cleanup_global_context` to `cleanup_global_context` and updates the `atexit` registration accordingly.
> 
> Simplifies cleanup behavior to *always* clear `GLOBAL_CONTEXT` on exit (dropping the redundant `None` check) to ensure referenced C++ resources can be released before shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7511ed93f03991f7b4f199bebe8bf4dff7592a6a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->