### PR TITLE
Select simulation device type based on path extension

### DIFF
--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,4 +1,4 @@
-tt-umd==0.9.4.260326
+tt-umd==0.9.5.dev260402
 deprecation>=2.1.0
 docopt>=0.6.2
 fastnumbers>=5.1.0

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -80,7 +80,10 @@ class UmdApi:
 
         UmdApi.select_noc_id(1 if initialize_with_noc1 else 0)
         if simulation_directory is not None:
-            tt_device = tt_umd.create_simulation_tt_device(simulation_directory)
+            if simulation_directory.endswith(".so"):
+                tt_device = tt_umd.TTSimTTDevice(simulation_directory)
+            else:
+                tt_device = tt_umd.RtlSimTTDevice(simulation_directory)
             soc_descriptor = tt_device.get_soc_descriptor()
             # Fix for simulator
             for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -80,7 +80,7 @@ class UmdApi:
 
         UmdApi.select_noc_id(1 if initialize_with_noc1 else 0)
         if simulation_directory is not None:
-            tt_device = tt_umd.RtlSimulationTTDevice.create(simulation_directory)
+            tt_device = tt_umd.create_simulation_tt_device(simulation_directory)
             soc_descriptor = tt_device.get_soc_descriptor()
             # Fix for simulator
             for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -81,9 +81,9 @@ class UmdApi:
         UmdApi.select_noc_id(1 if initialize_with_noc1 else 0)
         if simulation_directory is not None:
             if simulation_directory.endswith(".so"):
-                tt_device = tt_umd.TTSimTTDevice(simulation_directory)
+                tt_device = tt_umd.TTSimTTDevice.create(simulation_directory)
             else:
-                tt_device = tt_umd.RtlSimTTDevice(simulation_directory)
+                tt_device = tt_umd.RtlSimulationTTDevice.create(simulation_directory)
             soc_descriptor = tt_device.get_soc_descriptor()
             # Fix for simulator
             for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -80,6 +80,7 @@ class UmdApi:
 
         UmdApi.select_noc_id(1 if initialize_with_noc1 else 0)
         if simulation_directory is not None:
+            tt_device: tt_umd.TTDevice
             if simulation_directory.endswith(".so"):
                 tt_device = tt_umd.TTSimTTDevice.create(simulation_directory)
             else:


### PR DESCRIPTION
## Summary
- Select `TTSimTTDevice` for `.so` simulation paths (functional simulator), `RtlSimulationTTDevice` for directory paths (RTL simulator)
- Add `TTDevice` type annotation to fix mypy incompatible assignment error
- Bump tt-umd to 0.9.5.dev260402

## Test plan
- [x] Verify with RTL simulator directory paths
- [x] Verify with `.so` functional simulator paths
- [x] Run mypy type checking passes cleanly