### PR TITLE
Reorder NoC failover log message

### DIFF
--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -161,10 +161,11 @@ class Device:
 
                 failed_noc = noc_queue.pop(0)
                 noc_queue.append(failed_noc)
-                util.WARN(f"Device {self.id}: NOC{failed_noc} hung, switching over to NOC{noc_queue[0]}.")
 
                 if noc_queue[0] == first_used:
                     raise  # Exhausted all NOCs, raise Timeout
+
+                util.WARN(f"Device {self.id}: NOC{failed_noc} hung, switching over to NOC{noc_queue[0]}.")
 
     @property
     def board_type(self) -> tt_umd.BoardType:


### PR DESCRIPTION
When a NoC failover occurs, we output one additional log that says a switch happens, when in reality we exhausted all NoCs and will fail. This can be misleading when reading outputs. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to log emission ordering during NoC failover; no functional read/write or failover logic is modified.
> 
> **Overview**
> Adjusts NoC failover logging in `Device._with_noc_failover` so the "switching over" warning is emitted only when another NoC will actually be tried, and not when all NoCs are exhausted and a timeout is raised.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70cf2de2c316919bd73baa6e7e7a39a5ff16d00e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->