### PR TITLE
Fix performance for remote chips on T3K

### DIFF
--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -96,9 +96,9 @@ class UmdApi:
                 tt_device.send_tensix_risc_reset(
                     tt_umd.tt_xy_pair(core.x, core.y), tt_umd.TensixSoftResetOptions.TENSIX_DEASSERT_SOFT_RESET
                 )
-            self.devices[0] = UmdDevice(self, tt_device, 0, 0, soc_descriptor=soc_descriptor, is_simulation=True)
-            cluster_descriptor_content = create_simulation_cluster_descriptor(self.devices[0].arch)
+            cluster_descriptor_content = create_simulation_cluster_descriptor(tt_device.get_arch())
             self.cluster_descriptor = tt_umd.ClusterDescriptor.create_from_yaml_content(cluster_descriptor_content)
+            self.devices[0] = UmdDevice(self, tt_device, 0, 0, soc_descriptor=soc_descriptor, cluster_descriptor=self.cluster_descriptor, is_simulation=True)
         else:
             self.discovery_options = tt_umd.TopologyDiscoveryOptions()
             self.discovery_options.cmfw_mismatch_action = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
@@ -117,6 +117,7 @@ class UmdApi:
                 raise RuntimeError("No Tenstorrent devices were detected on this system.")
 
             # Setup used devices
+            eth_connections = self.cluster_descriptor.get_ethernet_connections()
             unique_ids = self.cluster_descriptor.get_chip_unique_ids()
             for chip_id in self.cluster_descriptor.get_all_chips():
                 device = devices[chip_id]
@@ -127,14 +128,20 @@ class UmdApi:
                     soc_descriptor = tt_umd.SocDescriptor(device)
                     mmio_chip_id = self.cluster_descriptor.get_closest_mmio_capable_chip(chip_id)
                     active_eth_channels = self.cluster_descriptor.get_active_eth_channels(mmio_chip_id)
+                    local_chip_eth_channels = set()
+                    for channel in active_eth_channels:
+                        if mmio_chip_id in eth_connections and channel in eth_connections[mmio_chip_id]:
+                            connection = eth_connections[mmio_chip_id][channel]
+                            if connection[0] == chip_id:
+                                local_chip_eth_channels.add(channel)
                     active_eth_cores = soc_descriptor.get_eth_cores_for_channels(
-                        active_eth_channels, tt_umd.CoordSystem.TRANSLATED
+                        local_chip_eth_channels, tt_umd.CoordSystem.TRANSLATED
                     )
-                    active_eth_coords_on_mmio_chip = [(core.x, core.y) for core in active_eth_cores]
+                    active_eth_coords_on_mmio_chip = [(core.x, core.y) for core in sorted(active_eth_cores, key=lambda core: (core.y, core.x))]
                 else:
                     active_eth_coords_on_mmio_chip = []
 
-                wrapped_device = UmdDevice(self, device, chip_id, unique_id, active_eth_coords_on_mmio_chip)
+                wrapped_device = UmdDevice(self, device, chip_id, unique_id, active_eth_coords_on_mmio_chip, cluster_descriptor=self.cluster_descriptor)
                 assert wrapped_device.is_mmio_capable == self.cluster_descriptor.is_chip_mmio_capable(chip_id)
                 self.devices[chip_id] = wrapped_device
                 self.devices[unique_id] = wrapped_device

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -98,7 +98,15 @@ class UmdApi:
                 )
             cluster_descriptor_content = create_simulation_cluster_descriptor(tt_device.get_arch())
             self.cluster_descriptor = tt_umd.ClusterDescriptor.create_from_yaml_content(cluster_descriptor_content)
-            self.devices[0] = UmdDevice(self, tt_device, 0, 0, soc_descriptor=soc_descriptor, cluster_descriptor=self.cluster_descriptor, is_simulation=True)
+            self.devices[0] = UmdDevice(
+                self,
+                tt_device,
+                0,
+                0,
+                soc_descriptor=soc_descriptor,
+                cluster_descriptor=self.cluster_descriptor,
+                is_simulation=True,
+            )
         else:
             self.discovery_options = tt_umd.TopologyDiscoveryOptions()
             self.discovery_options.cmfw_mismatch_action = tt_umd.TopologyDiscoveryOptions.Action.IGNORE
@@ -137,11 +145,20 @@ class UmdApi:
                     active_eth_cores = soc_descriptor.get_eth_cores_for_channels(
                         local_chip_eth_channels, tt_umd.CoordSystem.TRANSLATED
                     )
-                    active_eth_coords_on_mmio_chip = [(core.x, core.y) for core in sorted(active_eth_cores, key=lambda core: (core.y, core.x))]
+                    active_eth_coords_on_mmio_chip = [
+                        (core.x, core.y) for core in sorted(active_eth_cores, key=lambda core: (core.y, core.x))
+                    ]
                 else:
                     active_eth_coords_on_mmio_chip = []
 
-                wrapped_device = UmdDevice(self, device, chip_id, unique_id, active_eth_coords_on_mmio_chip, cluster_descriptor=self.cluster_descriptor)
+                wrapped_device = UmdDevice(
+                    self,
+                    device,
+                    chip_id,
+                    unique_id,
+                    active_eth_coords_on_mmio_chip,
+                    cluster_descriptor=self.cluster_descriptor,
+                )
                 assert wrapped_device.is_mmio_capable == self.cluster_descriptor.is_chip_mmio_capable(chip_id)
                 self.devices[chip_id] = wrapped_device
                 self.devices[unique_id] = wrapped_device

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -48,9 +48,15 @@ class UmdDevice:
         self.__write_timeout_events: list[TimeoutDeviceRegisterError] = []
 
         # On T3K we observed slower communication over default active ETH, so we try to switch to another active ETH if available.
-        if device.is_remote() and cluster_descriptor is not None and cluster_descriptor.get_board_type(device_id) == tt_umd.BoardType.N300:
+        if (
+            device.is_remote()
+            and cluster_descriptor is not None
+            and cluster_descriptor.get_board_type(device_id) == tt_umd.BoardType.N300
+        ):
             if len(active_eth_coords_on_mmio_chip) > 1:
-                self._active_eth_coords_on_mmio_chip = active_eth_coords_on_mmio_chip[1:] + active_eth_coords_on_mmio_chip[:1]
+                self._active_eth_coords_on_mmio_chip = (
+                    active_eth_coords_on_mmio_chip[1:] + active_eth_coords_on_mmio_chip[:1]
+                )
             self.__configure_working_active_eth()
 
     @property

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -25,6 +25,7 @@ class UmdDevice:
         unique_id: int,
         active_eth_coords_on_mmio_chip: list[tuple[int, int]] = [],
         soc_descriptor: tt_umd.SocDescriptor | None = None,
+        cluster_descriptor: tt_umd.ClusterDescriptor | None = None,
         is_simulation: bool = False,
     ):
         # IMPORTANT:
@@ -45,6 +46,12 @@ class UmdDevice:
         # TODO: Until UMD implements timeout exception, we measure time here
         self.__write_timeout_lock = threading.Lock()
         self.__write_timeout_events: list[TimeoutDeviceRegisterError] = []
+
+        # On T3K we observed slower communication over default active ETH, so we try to switch to another active ETH if available.
+        if device.is_remote() and cluster_descriptor is not None and cluster_descriptor.get_board_type(device_id) == tt_umd.BoardType.N300:
+            if len(active_eth_coords_on_mmio_chip) > 1:
+                self._active_eth_coords_on_mmio_chip = active_eth_coords_on_mmio_chip[1:] + active_eth_coords_on_mmio_chip[:1]
+            self.__configure_working_active_eth()
 
     @property
     def device_id(self) -> int:


### PR DESCRIPTION
Using second link to T3K solves performance issue with remote device.
Also, fixing how we find active ETH links on local device for remote device.