### PR TITLE
Change halt() warn to debug

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -298,7 +298,9 @@ class BabyRiscDebugHardware:
 
     def halt(self):
         if self.is_halted():
-            util.DEBUG(f"Halt: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already halted")
+            util.DEBUG(
+                f"Halt: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already halted"
+            )
             return
         util.TRACE("  halt()")
         self._halt_command()


### PR DESCRIPTION
The warning displayed when we try to halt an already halted core is not really a warning but rather an observation as we don't consider it as a marker that something is broken (a caller can call halt without really caring whether it's already halted) so I'm sending this PR to reduce its verbosity. This PR is mainly tied to ongoing issues we have with halt/continue on BH/WH and a prerequisite for https://github.com/tenstorrent/tt-metal/pull/38921 as that PR will cause spam on the output with a ton of warnings on every single read or write in triage.

Keeping the log in `cont()` as a warning for now as the semantics are closer to a warning (we expect that we're halted when we explicitly call `cont()`), we can also change that to debug as well.