### PR TITLE
Add trace_api decorator to get_tensix_state and update exports

### DIFF
--- a/ttexalens/__init__.py
+++ b/ttexalens/__init__.py
@@ -9,6 +9,7 @@ from .tt_exalens_lib import (
     check_context,
     convert_coordinate,
     coverage,
+    get_tensix_state,
     load_elf,
     parse_elf,
     read_arc_telemetry_entry,
@@ -32,8 +33,8 @@ from .util import TTException, TTFatalException, Verbosity
 from .exceptions import (
     CoordinateTranslationError,
     RestrictedMemoryAccessError,
-    UnsafeAccessException,
     TimeoutDeviceRegisterError,
+    UnsafeAccessException,
 )
 
 
@@ -41,10 +42,14 @@ __all__ = [
     # context.py
     "Context",
     # coordinate.py
-    "CoordinateTranslationError",
     "OnChipCoordinate",
     # device.py
     "Device",
+    # exceptions.py
+    "CoordinateTranslationError",
+    "RestrictedMemoryAccessError",
+    "TimeoutDeviceRegisterError",
+    "UnsafeAccessException",
     # tt_exalens_init.py
     "init_ttexalens",
     "init_ttexalens_remote",
@@ -55,6 +60,7 @@ __all__ = [
     "check_context",
     "convert_coordinate",
     "coverage",
+    "get_tensix_state",
     "load_elf",
     "parse_elf",
     "read_arc_telemetry_entry",
@@ -74,7 +80,4 @@ __all__ = [
     "TTException",
     "TTFatalException",
     "Verbosity",
-    "RestrictedMemoryAccessError",
-    "UnsafeAccessException",
-    "TimeoutDeviceRegisterError",
 ]

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -834,6 +834,7 @@ class TensixState:
     address_counters: dict[str, int]
 
 
+@trace_api
 def get_tensix_state(
     location: str | OnChipCoordinate,
     l1_address: int | None = None,


### PR DESCRIPTION
Introduce the `trace_api` decorator to the `get_tensix_state` function for enhanced tracing. Refactor `__init__.py` to reorder imports and ensure consistent exports.