### PR TITLE
Adding tests for locals/arguments evaluation during callstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ build:
 			-DCMAKE_POLICY_VERSION_MINIMUM=3.5; \
 	fi
 	@ninja -C $(BUILD_DIR)
+	@echo "Running mypy"
+	python3 -m mypy
+	@echo "Running basedpyright"
+	python3 -m basedpyright
 
 dump_elfs:
 	DUMP_ELFS=ON $(MAKE) build

--- a/riscv-src/callstack.cc
+++ b/riscv-src/callstack.cc
@@ -10,6 +10,20 @@ extern uint32_t* __firmware_end;
 volatile uint32_t* g_MAILBOX = (volatile uint32_t*)&__firmware_end;
 static volatile uint32_t g_MAILBOX_anchor __attribute__((used)) = (uint32_t)(uintptr_t)&g_MAILBOX;
 
+volatile uint8_t* g_MAILBOX_value = (volatile uint8_t*)(((uintptr_t)&__firmware_end + 4 + 16) & ~(uintptr_t)15);
+static volatile uint32_t g_MAILBOX_value_anchor __attribute__((used)) = (uint32_t)(uintptr_t)&g_MAILBOX_value;
+
+// Reads a value of type T from the host-written g_MAILBOX_value buffer at the given byte offset.
+template <typename T>
+static T host_value(unsigned offset) {
+    return *reinterpret_cast<volatile T*>(g_MAILBOX_value + offset);
+}
+
+// A real string that the const char* value tests point at, so a test can read and verify its
+// contents (rather than a pointer to nowhere). The single-frame and callee-saved tests get its
+// address from the host (which resolves this symbol), the chained tests point at it directly.
+char g_test_string[] __attribute__((used)) = "Tenstorrent callstack string";
+
 void halt() {
     // Halt core with ebreak
     asm volatile("ebreak");
@@ -49,8 +63,309 @@ class TemplateClass {
 };
 }  // namespace template_test
 
+#define TTEXALENS_KEEP_ON_STACK(arg, local) asm volatile("" : : "r"(&(arg)), "r"(&(local)) : "memory")
+
+namespace value_test {
+
+__attribute__((noinline, noclone)) void value_test_bool(bool arg) {
+    bool local = false;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    halt();
+}
+
+__attribute__((noinline, noclone)) void value_test_uint8(uint8_t arg) {
+    uint8_t local = 17;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_bool(true);
+}
+
+__attribute__((noinline, noclone)) void value_test_int8(int8_t arg) {
+    int8_t local = 50;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint8(200);
+}
+
+__attribute__((noinline, noclone)) void value_test_uint16(uint16_t arg) {
+    uint16_t local = 1234;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int8(-100);
+}
+
+__attribute__((noinline, noclone)) void value_test_int16(int16_t arg) {
+    int16_t local = 5678;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint16(60000);
+}
+
+__attribute__((noinline, noclone)) void value_test_uint32(uint32_t arg) {
+    uint32_t local = 12345678;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int16(-30000);
+}
+
+__attribute__((noinline, noclone)) void value_test_int32(int32_t arg) {
+    int32_t local = 87654321;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint32(4000000000u);
+}
+
+__attribute__((noinline, noclone)) void value_test_uint64(uint64_t arg) {
+    uint64_t local = 1234567890123ull;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int32(-2000000000);
+}
+
+__attribute__((noinline, noclone)) void value_test_int64(int64_t arg) {
+    int64_t local = 9876543210ll;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint64(18000000000000000000ull);
+}
+
+__attribute__((noinline, noclone)) void value_test_float(float arg) {
+    float local = -1.25f;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int64(-9000000000000000000ll);
+}
+
+__attribute__((noinline, noclone)) void value_test_double(double arg) {
+    double local = -7.75;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_float(3.5f);
+}
+
+__attribute__((noinline, noclone)) void value_test_charptr(const char* arg) {
+    const char* local = g_test_string;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_double(2.5);
+}
+}  // namespace value_test
+
+namespace inline_value_test {
+
+__attribute__((always_inline)) inline void value_test_bool(bool arg) {
+    bool local = false;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    halt();
+}
+
+__attribute__((always_inline)) inline void value_test_uint8(uint8_t arg) {
+    uint8_t local = 17;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_bool(true);
+}
+
+__attribute__((always_inline)) inline void value_test_int8(int8_t arg) {
+    int8_t local = 50;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint8(200);
+}
+
+__attribute__((always_inline)) inline void value_test_uint16(uint16_t arg) {
+    uint16_t local = 1234;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int8(-100);
+}
+
+__attribute__((always_inline)) inline void value_test_int16(int16_t arg) {
+    int16_t local = 5678;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint16(60000);
+}
+
+__attribute__((always_inline)) inline void value_test_uint32(uint32_t arg) {
+    uint32_t local = 12345678;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int16(-30000);
+}
+
+__attribute__((always_inline)) inline void value_test_int32(int32_t arg) {
+    int32_t local = 87654321;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint32(4000000000u);
+}
+
+__attribute__((always_inline)) inline void value_test_uint64(uint64_t arg) {
+    uint64_t local = 1234567890123ull;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int32(-2000000000);
+}
+
+__attribute__((always_inline)) inline void value_test_int64(int64_t arg) {
+    int64_t local = 9876543210ll;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_uint64(18000000000000000000ull);
+}
+
+__attribute__((always_inline)) inline void value_test_float(float arg) {
+    float local = -1.25f;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_int64(-9000000000000000000ll);
+}
+
+__attribute__((always_inline)) inline void value_test_double(double arg) {
+    double local = -7.75;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_float(3.5f);
+}
+
+__attribute__((always_inline)) inline void value_test_charptr(const char* arg) {
+    const char* local = g_test_string;
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    value_test_double(2.5);
+}
+
+__attribute__((noinline)) void run() { value_test_charptr(g_test_string); }
+}  // namespace inline_value_test
+
+namespace single_frame_value_test {
+
+volatile uint64_t single_frame_sink;
+
+template <typename T>
+__attribute__((noinline)) void value_test(T arg) {
+    T local = host_value<T>(8);
+    TTEXALENS_KEEP_ON_STACK(arg, local);
+    asm volatile("ebreak");
+}
+
+__attribute__((noinline)) void dispatch(uint32_t type_index) {
+    switch (type_index) {
+        case 0:
+            value_test<bool>(host_value<bool>(0));
+            break;
+        case 1:
+            value_test<uint8_t>(host_value<uint8_t>(0));
+            break;
+        case 2:
+            value_test<int8_t>(host_value<int8_t>(0));
+            break;
+        case 3:
+            value_test<uint16_t>(host_value<uint16_t>(0));
+            break;
+        case 4:
+            value_test<int16_t>(host_value<int16_t>(0));
+            break;
+        case 5:
+            value_test<uint32_t>(host_value<uint32_t>(0));
+            break;
+        case 6:
+            value_test<int32_t>(host_value<int32_t>(0));
+            break;
+        case 7:
+            value_test<uint64_t>(host_value<uint64_t>(0));
+            break;
+        case 8:
+            value_test<int64_t>(host_value<int64_t>(0));
+            break;
+        case 9:
+            value_test<float>(host_value<float>(0));
+            break;
+        case 10:
+            value_test<double>(host_value<double>(0));
+            break;
+        case 11:
+            value_test<const char*>(host_value<const char*>(0));
+            break;
+    }
+}
+}  // namespace single_frame_value_test
+
+// Declares reg_value, bound to the callee-saved register s2 and initialized from a distinct slot
+// of the host-written g_MAILBOX_value buffer, then forces the value into the register.
+#define DECLARE_CALLEE_SAVED_VALUE(type, slot)                        \
+    register type reg_value asm("s2") = host_value<type>((slot) * 8); \
+    asm volatile("" : "+r"(reg_value))
+
+// Keeps reg_value live past the nested call so it is preserved in - or spilled from - s2.
+#define USE_CALLEE_SAVED_VALUE() asm volatile("" : : "r"(reg_value))
+
+namespace callee_saved_test {
+// These functions form a chain that all reuse the same callee-saved register (s2), one value per
+// type. Because every inner function reuses s2, it spills the caller's s2 in its prologue, so at
+// the halt point every frame's value is recoverable by following the DWARF call-frame register
+// rules - from where an inner frame spilled it (DW_CFA_offset), or, for the innermost frame, still
+// live in s2 - exercising register recovery for all types in a single call stack evaluation. This
+// is unlike a value left in a caller-saved register, which is lost once a deeper call clobbers it.
+
+__attribute__((noinline, noclone)) void value_test_bool() {
+    DECLARE_CALLEE_SAVED_VALUE(bool, 0);
+    halt();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_uint8() {
+    DECLARE_CALLEE_SAVED_VALUE(uint8_t, 1);
+    value_test_bool();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_int8() {
+    DECLARE_CALLEE_SAVED_VALUE(int8_t, 2);
+    value_test_uint8();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_uint16() {
+    DECLARE_CALLEE_SAVED_VALUE(uint16_t, 3);
+    value_test_int8();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_int16() {
+    DECLARE_CALLEE_SAVED_VALUE(int16_t, 4);
+    value_test_uint16();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_uint32() {
+    DECLARE_CALLEE_SAVED_VALUE(uint32_t, 5);
+    value_test_int16();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_int32() {
+    DECLARE_CALLEE_SAVED_VALUE(int32_t, 6);
+    value_test_uint32();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_uint64() {
+    DECLARE_CALLEE_SAVED_VALUE(uint64_t, 7);
+    value_test_int32();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_int64() {
+    DECLARE_CALLEE_SAVED_VALUE(int64_t, 8);
+    value_test_uint64();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_float() {
+    DECLARE_CALLEE_SAVED_VALUE(float, 9);
+    value_test_int64();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_double() {
+    DECLARE_CALLEE_SAVED_VALUE(double, 10);
+    value_test_float();
+    USE_CALLEE_SAVED_VALUE();
+}
+
+__attribute__((noinline, noclone)) void value_test_charptr() {
+    DECLARE_CALLEE_SAVED_VALUE(const char*, 11);
+    value_test_double();
+    USE_CALLEE_SAVED_VALUE();
+}
+}  // namespace callee_saved_test
+
+#undef DECLARE_CALLEE_SAVED_VALUE
+#undef USE_CALLEE_SAVED_VALUE
+
 int main() {
-    if (*g_MAILBOX != 0xFFFFFFFF && *g_MAILBOX != 0xFFFFFFFE && (*g_MAILBOX < 0 || *g_MAILBOX > 1000)) {
+    if (*g_MAILBOX != 0xFFFFFFFF && *g_MAILBOX != 0xFFFFFFFE && *g_MAILBOX != 0xFFFFFFFD && *g_MAILBOX != 0xFFFFFFFC &&
+        *g_MAILBOX != 0xFFFFFFFB && (*g_MAILBOX & 0xFFFFFF00) != 0xFFFFFE00 && (*g_MAILBOX < 0 || *g_MAILBOX > 1000)) {
         *g_MAILBOX = 10;
     }
 
@@ -60,6 +375,14 @@ int main() {
         template_test::TemplateClass<3>::static_method<-1>();
     } else if (*g_MAILBOX == 0xFFFFFFFE) {
         template_test::TemplateClass<4>::static_method<-3>();
+    } else if (*g_MAILBOX == 0xFFFFFFFD) {
+        value_test::value_test_charptr(g_test_string);
+    } else if (*g_MAILBOX == 0xFFFFFFFC) {
+        inline_value_test::run();
+    } else if ((*g_MAILBOX & 0xFFFFFF00) == 0xFFFFFE00) {
+        single_frame_value_test::dispatch(*g_MAILBOX & 0xFF);
+    } else if (*g_MAILBOX == 0xFFFFFFFB) {
+        callee_saved_test::value_test_charptr();
     } else {
         int sum = recurse(*g_MAILBOX);
         *g_MAILBOX = sum;

--- a/riscv-src/callstack.cc
+++ b/riscv-src/callstack.cc
@@ -10,13 +10,14 @@ extern uint32_t* __firmware_end;
 volatile uint32_t* g_MAILBOX = (volatile uint32_t*)&__firmware_end;
 static volatile uint32_t g_MAILBOX_anchor __attribute__((used)) = (uint32_t)(uintptr_t)&g_MAILBOX;
 
-volatile uint8_t* g_MAILBOX_value = (volatile uint8_t*)(((uintptr_t)&__firmware_end + 4 + 16) & ~(uintptr_t)15);
-static volatile uint32_t g_MAILBOX_value_anchor __attribute__((used)) = (uint32_t)(uintptr_t)&g_MAILBOX_value;
+static volatile uint8_t* mailbox_value_buffer() {
+    return (volatile uint8_t*)(((uintptr_t)&__firmware_end + 4 + 16) & ~(uintptr_t)15);
+}
 
-// Reads a value of type T from the host-written g_MAILBOX_value buffer at the given byte offset.
+// Reads a value of type T from the host-written value buffer at the given byte offset.
 template <typename T>
 static T host_value(unsigned offset) {
-    return *reinterpret_cast<volatile T*>(g_MAILBOX_value + offset);
+    return *reinterpret_cast<volatile T*>(mailbox_value_buffer() + offset);
 }
 
 // A real string that the const char* value tests point at, so a test can read and verify its

--- a/riscv-src/globals_test.cc
+++ b/riscv-src/globals_test.cc
@@ -86,6 +86,8 @@ struct GlobalStruct : public BaseStruct, public BaseStruct2 {
     uint32_t* invalid_memory_ptr;
     InnerStruct* wrong_type_ptr;
     int64_t signed_int_field;
+    char string_buffer[32];
+    const char* string_pointer;
 };
 
 GlobalStruct g_global_struct;
@@ -133,6 +135,13 @@ void update_struct(GlobalStruct* gs) {
     gs->invalid_memory_ptr = reinterpret_cast<uint32_t*>(0xFFFF0000);
     gs->wrong_type_ptr = reinterpret_cast<InnerStruct*>(&gs->uint_array[0]);
     gs->signed_int_field = -123456789;
+    const char* string_source = "Hello, struct!";
+    int string_index = 0;
+    for (; string_source[string_index] != 0; string_index++) {
+        gs->string_buffer[string_index] = string_source[string_index];
+    }
+    gs->string_buffer[string_index] = 0;
+    gs->string_pointer = "pointer to string";
 }
 
 int main() {

--- a/riscv-src/sections.ld
+++ b/riscv-src/sections.ld
@@ -81,13 +81,27 @@ SECTIONS
      __ldm_data_start = .;
      *(.rodata .rodata.* .gnu.linkonce.r.*)
      *(.rodata1)
+    /*
+     * Align before each array boundary symbol. These arrays hold 4-byte function pointers that
+     * tmu-crt0 walks with a `start; while (s != end) { call *s; s += 4; }` loop. Because everything
+     * lives in one .ldm_data output section (instead of dedicated .init_array/etc. sections that
+     * carry their own alignment), the *_start symbols are captured at the bare location counter.
+     * If preceding .rodata (e.g. the gcov filename string in coverage builds) ends off a 4-byte
+     * boundary, the linker still places the pointer data 4-aligned, leaving *_start a few bytes
+     * below the real data: the crt0 loop then reads misaligned garbage and `s` steps right past
+     * `end` without ever equalling it, looping forever into garbage. ALIGN(4) keeps each *_start
+     * consistent with the aligned pointer data so start + 4*N == end exactly.
+     */
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array))
     PROVIDE_HIDDEN (__preinit_array_end = .);
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
     KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
     PROVIDE_HIDDEN (__init_array_end = .);
+    . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
     KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -158,6 +158,8 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(2, g_global_struct.enum_class_field.read_value())
         self.assertEqual(20, g_global_struct.enum_type_field.read_value())
         self.assertEqual(-123456789, g_global_struct.signed_int_field.read_value())
+        # A char array is read as its text (it lives inside the struct, so no extra memory read).
+        self.assertEqual("Hello, struct!", g_global_struct.string_buffer.read_value())
 
     def verify_global_struct(self, g_global_struct):
         self.assertEqual(0xAA, g_global_struct.base_field1)
@@ -210,6 +212,8 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(20, g_global_struct.enum_type_field)
         self.assertEqual("EnumType::TYPE_Y", str(g_global_struct.enum_type_field))
         self.assertEqual(-123456789, g_global_struct.signed_int_field)
+        # A char array compares as its text (it lives inside the struct, so no extra memory read).
+        self.assertEqual("Hello, struct!", g_global_struct.string_buffer)
 
     def test_elf_variable_low_level(self):
         variable_die = self.parsed_elf.find_die_by_name("g_global_struct")
@@ -431,6 +435,33 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertRaises(
             Exception, g_global_struct.enum_class_field.write_value, 0xFFFFFFFFFFFFFFFF
         )  # Overflow uint64 on byte enum
+
+        # C-style string: write into the char[32] buffer and read it back.
+        g_global_struct.string_buffer.write_value("rewritten string")
+        self.assertEqual("rewritten string", g_global_struct.string_buffer)
+        # A 31-character string still fits (31 characters + the null terminator == 32 bytes).
+        g_global_struct.string_buffer.write_value("x" * 31)
+        self.assertEqual("x" * 31, g_global_struct.string_buffer)
+        # A string that does not fit (with its null terminator) must fail - no reallocation.
+        self.assertRaises(Exception, g_global_struct.string_buffer.write_value, "x" * 32)
+        g_global_struct.string_buffer.write_value("Hello, struct!")  # Restore original value
+        self.assertEqual("Hello, struct!", g_global_struct.string_buffer)
+
+    def test_elf_variable_string(self):
+        """C-style strings (char array and char pointer) are read as their text via read_value."""
+        g_global_struct = self.parsed_elf.get_global("g_global_struct", TestDebugSymbols.mem_access)
+
+        # A char array contains the string.
+        self.assertEqual("Hello, struct!", g_global_struct.string_buffer.read_value())
+        self.assertEqual("Hello, struct!", g_global_struct.string_buffer)
+        self.assertEqual(32, len(g_global_struct.string_buffer))
+
+        # A char pointer points at the string (a string literal, outside the struct).
+        self.assertEqual("pointer to string", g_global_struct.string_pointer.read_value())
+        self.assertEqual("pointer to string", g_global_struct.string_pointer)
+
+        # A non-char array (uint8_t[16]) is not a string - it is still read as numbers.
+        self.assertEqual(list(range(16)), g_global_struct.c.as_value_list())
 
     @parameterized.expand(
         [

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import unittest
 import os
+import struct
 
 import itertools
 from functools import wraps
@@ -23,7 +24,7 @@ from ttexalens.device import Device, UnsafeAccessException
 from ttexalens.debug_bus_signal_store import DebugBusSignalDescription
 from ttexalens.memory_access import MemoryAccess
 from ttexalens.hardware.baby_risc_debug import BabyRiscDebug
-from ttexalens.hardware.risc_debug import CallstackEntry, RiscDebug
+from ttexalens.hardware.risc_debug import CallstackEntry, CallstackEntryVariable, RiscDebug
 
 from ttexalens.register_store import ConfigurationRegisterDescription, DebugRegisterDescription
 from ttexalens.elf_loader import ElfLoader
@@ -1477,6 +1478,10 @@ class TestCallStack(unittest.TestCase):
         cls.gdb_server = GdbServer(cls.context, server)
         cls.gdb_server.start()
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.gdb_server.stop()
+
     def setUp(self):
         try:
             self.location = get_core_location(self.location_desc, self.device)
@@ -1696,6 +1701,194 @@ class TestCallStack(unittest.TestCase):
         self.assertEqual(callstack[3].template_parameters[1].name, "ClassT1")
         self.assertEqual(callstack[3].template_parameters[1].value, 4)
         self.assertEqual(callstack[4].function_name, "main")
+
+    # Argument and local variable values used by every value-test scenario in callstack.cc. Each
+    # entry is (chained_function, single_frame_type, struct_format, argument, local).
+    VALUE_TEST_TYPES = [
+        ("value_test_bool", "bool", "<?", True, False),
+        ("value_test_uint8", "unsigned char", "<B", 200, 17),
+        ("value_test_int8", "signed char", "<b", -100, 50),
+        ("value_test_uint16", "short unsigned int", "<H", 60000, 1234),
+        ("value_test_int16", "short int", "<h", -30000, 5678),
+        ("value_test_uint32", "long unsigned int", "<I", 4000000000, 12345678),
+        ("value_test_int32", "long int", "<i", -2000000000, 87654321),
+        ("value_test_uint64", "long long unsigned int", "<Q", 18000000000000000000, 1234567890123),
+        ("value_test_int64", "long long int", "<q", -9000000000000000000, 9876543210),
+        ("value_test_float", "float", "<f", 3.5, -1.25),
+        ("value_test_double", "double", "<d", 2.5, -7.75),
+        (
+            "value_test_charptr",
+            "char const*",
+            "g_test_string",
+            "Tenstorrent callstack string",
+            "Tenstorrent callstack string",
+        ),
+    ]
+
+    def get_mailbox_value_address(self, elf: ParsedElfFile) -> int:
+        """Address of the g_MAILBOX_value buffer in callstack.cc."""
+        text_section = elf.sections.get(".text")
+        assert text_section is not None
+        assert text_section.address is not None
+
+        firmware_end: int = text_section.address + text_section.size
+        return (firmware_end + 4 + 16) & ~15
+
+    def get_symbol_address(self, elf: ParsedElfFile, name: str) -> int:
+        symbol = elf.symbols.get(name)
+        assert symbol is not None and symbol.value is not None, f"Symbol {name} not found in ELF"
+        return int(symbol.value)
+
+    def pack_value_test_value(self, elf: ParsedElfFile, struct_format: str, value):
+        # If struct_format doesn't start with "<", it's not a raw value but a symbol name whose address we want to get and pack as a uint32_t.
+        if struct_format.startswith("<"):
+            return struct.pack(struct_format, value)
+        return struct.pack("<I", self.get_symbol_address(elf, struct_format))
+
+    def assert_value_equals(self, actual, expected):
+        if isinstance(expected, float):
+            self.assertAlmostEqual(actual, expected, places=6)
+        else:
+            self.assertEqual(actual, expected)
+
+    def assert_variable(
+        self, variable: CallstackEntryVariable, expected_name: str, expected_value, require_value: bool, message: str
+    ):
+        self.assertEqual(variable.name, expected_name, message)
+        if variable.value is None:
+            self.assertFalse(require_value, f"Could not read {message}")
+        else:
+            self.assert_value_equals(variable.value.read_value(), expected_value)
+
+    def assert_string_pointer(self, variable: CallstackEntryVariable, expected_name: str, address: int, message: str):
+        self.assertEqual(variable.name, expected_name, message)
+        value = variable.value
+        assert value is not None, f"Could not read {message}"
+        self.assertEqual(value.dereference().get_address(), address, message)
+
+    def check_chained_value_test(
+        self, elf_name: str, mailbox: int, namespace: str, require_arguments: bool, wrapper: str | None = None
+    ):
+        if self.device.is_blackhole() and self.risc_name == "trisc2":
+            self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
+
+        elf_path = self.get_elf_path(elf_name)
+        parsed_elf = get_parsed_elf_file(elf_path)
+        self.set_recursion_count(parsed_elf, mailbox)
+        self.loader.run_elf(parsed_elf)
+        callstack: list[CallstackEntry] = lib.callstack(
+            self.location, parsed_elf, None, self.risc_name, None, 100, True
+        )
+
+        # The callstack is: halt, the value-test chain (one frame per type), an optional wrapper
+        # frame, then main.
+        self.assertEqual(len(callstack), len(self.VALUE_TEST_TYPES) + 2 + (1 if wrapper else 0))
+        self.assertEqual(callstack[0].function_name, "halt")
+        self.assertEqual(callstack[-1].function_name, "main")
+        if wrapper is not None:
+            # As with the chain leaf, the optimized debug info may drop the namespace prefix.
+            self.assertIn(callstack[len(self.VALUE_TEST_TYPES) + 1].function_name, (wrapper, wrapper.split("::")[-1]))
+
+        for index, (function, _, _, expected_arg, expected_local) in enumerate(self.VALUE_TEST_TYPES):
+            entry = callstack[index + 1]
+            function_name = f"{namespace}::{function}"
+            # On the optimized build a constant-propagated clone of a leaf function can lose its
+            # namespace qualification in the debug info, so accept the bare name there too.
+            self.assertIn(entry.function_name, (function_name, function), f"Unexpected frame: {entry.function_name}")
+
+            # Every value-test function has exactly one argument and one local variable.
+            self.assertEqual(len(entry.arguments), 1, f"Unexpected arguments for {function_name}")
+            self.assertEqual(len(entry.locals), 1, f"Unexpected locals for {function_name}")
+            self.assert_variable(
+                entry.arguments[0], "arg", expected_arg, require_arguments, f"argument of {function_name}"
+            )
+            self.assert_variable(entry.locals[0], "local", expected_local, True, f"local of {function_name}")
+
+    @parameterized.expand(CALLSTACK_ELFS)
+    def test_callstack_argument_and_local_values(self, elf_name: str):
+        require_arguments = "release" not in elf_name
+        # 0xFFFFFFFD selects the value_test chain (separate frames, one per type) in callstack.cc.
+        self.check_chained_value_test(elf_name, 0xFFFFFFFD, "value_test", require_arguments)
+
+    @parameterized.expand(CALLSTACK_ELFS)
+    def test_callstack_inlined_argument_and_local_values(self, elf_name: str):
+        # 0xFFFFFFFC selects the inline_value_test chain (inlined virtual frames) in callstack.cc.
+        self.check_chained_value_test(elf_name, 0xFFFFFFFC, "inline_value_test", True, wrapper="inline_value_test::run")
+
+    @parameterized.expand(itertools.product(CALLSTACK_ELFS, range(len(VALUE_TEST_TYPES))))
+    def test_callstack_single_frame_argument_and_local_values(self, elf_name: str, type_index: int):
+        if self.device.is_blackhole() and self.risc_name == "trisc2":
+            self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
+
+        _, type_name, struct_format, expected_arg, expected_local = self.VALUE_TEST_TYPES[type_index]
+        elf_path = self.get_elf_path(elf_name)
+        parsed_elf = get_parsed_elf_file(elf_path)
+
+        # Select the single-frame dispatch for this type, then provide the argument (offset 0)
+        # and local (offset 8) values through the host-written g_MAILBOX_value buffer.
+        # 0xFFFFFE00 | type_index invokes single_frame_value_test::dispatch for that type.
+        self.set_recursion_count(parsed_elf, 0xFFFFFE00 | type_index)
+        mailbox_value_address = self.get_mailbox_value_address(parsed_elf)
+        self.l1_mem_access.write(
+            mailbox_value_address, self.pack_value_test_value(parsed_elf, struct_format, expected_arg)
+        )
+        self.l1_mem_access.write(
+            mailbox_value_address + 8, self.pack_value_test_value(parsed_elf, struct_format, expected_local)
+        )
+        self.loader.run_elf(parsed_elf)
+        callstack: list[CallstackEntry] = lib.callstack(
+            self.location, parsed_elf, None, self.risc_name, None, 100, True
+        )
+
+        # The callstack is: value_test<T> (top frame), dispatch, main.
+        top = callstack[0]
+        self.assertEqual(top.function_name, f"single_frame_value_test::value_test<{type_name}>")
+        self.assertEqual(len(top.arguments), 1)
+        self.assertEqual(len(top.locals), 1)
+        if struct_format.startswith("<"):
+            self.assert_variable(top.arguments[0], "arg", expected_arg, True, f"argument of {top.function_name}")
+            self.assert_variable(top.locals[0], "local", expected_local, True, f"local of {top.function_name}")
+        else:
+            # A const char* transferred through a register: verify it points at the test string.
+            address = self.get_symbol_address(parsed_elf, struct_format)
+            self.assert_string_pointer(top.arguments[0], "arg", address, f"argument of {top.function_name}")
+            self.assert_string_pointer(top.locals[0], "local", address, f"local of {top.function_name}")
+
+    @parameterized.expand(CALLSTACK_ELFS)
+    def test_callstack_callee_saved_register_values(self, elf_name: str):
+        if self.device.is_blackhole() and self.risc_name == "trisc2":
+            self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
+
+        elf_path = self.get_elf_path(elf_name)
+        parsed_elf = get_parsed_elf_file(elf_path)
+        mailbox_value_address = self.get_mailbox_value_address(parsed_elf)
+        for index, (_, _, struct_format, value, _) in enumerate(self.VALUE_TEST_TYPES):
+            self.l1_mem_access.write(
+                mailbox_value_address + index * 8, self.pack_value_test_value(parsed_elf, struct_format, value)
+            )
+        # 0xFFFFFFFB selects the callee_saved_test chain (value per type in a callee-saved register).
+        self.set_recursion_count(parsed_elf, 0xFFFFFFFB)
+        self.loader.run_elf(parsed_elf)
+        callstack: list[CallstackEntry] = lib.callstack(
+            self.location, parsed_elf, None, self.risc_name, None, 100, True
+        )
+
+        # The callstack is: halt, the callee_saved_test chain (one frame per type), then main.
+        self.assertEqual(len(callstack), len(self.VALUE_TEST_TYPES) + 2)
+        self.assertEqual(callstack[0].function_name, "halt")
+        self.assertEqual(callstack[-1].function_name, "main")
+        for index, (function, _, struct_format, value, _) in enumerate(self.VALUE_TEST_TYPES):
+            frame = callstack[index + 1]
+            function_name = f"callee_saved_test::{function}"
+            # As elsewhere, the optimized build can drop the namespace of a leaf function.
+            self.assertIn(frame.function_name, (function_name, function), f"Unexpected frame: {frame.function_name}")
+            self.assertEqual(len(frame.locals), 1, f"Unexpected locals for {function_name}")
+            if struct_format.startswith("<"):
+                self.assert_variable(frame.locals[0], "reg_value", value, True, f"reg_value of {function_name}")
+            else:
+                # A const char* held in a callee-saved register: verify it points at the test string.
+                address = self.get_symbol_address(parsed_elf, struct_format)
+                self.assert_string_pointer(frame.locals[0], "reg_value", address, f"reg_value of {function_name}")
 
     @parameterized.expand(
         [

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -1726,7 +1726,7 @@ class TestCallStack(unittest.TestCase):
     ]
 
     def get_mailbox_value_address(self, elf: ParsedElfFile) -> int:
-        """Address of the g_MAILBOX_value buffer in callstack.cc."""
+        """Address of the host-written value buffer in callstack.cc (see mailbox_value_buffer())."""
         text_section = elf.sections.get(".text")
         assert text_section is not None
         assert text_section.address is not None
@@ -1825,7 +1825,7 @@ class TestCallStack(unittest.TestCase):
         parsed_elf = get_parsed_elf_file(elf_path)
 
         # Select the single-frame dispatch for this type, then provide the argument (offset 0)
-        # and local (offset 8) values through the host-written g_MAILBOX_value buffer.
+        # and local (offset 8) values through the host-written value buffer.
         # 0xFFFFFE00 | type_index invokes single_frame_value_test::dispatch for that type.
         self.set_recursion_count(parsed_elf, 0xFFFFFE00 | type_index)
         mailbox_value_address = self.get_mailbox_value_address(parsed_elf)

--- a/ttexalens/elf/__init__.py
+++ b/ttexalens/elf/__init__.py
@@ -7,7 +7,7 @@ from .die import ElfDie
 from .dwarf import ElfDwarf
 from .parsed import ParsedElfFile, ParsedElfFileWithOffset, read_elf
 from .variable import ElfVariable
-from .frame import FrameInspection
+from .frame import FrameDescription, FrameInspection
 
 __all__ = [
     "ElfCompileUnit",
@@ -17,5 +17,6 @@ __all__ = [
     "ParsedElfFile",
     "ParsedElfFileWithOffset",
     "read_elf",
+    "FrameDescription",
     "FrameInspection",
 ]

--- a/ttexalens/elf/die.py
+++ b/ttexalens/elf/die.py
@@ -713,12 +713,90 @@ class ElfDie:
                 try:
                     value = int(value)
                     size = variable_type.size if variable_type.size is not None else 4
-                    memory = value.to_bytes(size, byteorder="little")
+                    # # The value may be wider than the variable (e.g. a sign-extended sub-word
+                    # # value read from a 32-bit register), so keep only its low `size` bytes;
+                    # # ElfVariable then re-applies the variable's own signedness.
+                    memory = (value & ((1 << (size * 8)) - 1)).to_bytes(size, byteorder="little")
                 except Exception:
                     return None
 
             # We explicitly set address to 0 to indicate that this is not an addressable variable
             return ElfVariable(variable_type, 0, FixedMemoryAccess(memory))
+
+    def _evaluate_location_expression_piece(
+        self, ops: list[DWARFExprOp], size: int, frame_inspection: FrameInspection | None
+    ) -> bytes | None:
+        """Evaluate a single piece of a composite location and return its `size` bytes."""
+        # An empty piece (no operations) means this part of the object is not available.
+        if len(ops) == 0 or size <= 0:
+            return None
+
+        is_address, value = self._evaluate_location_expression(ops, frame_inspection)
+        if value is None:
+            return None
+
+        if is_address:
+            # The piece is `size` bytes read from the computed memory address.
+            if frame_inspection is None:
+                return None
+            try:
+                return bytes(frame_inspection.mem_access.read(int(value), size))
+            except Exception:
+                util.DEBUG(f"Failed to read {size} bytes for location piece:\n{traceback.format_exc()}")
+                return None
+
+        # Otherwise the piece is `size` bytes of the computed value (register contents, an
+        # implicit value, or any other value left on the stack).
+        if isinstance(value, bytes):
+            data = value[:size]
+            return data + bytes(size - len(data)) if len(data) < size else data
+        try:
+            int_value = int(value)
+        except (TypeError, ValueError):
+            return None
+        return (int_value & ((1 << (size * 8)) - 1)).to_bytes(size, byteorder="little")
+
+    def _evaluate_composite_location_expression(
+        self, parsed_expression: list[DWARFExprOp], frame_inspection: FrameInspection | None
+    ) -> tuple[bool, Any | None]:
+        # A composite location description describes an object or value which may be
+        # contained in part of a register or stored in more than one location. Each piece is
+        # described by a composition operation, which does not compute a value nor store
+        # any result on the DWARF stack. There may be one or more composition
+        # operations in a single composite location description. A series of such operations
+        # describes the parts of a value in memory address order.
+        # Each composition operation is immediately preceded by a simple location
+        # description which describes the location where part of the resultant value is contained.
+        composed = bytearray()
+        current_ops: list[DWARFExprOp] = []
+        for op in parsed_expression:
+            if op.op_name == "DW_OP_piece":
+                if len(op.args) != 1 or not isinstance(op.args[0], int):
+                    return False, None
+                piece = self._evaluate_location_expression_piece(current_ops, op.args[0], frame_inspection)
+                if piece is None:
+                    return False, None
+                composed += piece
+                current_ops = []
+            elif op.op_name == "DW_OP_bit_piece":
+                if len(op.args) != 2 or not isinstance(op.args[0], int) or not isinstance(op.args[1], int):
+                    return False, None
+                bit_size = op.args[0]
+                bit_offset = op.args[1]
+                if bit_size % 8 != 0:
+                    return False, None  # Bit-granular pieces are not supported
+                byte_size = bit_size // 8
+                piece = self._evaluate_location_expression_piece(current_ops, byte_size, frame_inspection)
+                if piece is None:
+                    return False, None
+                # Extract the relevant bytes for the bit piece, then shift and mask to get the correct bits.
+                int_piece = int.from_bytes(piece, byteorder="little")
+                int_piece = (int_piece >> bit_offset) & ((1 << bit_size) - 1)
+                composed += int_piece.to_bytes(byte_size, byteorder="little")
+                current_ops = []
+            else:
+                current_ops.append(op)
+        return False, bytes(composed)
 
     def _evaluate_location_expression(
         self, parsed_expression: list[DWARFExprOp], frame_inspection: FrameInspection | None = None
@@ -728,13 +806,17 @@ class ElfDie:
 
         util.DEBUG(f"   {parsed_expression}")
 
+        # Check if it is a composite location expression, which describes a value stored in multiple pieces.
+        if any(op.op_name == "DW_OP_piece" or op.op_name == "DW_OP_bit_piece" for op in parsed_expression):
+            return self._evaluate_composite_location_expression(parsed_expression, frame_inspection)
+
         location_parser = self.cu.dwarf.location_parser
         is_address = False
         value = None
         stack = []
         for op in parsed_expression:
             if op.op_name == "DW_OP_fbreg":
-                # We need to get attribute frabe_base from the current function
+                # We need to get attribute frame_base from the current function
                 function_die = self.parent
                 while (
                     function_die is not None
@@ -984,7 +1066,7 @@ class ElfDie:
             elif op.op_name == "DW_OP_neg":
                 if len(stack) > 0:
                     value = stack.pop()
-                if value is None:
+                if value is None or isinstance(value, str):
                     return False, None
                 try:
                     value = -value
@@ -1260,13 +1342,11 @@ class ElfDie:
                 # TODO: Implement missing expression operations
                 # DW_OP_bra=0x28, # Hard to implement without full control flow support
                 # DW_OP_skip=0x2f, # Hard to implement without full control flow support
-                # DW_OP_piece=0x93,
                 # DW_OP_deref_size=0x94,
                 # DW_OP_xderef_size=0x95,
                 # DW_OP_nop=0x96,
                 # DW_OP_push_object_address=0x97,
                 # DW_OP_form_tls_address=0x9b,
-                # DW_OP_bit_piece=0x9d,
                 # DW_OP_implicit_value=0x9e,
                 # DW_OP_implicit_pointer=0xa0,
                 # DW_OP_addrx=0xa1,

--- a/ttexalens/elf/frame.py
+++ b/ttexalens/elf/frame.py
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
     from ttexalens.elf.dwarf import ElfDwarf
 
 
+# https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc
+# RISC-V calling convention defines 12 callee-saved integer registers: s0/fp (x8), s1 (x9) and s2-s11 (x18-x27).
+# If register wasn't mentioned in the call frame rules, it is preserved unchanged,
+# so we can look for it further out or read it live.
+RISCV_CALLEE_SAVED_REGISTERS = frozenset({8, 9} | set(range(18, 28)))
+
+
 class FrameDescription:
     def __init__(self, pc: int, fde: FDE, risc_debug: RiscDebug):
         self.pc = pc
@@ -28,9 +35,31 @@ class FrameDescription:
                 break
             self.current_fde_entry = entry
 
-    def try_read_register(self, register_index: int, cfa: int | None) -> int | None:
-        # TODO #761: Figure out how to handle all types of rules (CFARule, RegisterRule)
-        return None
+    def recover_register(self, register_index: int, cfa: int) -> tuple[bool, int | None]:
+        """Describe how this frame restores the given register for its caller.
+
+        First element of the returned tuple is boolean status: is value lost?
+        Second element is the value if it is saved by this frame, or None if it is preserved unchanged or lost.
+
+        Returns one of:
+          (False, value)   - the frame spilled the register to the stack, here is its value;
+          (True, None)     - the register is no longer recoverable through this frame;
+          (False, None)    - the frame leaves the register unchanged (it is preserved), so the
+                             caller's value must be looked for further out (or read live).
+        """
+        if self.current_fde_entry is None or register_index not in self.current_fde_entry:
+            # Not mentioned by this frame's call-frame rules: preserved unchanged.
+            return False, None
+        rule = self.current_fde_entry[register_index]
+        if rule.type == "OFFSET":
+            try:
+                return False, self.mem_access.read_word(cfa + rule.arg)
+            except RestrictedMemoryAccessError:
+                return True, None
+        if rule.type == "SAME_VALUE":
+            return False, None
+        # UNDEFINED / REGISTER / EXPRESSION / ... - cannot recover the value safely.
+        return True, None
 
     def read_register(self, register_index: int, cfa: int) -> int | None:
         if self.current_fde_entry is not None and register_index in self.current_fde_entry:
@@ -77,13 +106,13 @@ class FrameInspection:
         self,
         risc_debug: RiscDebug,
         loaded_offset: int,
-        frame_description: FrameDescription | None = None,
-        cfa: int | None = None,
+        cfa: int | None,
+        inner_frames: list[tuple[FrameDescription, int]],
     ):
         self.risc_debug = risc_debug
         self.loaded_offset = loaded_offset
-        self.frame_description = frame_description
         self.cfa = cfa
+        self.inner_frames = inner_frames
         self.mem_access = MemoryAccess.create(risc_debug)
 
     @cached_property
@@ -93,12 +122,28 @@ class FrameInspection:
         return value
 
     def read_register(self, register_index: int) -> int | None:
-        # If it is top frame, we can read all registers from RiscDebug
-        if self.frame_description is None:
+        # If there are no inner frames, we are at the top of the call stack
+        # and all registers are live in the core, so read directly.
+        if not self.inner_frames:
             return self.risc_debug.read_gpr(register_index)
 
-        # If it is not top frame, we need to read registers from frame description
-        return self.frame_description.try_read_register(register_index, self.cfa)
+        # Look for the register value in the inner frames.
+        for frame_description, cfa in self.inner_frames:
+            lost, value = frame_description.recover_register(register_index, cfa)
+            if lost:
+                # Stop the search, the register is unrecoverable.
+                return None
+            elif not lost and value is not None:
+                # The register is saved by this inner frame, return its value.
+                return value
+            else:
+                # It could be preserved by this inner frame, keep looking further out.
+                continue
+
+        # Register wasn't preseved on any inner frame, so it is live in the core. Read it directly.
+        if register_index in RISCV_CALLEE_SAVED_REGISTERS:
+            return self.risc_debug.read_gpr(register_index)
+        return None
 
 
 class FrameInfoProvider:

--- a/ttexalens/elf/variable.py
+++ b/ttexalens/elf/variable.py
@@ -154,7 +154,7 @@ class ElfVariable:
         """
         return [self[i] for i in range(len(self))]
 
-    def as_value_list(self) -> list[int | float | bool]:
+    def as_value_list(self) -> list[int | float | bool | str]:
         """
         Return the array elements as a list of values
         """
@@ -172,7 +172,43 @@ class ElfVariable:
         address = int.from_bytes(address_bytes, byteorder="little")
         return ElfVariable(self.__type_die.dereference_type, address, self.__mem_access)
 
-    def read_value(self) -> int | float | bool:
+    @property
+    def __is_string(self) -> bool:
+        """
+        Whether this variable is a C-style string: a pointer to char or an array of char.
+
+        Only plain `char` qualifies (so `unsigned char`/`signed char` arrays - e.g. byte buffers -
+        keep being read as numbers, not strings).
+        """
+        if self.__type_die.tag_is("array_type"):
+            element = self.__type_die.array_element_type
+        elif self.__type_die.tag_is("pointer_type"):
+            element = self.__type_die.dereference_type
+        else:
+            return False
+        return element is not None and element.tag_is("base_type") and element.name == "char"
+
+    def __read_string(self) -> str:
+        """Read the null-terminated string this variable points to or contains."""
+        if self.__type_die.tag_is("array_type"):
+            address = self.__address
+            limit = self.__type_die.size if self.__type_die.size is not None else 0
+        else:  # pointer
+            address = self.dereference().get_address()
+            limit = 1024 * 1024  # Arbitrary max length to prevent infinite loops on non-null-terminated data
+        data = bytearray()
+        for offset in range(limit):
+            byte = self.__mem_access.read(address + offset, 1)
+            if len(byte) == 0 or byte[0] == 0:
+                break
+            data.append(byte[0])
+        return data.decode("utf-8", errors="replace")
+
+    def read_value(self) -> int | float | bool | str:
+        # A C-style string (char* or char[]) is read as its (null-terminated) text.
+        if self.__is_string:
+            return self.__read_string()
+
         # Check that type_die is a basic type
         type = self.__type_die
         if not type.tag_is("base_type") and not type.tag_is("pointer_type") and not type.tag_is("enumeration_type"):
@@ -198,7 +234,29 @@ class ElfVariable:
         else:
             return int.from_bytes(value_bytes, byteorder="little", signed=type.is_signed_type)
 
-    def write_value(self, value: int | float | bool, check_data_loss: bool = True) -> None:
+    def __write_string(self, value: int | float | bool | str, check_data_loss: bool = True) -> None:
+        """Write a null-terminated string into a char array (or char buffer a pointer points to).
+
+        The existing buffer is never reallocated, so writing a string that does not fit (including
+        its null terminator) into a fixed-size char array raises DataLossError.
+        """
+        if not isinstance(value, str):
+            raise TypeMismatchError("write_value", "string")
+        encoded = value.encode("utf-8") + b"\x00"
+        if self.__type_die.tag_is("array_type"):
+            address = self.__address
+            capacity = self.__type_die.size
+            if check_data_loss and capacity is not None and len(encoded) > capacity:
+                raise DataLossError(value, "string")
+        else:  # pointer - the pointed-to buffer size is unknown, so write as-is
+            address = self.dereference().get_address()
+        self.__mem_access.write(address, encoded)
+
+    def write_value(self, value: int | float | bool | str, check_data_loss: bool = True) -> None:
+        # A C-style string (char* or char[]) is written as its (null-terminated) text.
+        if self.__is_string:
+            return self.__write_string(value, check_data_loss)
+
         # Check that type_die is a basic type
         type = self.__type_die
         if not type.tag_is("base_type") and not type.tag_is("enumeration_type"):
@@ -262,6 +320,14 @@ class ElfVariable:
         For base types, compares the actual value.
         For arrays, compares element-by-element with the other sequence.
         """
+        # A C-style string compares by its text value (a char array would otherwise be compared
+        # element-by-element below).
+        if self.__is_string:
+            try:
+                return bool(self.read_value() == other)
+            except TypeError:
+                return False
+
         # For arrays, compare element-by-element
         if self.__type_die.tag_is("array_type"):
             if hasattr(other, "__len__") and hasattr(other, "__getitem__"):
@@ -510,18 +576,25 @@ class ElfVariable:
             pass
         return NotImplemented
 
+    def __read_numeric_value(self) -> int | float | bool:
+        """read_value, requiring a numeric result (arithmetic is not supported on strings)."""
+        value = self.read_value()
+        if isinstance(value, str):
+            raise TypeError(f"unsupported operand type for arithmetic on '{self.__type_die.name}'")
+        return value
+
     # Unary operators
     def __neg__(self):
         """Unary negation operator."""
-        return -self.read_value()
+        return -self.__read_numeric_value()
 
     def __pos__(self):
         """Unary positive operator."""
-        return +self.read_value()
+        return +self.__read_numeric_value()
 
     def __abs__(self):
         """Absolute value operator."""
-        return abs(self.read_value())
+        return abs(self.__read_numeric_value())
 
     def __invert__(self):
         """Bitwise inversion operator."""
@@ -548,7 +621,7 @@ class ElfVariable:
                 return int(value)  # Convert bool to int (True -> 1, False -> 0)
             if isinstance(value, int):
                 return value
-            if value.is_integer():
+            if isinstance(value, float) and value.is_integer():
                 return int(value)
         except (TimeoutDeviceRegisterError, RiscHaltError, RestrictedMemoryAccessError):
             raise

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -9,7 +9,7 @@ from typing import Any, Generator
 from ttexalens import util
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.hardware.memory_block import MemoryBlock
-from ttexalens.elf import ParsedElfFile, ParsedElfFileWithOffset, ElfVariable, ElfDie, FrameInspection
+from ttexalens.elf import ParsedElfFile, ParsedElfFileWithOffset, ElfVariable, ElfDie, FrameDescription, FrameInspection
 from ttexalens.hardware.risc_info import RiscInfo
 
 
@@ -514,9 +514,10 @@ class RiscDebug:
                 util.WARN("We don't have information on frame and we don't know how to proceed.")
                 return []
 
-            frame_inspection = FrameInspection(self, elf.loaded_offset)
             frame_pointer = frame_description.read_previous_cfa()
+            inner_frames: list[tuple[FrameDescription, int]] = []
             while len(callstack) < limit:
+                frame_inspection = FrameInspection(self, elf.loaded_offset, frame_pointer, inner_frames)
                 callstack, function_die = RiscDebug.get_frame_callstack(
                     elf, pc, frame_pointer, callstack, top_frame=len(callstack) == 0, frame_inspection=frame_inspection
                 )
@@ -540,7 +541,9 @@ class RiscDebug:
                 if return_address is None:
                     break
                 pc = return_address
-                frame_inspection = FrameInspection(self, elf.loaded_offset, frame_description, cfa)
+
+                # Add current frame to the list
+                inner_frames = [(frame_description, cfa)] + inner_frames
 
                 # Get the caller's frame description BEFORE computing the caller's CFA,
                 # because the CFA offset comes from the caller's FDE, not the current one.


### PR DESCRIPTION
Adding example function calls in `callstack.cc`.
Fixing code to parse all test cases.
Adding string tests for `ElfVariable`.