### PR TITLE
Making fetching risc debug for rocket cores case insensitive

### DIFF
--- a/ttexalens/hardware/quasar/functional_overlay_block.py
+++ b/ttexalens/hardware/quasar/functional_overlay_block.py
@@ -193,6 +193,7 @@ class QuasarFunctionalOverlayBlock:
             self.rocket6,
             self.rocket7,
         ]
+        risc_name = risc_name.lower()
         for core in rocket_infos:
             if core.risc_name == risc_name:
                 return QuasarRocketCoreDebug(core, self.register_store)


### PR DESCRIPTION
Making fetching `RiscDebug` instance for rocket cores case insensitive to align with `get_risc_debug` for other risc types.