### PR TITLE
Fix remote test safe_mode not being passed

### DIFF
--- a/test/ttexalens/unit_tests/test_base.py
+++ b/test/ttexalens/unit_tests/test_base.py
@@ -32,7 +32,9 @@ def init_default_test_context():
     if os.getenv("TTEXALENS_TESTS_REMOTE"):
         ip_address = os.getenv("TTEXALENS_TESTS_REMOTE_ADDRESS", "localhost")
         port = int(os.getenv("TTEXALENS_TESTS_REMOTE_PORT", "5555"))
-        _cached_test_context = init_ttexalens_remote(ip_address, port, use_4B_mode=False, noc_failover=False)
+        _cached_test_context = init_ttexalens_remote(
+            ip_address, port, use_4B_mode=False, noc_failover=False, safe_mode=False
+        )
     elif os.getenv("TTEXALENS_SIMULATOR"):
         # Reuse cached simulator context to prevent multiple simulator processes
         if _cached_simulator_context is None:


### PR DESCRIPTION
In `test_base.py`, `safe_mode` should be passed down to the remote branch and causes issues in quasar tests. This PR fixes that