### PR TITLE
Fixing info os processes bug

### DIFF
--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -1209,7 +1209,7 @@ class GdbServer(threading.Thread):
                     "pid": pid,
                     "user": self.context.short_name,
                     "cores": process.virtual_core_id,
-                    "device": process.risc_debug.risc_location.location._device._id,
+                    "device": process.risc_debug.risc_location.location.device_id,
                     "core_type": process.core_type,
                     "core_location": process.risc_debug.risc_location.location.to_user_str(),
                     "risc": process.risc_debug.risc_location.risc_name,


### PR DESCRIPTION
We had regression in `gdb_server.py`, when trying to list processes we use deprecated `device._id` which causes error to be thrown.

This PR fixes it.