### PR TITLE
Fix timeout exception masking with UMD coordinate translation exception

### DIFF
--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -101,7 +101,7 @@ class UmdDevice:
         for translated_coord in self._active_eth_coords_on_mmio_chip:
             self.__device.get_remote_communication().set_remote_transfer_ethernet_cores([translated_coord])
             try:
-                self.__read_from_device_reg(tensix_translated_coord.x, tensix_translated_coord.y, 0, 4, 8)
+                self.__read_from_device_reg(tensix_translated_coord, 0, 4, 8)
                 return
             except Exception:
                 util.DEBUG(f"Active ETH core {translated_coord} not working, trying next:\n{traceback.format_exc()}")
@@ -117,14 +117,14 @@ class UmdDevice:
     WRITE_TIMEOUT = float(os.environ.get("TT_EXALENS_WRITE_TIMEOUT_MS", 2)) / 1_000  # seconds
     NUM_OF_CONSECUTIVE_TIMEOUTS = int(os.environ.get("TT_EXALENS_NUM_OF_CONSECUTIVE_TIMEOUTS", 5))
 
-    def __read_from_device_reg(self, coord_x: int, coord_y: int, address: int, size: int, dma_threshold: int) -> bytes:
+    def __read_from_device_reg(self, coord: tt_umd.CoreCoord, address: int, size: int, dma_threshold: int) -> bytes:
         # Check if we can use DMA read
         if size >= dma_threshold and self.can_use_dma:
-            return self.__device.dma_read_from_device(coord_x, coord_y, address, size)
+            return self.__device.dma_read_from_device(coord.x, coord.y, address, size)
 
         # TODO: Until UMD implements timeout exception, we measure time here
         start_time = time.time()
-        result = self.__device.noc_read(coord_x, coord_y, address, size)
+        result = self.__device.noc_read(coord.x, coord.y, address, size)
         end_time = time.time()
         elapsed_time = end_time - start_time  # seconds
         if (
@@ -133,20 +133,21 @@ class UmdDevice:
             and elapsed_time > UmdDevice.READ_TIMEOUT
             and result[-4:] == b"\xFF\xFF\xFF\xFF"
         ):
-            translated_coord = self._soc_descriptor.translate_coord_to(
-                tt_umd.tt_xy_pair(coord_x, coord_y), tt_umd.CoordSystem.TRANSLATED, tt_umd.CoordSystem.LOGICAL
-            )
+            try:
+                translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.LOGICAL)
+            except Exception:
+                translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.NOC0)
             raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, size, True, elapsed_time)
         return result
 
-    def __write_to_device_reg(self, coord_x: int, coord_y: int, address: int, data: bytes, dma_threshold: int):
+    def __write_to_device_reg(self, coord: tt_umd.CoreCoord, address: int, data: bytes, dma_threshold: int):
         # Check if we can use DMA write
         if len(data) >= dma_threshold and self.can_use_dma:
-            return self.__device.dma_write_to_device(coord_x, coord_y, address, data)
+            return self.__device.dma_write_to_device(coord.x, coord.y, address, data)
 
         # TODO: Until UMD implements timeout exception, we measure time here
         start_time = time.time()
-        self.__device.noc_write(coord_x, coord_y, address, data)
+        self.__device.noc_write(coord.x, coord.y, address, data)
         end_time = time.time()
         elapsed_time = end_time - start_time  # seconds
         if (
@@ -155,9 +156,10 @@ class UmdDevice:
             and len(data) == 4
             and elapsed_time > UmdDevice.WRITE_TIMEOUT
         ):
-            translated_coord = self._soc_descriptor.translate_coord_to(
-                tt_umd.tt_xy_pair(coord_x, coord_y), tt_umd.CoordSystem.TRANSLATED, tt_umd.CoordSystem.LOGICAL
-            )
+            try:
+                translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.LOGICAL)
+            except Exception:
+                translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.NOC0)
             event = TimeoutDeviceRegisterError(
                 self.device_id, translated_coord, address, len(data), False, elapsed_time
             )
@@ -177,7 +179,7 @@ class UmdDevice:
         # Read first unaligned word
         first_unaligned_index = address % 4
         if first_unaligned_index != 0:
-            temp = self.__read_from_device_reg(coord.x, coord.y, address - first_unaligned_index, 4, dma_threshold)
+            temp = self.__read_from_device_reg(coord, address - first_unaligned_index, 4, dma_threshold)
             if first_unaligned_index + size <= 4:
                 return temp[first_unaligned_index : first_unaligned_index + size]
             data = bytearray()
@@ -191,7 +193,7 @@ class UmdDevice:
         aligned_size = size - (size % 4)
         block_size = 4 if use_4B_mode and self._is_mmio_capable and not self._is_simulation else aligned_size
         while aligned_size > 0:
-            data.extend(self.__read_from_device_reg(coord.x, coord.y, address, block_size, dma_threshold))
+            data.extend(self.__read_from_device_reg(coord, address, block_size, dma_threshold))
             aligned_size -= block_size
             address += block_size
             size -= block_size
@@ -199,7 +201,7 @@ class UmdDevice:
         # Read last unaligned word
         last_unaligned_size = size
         if last_unaligned_size != 0:
-            temp = self.__read_from_device_reg(coord.x, coord.y, address, 4, dma_threshold)
+            temp = self.__read_from_device_reg(coord, address, 4, dma_threshold)
             data.extend(temp[:last_unaligned_size])
 
         return bytes(data)
@@ -229,17 +231,17 @@ class UmdDevice:
         first_unaligned_index = address % 4
         if first_unaligned_index != 0:
             aligned_address = address - first_unaligned_index
-            temp = self.__read_from_device_reg(coord.x, coord.y, aligned_address, 4, dma_threshold)
+            temp = self.__read_from_device_reg(coord, aligned_address, 4, dma_threshold)
             if first_unaligned_index + size_in_bytes <= 4:
                 temp = (
                     temp[0:first_unaligned_index]
                     + data[0:size_in_bytes]
                     + temp[first_unaligned_index + size_in_bytes : 4]
                 )
-                self.__write_to_device_reg(coord.x, coord.y, aligned_address, temp, dma_threshold)
+                self.__write_to_device_reg(coord, aligned_address, temp, dma_threshold)
                 return
             temp = temp[0:first_unaligned_index] + data[0 : 4 - first_unaligned_index]
-            self.__write_to_device_reg(coord.x, coord.y, aligned_address, temp, dma_threshold)
+            self.__write_to_device_reg(coord, aligned_address, temp, dma_threshold)
             data = data[4 - first_unaligned_index :]
             address += 4 - first_unaligned_index
             size_in_bytes -= 4 - first_unaligned_index
@@ -249,7 +251,7 @@ class UmdDevice:
         block_size = 4 if use_4B_mode and self._is_mmio_capable and not self._is_simulation else aligned_size
         offset = 0
         while aligned_size > 0:
-            self.__write_to_device_reg(coord.x, coord.y, address, data[offset : offset + block_size], dma_threshold)
+            self.__write_to_device_reg(coord, address, data[offset : offset + block_size], dma_threshold)
             aligned_size -= block_size
             offset += block_size
             address += block_size
@@ -259,9 +261,9 @@ class UmdDevice:
         # Read/Write last unaligned word
         last_unaligned_size = size_in_bytes
         if last_unaligned_size != 0:
-            temp = self.__read_from_device_reg(coord.x, coord.y, address, 4, dma_threshold)
+            temp = self.__read_from_device_reg(coord, address, 4, dma_threshold)
             temp = data[0:last_unaligned_size] + temp[last_unaligned_size:4]
-            self.__write_to_device_reg(coord.x, coord.y, address, temp, dma_threshold)
+            self.__write_to_device_reg(coord, address, temp, dma_threshold)
 
     def __write_to_device_reg_unaligned(
         self, noc0_x: int, noc0_y: int, address: int, data: bytes, use_4B_mode: bool, dma_threshold: int


### PR DESCRIPTION
When timeout happens on coordinate that doesn't have logical coordinate, we will get wrong exception.
Forwarding CoreCoord to read/write methods to know how to do conversion of coordinates.