### PR TITLE
Fixing ARC and PCIe BAR0 addresses on BH

### DIFF
--- a/ttexalens/hardware/blackhole/arc_block.py
+++ b/ttexalens/hardware/blackhole/arc_block.py
@@ -54,12 +54,12 @@ def get_register_base_address_callable(noc_id: int, has_mmio: bool) -> Callable[
                 return DeviceAddress(noc_address=0x80000000)
         elif noc_id == 0:
             return get_niu_register_base_address_callable(
-                DeviceAddress(noc_address=0x80050000, bar0_address=0x1FD04000 if has_mmio else None, noc_id=0)
+                DeviceAddress(noc_address=0x80050000)
             )(register_description)
         else:
             assert noc_id == 1
             return get_niu_register_base_address_callable(
-                DeviceAddress(noc_address=0x80058000, bar0_address=0x1FD14000 if has_mmio else None, noc_id=1)
+                DeviceAddress(noc_address=0x80058000)
             )(register_description)
 
     return get_register_base_address
@@ -87,10 +87,10 @@ class BlackholeArcBlock(ArcBlock):
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_local, self.location)
             self.noc0_regs = MemoryBlock(
-                size=0x10000, address=DeviceAddress(noc_address=0x80050000, bar0_address=0x1FD04000)
+                size=0x8000, address=DeviceAddress(noc_address=0x80050000)
             )
             self.noc1_regs = MemoryBlock(
-                size=0x10000, address=DeviceAddress(noc_address=0x80058000, bar0_address=0x1FD14000)
+                size=0x8000, address=DeviceAddress(noc_address=0x80058000)
             )
         else:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_remote, self.location)

--- a/ttexalens/hardware/blackhole/arc_block.py
+++ b/ttexalens/hardware/blackhole/arc_block.py
@@ -53,14 +53,10 @@ def get_register_base_address_callable(noc_id: int, has_mmio: bool) -> Callable[
             else:
                 return DeviceAddress(noc_address=0x80000000)
         elif noc_id == 0:
-            return get_niu_register_base_address_callable(
-                DeviceAddress(noc_address=0x80050000)
-            )(register_description)
+            return get_niu_register_base_address_callable(DeviceAddress(noc_address=0x80050000))(register_description)
         else:
             assert noc_id == 1
-            return get_niu_register_base_address_callable(
-                DeviceAddress(noc_address=0x80058000)
-            )(register_description)
+            return get_niu_register_base_address_callable(DeviceAddress(noc_address=0x80058000))(register_description)
 
     return get_register_base_address
 
@@ -86,12 +82,8 @@ class BlackholeArcBlock(ArcBlock):
         if self.device.is_local:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_local, self.location)
-            self.noc0_regs = MemoryBlock(
-                size=0x8000, address=DeviceAddress(noc_address=0x80050000)
-            )
-            self.noc1_regs = MemoryBlock(
-                size=0x8000, address=DeviceAddress(noc_address=0x80058000)
-            )
+            self.noc0_regs = MemoryBlock(size=0x8000, address=DeviceAddress(noc_address=0x80050000))
+            self.noc1_regs = MemoryBlock(size=0x8000, address=DeviceAddress(noc_address=0x80058000))
         else:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_remote, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_remote, self.location)

--- a/ttexalens/hardware/blackhole/pcie_block.py
+++ b/ttexalens/hardware/blackhole/pcie_block.py
@@ -10,8 +10,12 @@ from ttexalens.hardware.memory_block import MemoryBlock
 from ttexalens.memory_map import MemoryMapBlockInfo
 from ttexalens.register_store import RegisterStore
 
-register_store_noc0_initialization = get_niu_register_store_initialization(DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD04000, noc_id=0))
-register_store_noc1_initialization = get_niu_register_store_initialization(DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD14000, noc_id=1))
+register_store_noc0_initialization = get_niu_register_store_initialization(
+    DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD04000, noc_id=0)
+)
+register_store_noc1_initialization = get_niu_register_store_initialization(
+    DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD14000, noc_id=1)
+)
 
 
 class BlackholePcieBlock(BlackholeNocBlock):

--- a/ttexalens/hardware/blackhole/pcie_block.py
+++ b/ttexalens/hardware/blackhole/pcie_block.py
@@ -3,15 +3,23 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.hardware.blackhole.niu_registers import get_niu_register_store_initialization
 from ttexalens.hardware.blackhole.noc_block import BlackholeNocBlock
 from ttexalens.hardware.device_address import DeviceAddress
 from ttexalens.hardware.memory_block import MemoryBlock
 from ttexalens.memory_map import MemoryMapBlockInfo
+from ttexalens.register_store import RegisterStore
+
+register_store_noc0_initialization = get_niu_register_store_initialization(DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD04000, noc_id=0))
+register_store_noc1_initialization = get_niu_register_store_initialization(DeviceAddress(noc_address=0xFFFFFFFF_FF000000, bar0_address=0x1FD14000, noc_id=1))
 
 
 class BlackholePcieBlock(BlackholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(location, block_type="pcie")
+
+        self.register_store_noc0 = RegisterStore(register_store_noc0_initialization, self.location)
+        self.register_store_noc1 = RegisterStore(register_store_noc1_initialization, self.location)
 
         self.noc_regs = MemoryBlock(size=0x10000, address=DeviceAddress(noc_address=0xFFFFFFFF_FF000000))
         self.noc_memory_map.add_blocks(


### PR DESCRIPTION
On BH, NIU on BAR0 is not ARC, but PCIe. On WH, it is other way around.