### PR TITLE
[umd] Disable ETH FW checks in TopologyDiscovery

### DIFF
--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -85,11 +85,13 @@ class UmdApi:
                 tt_umd.logging.set_level(tt_umd.logging.Level.Error)
 
             discovery_options = tt_umd.TopologyDiscoveryOptions()
-            discovery_options.io_device_type = tt_umd.IODeviceType.PCIe if not init_jtag else tt_umd.IODeviceType.JTAG
-            # TODO: discovery_options.no_wait_for_eth_training = True
+            discovery_options.no_wait_for_eth_training = True
             discovery_options.no_eth_firmware_strictness = True
             discovery_options.predict_eth_fw_version = True
-            self.cluster_descriptor, devices = tt_umd.TopologyDiscovery.discover(discovery_options)
+            self.cluster_descriptor, devices = tt_umd.TopologyDiscovery.discover(
+                discovery_options,
+                tt_umd.IODeviceType.PCIe if not init_jtag else tt_umd.IODeviceType.JTAG,
+            )
 
             if len(self.cluster_descriptor.get_all_chips()) == 0:
                 raise RuntimeError("No Tenstorrent devices were detected on this system.")


### PR DESCRIPTION
We're introducing an ETH FW heartbeat check to UMD.
This is probably the best way to check ETH core functionality after L1 corruption/ERISC fault.
The ETH FW version check will be of smaller importance once https://github.com/tenstorrent/tt-umd/pull/2109 is merged.

Expected behavior:
- If ETH FW heartbeat check fails:
  - with no_eth_fw_strictness: Skip discovery. The design ETH FW will ensure that hearbeat gets updated regularly, if this is not the case we are certain discovery will fail. 
  - without  no_eth_fw_strictness: Throw exception (tt-metal preferred behavior)
- If ETH FW version check fails:
  - with no_eth_fw_strictness: Continue discovery.
  - without  no_eth_fw_strictness: Skip discovery. (will be changed to exception for mismatched ETH FW versions *inside* one chip)