### PR TITLE
Fixing flaky CI due to umd bug

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,13 +146,13 @@ jobs:
       - name: Run Python tests for ttexalens library (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py & # Workaround due to bug: #999
+          python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py & # Workaround due to bug: #999
+          python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/app -p *test*.py
 
       - name: Install wheel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,11 @@ jobs:
           JOB_ID="${{ github.run_id }}_ubuntu_${{ inputs.ubuntu-version }}_${{ matrix.runner-info.arch }}_${{ matrix.runner-info.board }}"
           echo "test_report_path=report_${JOB_ID}.xml" >> "$GITHUB_OUTPUT"
 
+      - name: Start ttexalens
+        run: |
+          tt-exalens &
+          echo "TTEXALENS_PID=$!" >> $GITHUB_ENV
+
       - name: Run Python tests for ttexalens library (using NOC0)
         run: |
           python3 -m xmlrunner discover -v -t . -s test/ttexalens -p '*test*.py' \
@@ -161,3 +166,8 @@ jobs:
           # Change to the wheel tests directory so that we are certain we don't import dev files
           cd test/wheel
           ./run-wheel.sh
+
+      - name: Stop ttexalens
+        if: always()
+        run: |
+          kill $TTEXALENS_PID || true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,13 +146,13 @@ jobs:
       - name: Run Python tests for ttexalens library (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py & # HACK
+          python3 tt-exalens.py & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py & # HACK
+          python3 tt-exalens.py & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/app -p *test*.py
 
       - name: Install wheel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,6 +128,12 @@ jobs:
           JOB_ID="${{ github.run_id }}_ubuntu_${{ inputs.ubuntu-version }}_${{ matrix.runner-info.arch }}_${{ matrix.runner-info.board }}"
           echo "test_report_path=report_${JOB_ID}.xml" >> "$GITHUB_OUTPUT"
 
+      - name: Run tt-exalens in background
+        shell: bash
+        run: |
+          # Run tt-exalens in the background to mitigate #999.
+          python3 tt-exalens.py > /dev/null 2>&1 &
+
       - name: Run Python tests for ttexalens library (using NOC0)
         run: |
           python3 -m xmlrunner discover -v -t . -s test/ttexalens -p '*test*.py' \
@@ -146,13 +152,11 @@ jobs:
       - name: Run Python tests for ttexalens library (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py > /dev/null 2>&1 & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py > /dev/null 2>&1 & # Workaround due to bug: #999
           python3 -m unittest discover -v -t . -s test/app -p *test*.py
 
       - name: Install wheel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,14 +146,14 @@ jobs:
       - name: Run Python tests for ttexalens library (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
-          python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py > /dev/null
+          python3 tt-exalens.py > /dev/null 2>&1 & # Workaround due to bug: #999
+          python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
-          python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
-          python3 -m unittest discover -v -t . -s test/app -p *test*.py > /dev/null
+          python3 tt-exalens.py > /dev/null 2>&1 & # Workaround due to bug: #999
+          python3 -m unittest discover -v -t . -s test/app -p *test*.py
 
       - name: Install wheel
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -128,11 +128,6 @@ jobs:
           JOB_ID="${{ github.run_id }}_ubuntu_${{ inputs.ubuntu-version }}_${{ matrix.runner-info.arch }}_${{ matrix.runner-info.board }}"
           echo "test_report_path=report_${JOB_ID}.xml" >> "$GITHUB_OUTPUT"
 
-      - name: Start ttexalens
-        run: |
-          tt-exalens &
-          echo "TTEXALENS_PID=$!" >> $GITHUB_ENV
-
       - name: Run Python tests for ttexalens library (using NOC0)
         run: |
           python3 -m xmlrunner discover -v -t . -s test/ttexalens -p '*test*.py' \
@@ -151,11 +146,13 @@ jobs:
       - name: Run Python tests for ttexalens library (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
+          python3 tt-exalens.py & # HACK
           python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
+          python3 tt-exalens.py & # HACK
           python3 -m unittest discover -v -t . -s test/app -p *test*.py
 
       - name: Install wheel
@@ -166,8 +163,3 @@ jobs:
           # Change to the wheel tests directory so that we are certain we don't import dev files
           cd test/wheel
           ./run-wheel.sh
-
-      - name: Stop ttexalens
-        if: always()
-        run: |
-          kill $TTEXALENS_PID || true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -147,13 +147,13 @@ jobs:
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
           python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
-          python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py
+          python3 -m unittest discover -v -t . -s test/ttexalens -p *test*.py > /dev/null
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |
           export TTEXALENS_TESTS_USE_NOC1=1
           python3 tt-exalens.py < /dev/null & # Workaround due to bug: #999
-          python3 -m unittest discover -v -t . -s test/app -p *test*.py
+          python3 -m unittest discover -v -t . -s test/app -p *test*.py > /dev/null
 
       - name: Install wheel
         run: |

--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,4 +1,5 @@
 tt-umd==0.9.5.dev260402
+deprecation>=2.1.0
 docopt>=0.6.2
 fastnumbers>=5.1.0
 fuzzywuzzy>=0.18.0

--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,5 +1,4 @@
-tt-umd==0.9.4.260326
-deprecation>=2.1.0
+tt-umd==0.9.5.dev260402
 docopt>=0.6.2
 fastnumbers>=5.1.0
 fuzzywuzzy>=0.18.0

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -80,7 +80,11 @@ class UmdApi:
 
         UmdApi.select_noc_id(1 if initialize_with_noc1 else 0)
         if simulation_directory is not None:
-            tt_device = tt_umd.RtlSimulationTTDevice.create(simulation_directory)
+            tt_device: tt_umd.TTDevice
+            if simulation_directory.endswith(".so"):
+                tt_device = tt_umd.TTSimTTDevice.create(simulation_directory)
+            else:
+                tt_device = tt_umd.RtlSimulationTTDevice.create(simulation_directory)
             soc_descriptor = tt_device.get_soc_descriptor()
             # Fix for simulator
             for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):


### PR DESCRIPTION
This closes https://github.com/tenstorrent/tt-umd/issues/2449

Our NOC1 tests became flaky on blackhole due to issue with new KMD that puts device in low power mode when no processes are running. The problem is when we try to start UMD it does not wait for device to leave low power mode and due to that we can start testing before device is ready hitting an error.

We mitigate this by starting exalens before running tests so device has enough time to leave low power mode. This is a mitigation and will be reverted when UMD implements a fix.

Issue for tracking real fix: #999

Reintroducing reverted commit: #950 