### PR TITLE
Fixing safe mode arugment in lib methods

### DIFF
--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -288,7 +288,7 @@ def write_to_device(
     if len(data) == 0:
         raise TTException("Data to write must not be empty.")
 
-    coordinate.noc_write(addr, data, noc_id, use_4B_mode, safe_mode)
+    coordinate.noc_write(addr, data, noc_id, use_4B_mode, safe_mode=safe_mode)
 
 
 @trace_api


### PR DESCRIPTION
In some places in lib functions there is a bug where `safe_mode` argument is passed in place of `dma_threshold` argument. 
This PR fixes that.