### PR TITLE
[umd] Support for ETH FW heartbeat check

### DIFF
--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,4 +1,4 @@
-tt-umd==0.9.3.260309
+tt-umd==0.9.3.260311
 deprecation>=2.1.0
 docopt>=0.6.2
 fastnumbers>=5.1.0

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -98,8 +98,8 @@ class UmdApi:
             discovery_options.cmfw_unsupported_action = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
             discovery_options.eth_fw_mismatch_action = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
             discovery_options.unexpected_routing_firmware_config = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
+            discovery_options.eth_fw_heartbeat_failure = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
             discovery_options.wait_on_ethernet_link_training = True  # TODO: Set to False.
-            discovery_options.predict_eth_fw_version_from_cmfw_version = True
 
             self.cluster_descriptor, devices = tt_umd.TopologyDiscovery.discover(
                 discovery_options, tt_umd.IODeviceType.PCIe if not init_jtag else tt_umd.IODeviceType.JTAG


### PR DESCRIPTION
We're introducing an ETH FW heartbeat check to UMD.
This is probably the best way to check ETH core functionality after L1 corruption/ERISC fault.
The ETH FW version check will be of smaller importance once https://github.com/tenstorrent/tt-umd/pull/2109 is merged.