### PR TITLE
Disable BH DMA

### DIFF
--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -86,6 +86,10 @@ class UmdDevice:
     def is_simulation(self) -> bool:
         return self._is_simulation
 
+    @property
+    def can_use_dma(self) -> bool:
+        return self._arch != tt_umd.ARCH.BLACKHOLE and self._is_mmio_capable and not self._is_simulation
+
     def __select_noc_id(self, noc_id: int):
         from ttexalens.umd_api import UmdApi
 
@@ -115,12 +119,7 @@ class UmdDevice:
 
     def __read_from_device_reg(self, coord_x: int, coord_y: int, address: int, size: int, dma_threshold: int) -> bytes:
         # Check if we can use DMA read
-        if (
-            size >= dma_threshold
-            and self._arch != tt_umd.ARCH.BLACKHOLE
-            and self._is_mmio_capable
-            and not self._is_simulation
-        ):
+        if size >= dma_threshold and self.can_use_dma:
             return self.__device.dma_read_from_device(coord_x, coord_y, address, size)
 
         # TODO: Until UMD implements timeout exception, we measure time here
@@ -142,12 +141,7 @@ class UmdDevice:
 
     def __write_to_device_reg(self, coord_x: int, coord_y: int, address: int, data: bytes, dma_threshold: int):
         # Check if we can use DMA write
-        if (
-            len(data) >= dma_threshold
-            and self._arch != tt_umd.ARCH.BLACKHOLE
-            and self._is_mmio_capable
-            and not self._is_simulation
-        ):
+        if len(data) >= dma_threshold and self.can_use_dma:
             return self.__device.dma_write_to_device(coord_x, coord_y, address, data)
 
         # TODO: Until UMD implements timeout exception, we measure time here


### PR DESCRIPTION
UMD wants to disable BH DMA because of hardware bug. Syseng is investigating mitigation. Currently, UMD is silently skipping DMA, but they want to change it to exception.