### PR TITLE
Depend on ID instead of TTDevice object for remote communication and use different coord system for remote eth core

### DIFF
--- a/test/ttexalens/unit_tests/test_remote_communication.py
+++ b/test/ttexalens/unit_tests/test_remote_communication.py
@@ -44,8 +44,7 @@ class TestRemoteCommunication(unittest.TestCase):
         eth_core = self.context.umd_api.get_device(self.remote_device_id).get_remote_transfer_eth_core()
         self.assertIsNotNone(eth_core, "Could not find ETH core used for remote communication")
         assert eth_core is not None
-        coord_str = f"e{eth_core[0]}-{eth_core[1]}"
-        loc = OnChipCoordinate.create(coord_str, self.local_device)
+        loc = OnChipCoordinate(eth_core[0], eth_core[1], input_type="translated", device=self.local_device)
         noc_block = self.local_device.get_block(loc)
         risc_debug = noc_block.get_default_risc_debug()
         risc_debug.halt()

--- a/test/ttexalens/unit_tests/test_remote_communication.py
+++ b/test/ttexalens/unit_tests/test_remote_communication.py
@@ -44,7 +44,7 @@ class TestRemoteCommunication(unittest.TestCase):
         eth_core = self.context.umd_api.get_device(self.remote_device_id).get_remote_transfer_eth_core()
         self.assertIsNotNone(eth_core, "Could not find ETH core used for remote communication")
         assert eth_core is not None
-        coord_str = f"e{eth_core[0]},{eth_core[1]}"
+        coord_str = f"e{eth_core[0]}-{eth_core[1]}"
         loc = OnChipCoordinate.create(coord_str, self.local_device)
         noc_block = self.local_device.get_block(loc)
         risc_debug = noc_block.get_default_risc_debug()

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -204,9 +204,9 @@ class Device:
     def local_device(self) -> Device:
         if self.is_local:
             return self
-        local_tt_device = self._umd_device.get_local_tt_device()
+        local_tt_device_id = self._umd_device.get_local_tt_device_id()
         for device in self._context.devices.values():
-            if device.is_local and device._umd_device.get_local_tt_device() == local_tt_device:
+            if device.is_local and device._umd_device.get_local_tt_device_id() == local_tt_device_id:
                 return device
         raise RuntimeError("Local device not found in context devices")
 

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -367,6 +367,6 @@ class UmdDevice:
 
     def get_local_tt_device_id(self) -> int:
         if self._is_mmio_capable:
-            return self.__device
+            return self.__device.get_communication_device_id()
         remote_communication = self.__device.get_remote_communication()
         return remote_communication.get_local_device().get_communication_device_id()

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -363,17 +363,10 @@ class UmdDevice:
         if remote_communication is None:
             return None
         translated_coord = remote_communication.get_remote_transfer_ethernet_core()
-        local_device = remote_communication.get_local_device()
-        logical_coord = tt_umd.SocDescriptor(local_device).translate_coord_to(
-            tt_umd.CoreCoord(
-                translated_coord[0], translated_coord[1], tt_umd.CoreType.ETH, tt_umd.CoordSystem.TRANSLATED
-            ),
-            tt_umd.CoordSystem.LOGICAL,
-        )
-        return (logical_coord.x, logical_coord.y)
+        return (translated_coord.x, translated_coord.y)
 
-    def get_local_tt_device(self) -> tt_umd.TTDevice:
+    def get_local_tt_device_id(self) -> int:
         if self._is_mmio_capable:
             return self.__device
         remote_communication = self.__device.get_remote_communication()
-        return remote_communication.get_local_device()
+        return remote_communication.get_local_device().get_communication_device_id()


### PR DESCRIPTION
Changed the way how local devices are identified (now by ID instead of the dependency on an object) and also changed the coordinate system from logical to translated when fetching eth core for remote communication (this should be interchangeable). The change is done as an effort to minimize tight coupling in the UMD codebase, as there is ongoing work to introduce a device protocol class which will be used for IO transactions.

Changes to device identification:

* Replaced the use of the actual device object with its device ID in `get_local_tt_device_id` and updated all related logic in `ttexalens/device.py` to match, ensuring device comparisons are based on IDs rather than object references. 

Simplification of Ethernet core coordinate handling:

* Updated `get_remote_transfer_eth_core` to return the translated Ethernet core coordinates directly, removing unnecessary translation steps.

* Changed the coordinate string formatting in the unit test to use a hyphen (`-`) instead of a comma (`,`), aligning with the new coordinate representation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote-communication plumbing by changing how local devices are identified and how ETH core coordinates are interpreted; issues would primarily surface on multi-device/remote setups and could break coordinate parsing or device matching.
> 
> **Overview**
> Remote communication lookups are **decoupled from `TTDevice` object identity** by switching local-device matching to use a stable *communication device ID* (`get_local_tt_device_id`) and updating `Device.local_device` to compare IDs.
> 
> `get_remote_transfer_eth_core` is simplified to return the remote-transfer Ethernet core’s **translated** coordinates directly (removing the logical-coordinate translation), and the remote-communication unit test is updated to format ETH coordinates using `eX-Y` to match the expected parsed representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 378a3841eb7a6cc0fd0a18d55cf060ae7ca3294f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->