### PR TITLE
hardware/baby_risc_info: fix JAL offset calculation in set_code_start_address

### DIFF
--- a/ttexalens/hardware/baby_risc_info.py
+++ b/ttexalens/hardware/baby_risc_info.py
@@ -68,7 +68,7 @@ class BabyRiscInfo(RiscInfo):
 
             # If we cannot change the code start address, we write a jump instruction to the specified address
             assert self.default_code_start_address is not None
-            jump_instruction = ElfLoader.get_jump_to_offset_instruction(address)
+            jump_instruction = ElfLoader.get_jump_to_offset_instruction(address - self.default_code_start_address)
             register_store.location.noc_write32(self.default_code_start_address, jump_instruction)
         elif address is not None:
             if self.code_start_address_enable_register is not None and self.code_start_address_enable_bit is not None:


### PR DESCRIPTION
## Summary

`set_code_start_address` falls back to writing a JAL instruction at
`default_code_start_address` when the core cannot change its start address
via a register. JAL in RISC-V is PC-relative, so the immediate must be
`target - PC`. The code was passing the raw `address` as the immediate,
which is only accidentally correct when `default_code_start_address == 0`
(BRISC). For all other cores the generated JAL would jump to
`default_code_start_address + address` instead of `address`.

## Root Cause

```python
# Before (incorrect for any non-zero default_code_start_address)
jump_instruction = ElfLoader.get_jump_to_offset_instruction(address)

# After (correct PC-relative offset)
jump_instruction = ElfLoader.get_jump_to_offset_instruction(address - self.default_code_start_address)
```

## Affected Cores

| Core   | `default_code_start_address` | Broken before fix? |
|--------|-----------------------------|--------------------|
| BRISC  | `0x00000000`                | No (offset == address) |
| TRISC0 | `0x00006000`                | ✅ Yes |
| TRISC1 | `0x0000A000`                | ✅ Yes |
| TRISC2 | `0x0000E000`                | ✅ Yes |
| NCRISC | `0x00012000`                | ✅ Yes |
| ERISC  | `0xFFC00000`                | ✅ Yes |

## Testing

Existing unit tests pass. The fix is a single-token change with no
API surface or behaviour change for BRISC (`0 - 0 == 0`).