### PR TITLE
Enabling reading/writing via debug modul's system bus

### DIFF
--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -695,10 +695,10 @@ class BabyRiscDebug(RiscDebug):
         """Safety validations to be added. tt-exalens:#913"""
         pass
 
-    def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
+    def _read_memory(self, address: int, safe_mode: bool | None = None) -> int:
         return int.from_bytes(self.read_memory_bytes(address, 4, safe_mode=safe_mode), byteorder="little")
 
-    def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
+    def _write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
         self.write_memory_bytes(address, data.to_bytes(4, byteorder="little"), safe_mode=safe_mode)
 
     def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:

--- a/ttexalens/hardware/quasar/rocket_core_debug.py
+++ b/ttexalens/hardware/quasar/rocket_core_debug.py
@@ -7,7 +7,6 @@ from typing import Any, Generator
 import time
 
 from ttexalens import util
-from ttexalens.device import Device
 from ttexalens.exceptions import RiscHaltError
 from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 from ttexalens.hardware.rocket_core_debug import RocketCoreDebug
@@ -37,10 +36,6 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
     def __init__(self, risc_info: BabyRiscInfo, register_store: RegisterStore, enable_asserts: bool = True):
         super().__init__(risc_info, enable_asserts)
         self.register_store = register_store
-
-    @property
-    def device(self) -> Device:
-        return self.risc_info.noc_block.device
 
     def is_in_reset(self) -> bool:
         reset_bit = 1 << self.baby_risc_info.reset_flag_shift

--- a/ttexalens/hardware/quasar/rocket_core_debug.py
+++ b/ttexalens/hardware/quasar/rocket_core_debug.py
@@ -24,6 +24,13 @@ DM_OUT_OF_RESET_BIT = 1 << 17
 ABSTRACTS_BUSY = 1 << 12
 CMD_READ_DPC = (3 << 20) | (1 << 17) | 0x7B1
 
+# System Bus Access Control and Status (SBCS) fields.
+SBCS_SBBUSY = 1 << 21
+SBCS_SBREADONADDR = 1 << 20
+SBCS_SBACCESS_32 = 2 << 17
+SBCS_SBERROR_MASK = 0x7 << 12
+SBCS_SBBUSYERROR = 1 << 22
+
 
 class QuasarRocketCoreDebug(RocketCoreDebug):
     def __init__(self, risc_info: BabyRiscInfo, register_store: RegisterStore, enable_asserts: bool = True):
@@ -119,6 +126,36 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
             self.register_store.read_register("TT_CLUSTER_CTRL_WB_PC_CTRL") == 1
         ), "WB PC control has to be enabled to read PC"
         return self.register_store.read_register(f"TT_CLUSTER_CTRL_WB_PC_REG_C{self.baby_risc_info.risc_id}")
+
+    def _sba_wait_not_busy(self, timeout: int = 10) -> None:
+        """Poll SBCS until the system bus manager is idle. Raise on timeout."""
+        start_time = time.time()
+        while self.register_store.read_register("TT_DEBUG_MODULE_APB_SBCS") & SBCS_SBBUSY:
+            if time.time() - start_time > timeout:
+                raise Exception("Timeout waiting for system bus access")
+            time.sleep(0.01)
+
+    def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
+        """Read a 32-bit word via System Bus Access."""
+        with self.ensure_debug_module_out_of_reset():
+            self._sba_wait_not_busy()
+            self.register_store.write_register(
+                "TT_DEBUG_MODULE_APB_SBCS",
+                SBCS_SBACCESS_32 | SBCS_SBREADONADDR | SBCS_SBERROR_MASK | SBCS_SBBUSYERROR,
+            )
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address & 0xFFFFFFFF)
+            return self.register_store.read_register("TT_DEBUG_MODULE_APB_SBDATA0")
+
+    def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
+        """Write a 32-bit word via System Bus Access."""
+        with self.ensure_debug_module_out_of_reset():
+            self._sba_wait_not_busy()
+            self.register_store.write_register(
+                "TT_DEBUG_MODULE_APB_SBCS",
+                SBCS_SBACCESS_32 | SBCS_SBERROR_MASK | SBCS_SBBUSYERROR,
+            )
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address & 0xFFFFFFFF)
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBDATA0", data & 0xFFFFFFFF)
 
     def set_code_start_address(self, address: int | None) -> None:
         self.baby_risc_info.set_code_start_address(self.register_store, address if address is not None else 0)

--- a/ttexalens/hardware/quasar/rocket_core_debug.py
+++ b/ttexalens/hardware/quasar/rocket_core_debug.py
@@ -7,6 +7,7 @@ from typing import Any, Generator
 import time
 
 from ttexalens import util
+from ttexalens.device import Device
 from ttexalens.exceptions import RiscHaltError
 from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 from ttexalens.hardware.rocket_core_debug import RocketCoreDebug
@@ -36,6 +37,10 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
     def __init__(self, risc_info: BabyRiscInfo, register_store: RegisterStore, enable_asserts: bool = True):
         super().__init__(risc_info, enable_asserts)
         self.register_store = register_store
+
+    @property
+    def device(self) -> Device:
+        return self.risc_info.noc_block.device
 
     def is_in_reset(self) -> bool:
         reset_bit = 1 << self.baby_risc_info.reset_flag_shift
@@ -71,7 +76,7 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
         assert not self.is_debug_module_in_reset(), "Debug module should be out of reset"
 
     @contextmanager
-    def ensure_debug_module_out_of_reset(self) -> Generator[None, Any, None]:
+    def ensure_debug_module_is_active(self) -> Generator[None, Any, None]:
         value = self.register_store.read_register("SMN_RISC_RESET_REG")
         dm_was_in_reset = self.is_debug_module_in_reset(value)
         if dm_was_in_reset:
@@ -84,12 +89,12 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
                 self.register_store.write_register("SMN_RISC_RESET_REG", value)
 
     def is_halted(self) -> bool:
-        with self.ensure_debug_module_out_of_reset():
+        with self.ensure_debug_module_is_active():
             haltsummary = self.register_store.read_register("TT_DEBUG_MODULE_APB_HALTSUMMARY0")
             return bool(haltsummary & (1 << self.baby_risc_info.risc_id))
 
     def halt(self) -> None:
-        with self.ensure_debug_module_out_of_reset():
+        with self.ensure_debug_module_is_active():
             if self.is_halted():
                 util.WARN(f"Halt: {self.risc_location.risc_name} at {self.risc_location.location} is already halted")
                 return
@@ -100,7 +105,7 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
                 raise RiscHaltError(self.risc_location.risc_name, self.risc_location.location)
 
     def cont(self) -> None:
-        with self.ensure_debug_module_out_of_reset():
+        with self.ensure_debug_module_is_active():
             if not self.is_halted():
                 util.WARN(
                     f"Continue: {self.risc_location.risc_name} at {self.risc_location.location} is already running"
@@ -135,27 +140,27 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
                 raise Exception("Timeout waiting for system bus access")
             time.sleep(0.01)
 
-    def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
+    def _read_memory(self, address: int, safe_mode: bool | None = None) -> int:
         """Read a 32-bit word via System Bus Access."""
-        with self.ensure_debug_module_out_of_reset():
+        with self.ensure_debug_module_is_active():
             self._sba_wait_not_busy()
             self.register_store.write_register(
                 "TT_DEBUG_MODULE_APB_SBCS",
                 SBCS_SBACCESS_32 | SBCS_SBREADONADDR | SBCS_SBERROR_MASK | SBCS_SBBUSYERROR,
             )
-            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address & 0xFFFFFFFF)
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address)
             return self.register_store.read_register("TT_DEBUG_MODULE_APB_SBDATA0")
 
-    def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
+    def _write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
         """Write a 32-bit word via System Bus Access."""
-        with self.ensure_debug_module_out_of_reset():
+        with self.ensure_debug_module_is_active():
             self._sba_wait_not_busy()
             self.register_store.write_register(
                 "TT_DEBUG_MODULE_APB_SBCS",
                 SBCS_SBACCESS_32 | SBCS_SBERROR_MASK | SBCS_SBBUSYERROR,
             )
-            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address & 0xFFFFFFFF)
-            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBDATA0", data & 0xFFFFFFFF)
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBADDR0", address)
+            self.register_store.write_register("TT_DEBUG_MODULE_APB_SBDATA0", data)
 
     def set_code_start_address(self, address: int | None) -> None:
         self.baby_risc_info.set_code_start_address(self.register_store, address if address is not None else 0)

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -175,7 +175,15 @@ class RiscDebug:
         """
         pass
 
+    def _validate_32_bit_value(self, value: int):
+        """Validate that a value fits within 32 bits for SBA access."""
+        if value < 0 or value > 0xFFFFFFFF:
+            raise ValueError(f"Value out of bounds: value=0x{value:08x}. Value must fit within 32 bits.")
+
     @abstractmethod
+    def _read_memory(self, address: int) -> int:
+        raise NotImplementedError("_read_memory must be implemented by subclasses of RiscDebug")
+
     def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
         """
         Read a memory address.
@@ -185,7 +193,8 @@ class RiscDebug:
         Returns:
             int: Value at the memory address.
         """
-        pass
+        self._validate_32_bit_value(address)
+        return self._read_memory(address)
 
     @abstractmethod
     def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
@@ -201,6 +210,9 @@ class RiscDebug:
         pass
 
     @abstractmethod
+    def _write_memory(self, address: int, data: int) -> None:
+        raise NotImplementedError("_write_memory must be implemented by subclasses of RiscDebug")
+
     def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
         """
         Write data to a memory address.
@@ -209,7 +221,9 @@ class RiscDebug:
             data (int): Data to write to the memory address.
             safe_mode (bool | None): If True, apply additional safety checks to prevent access to known unsafe memory regions.
         """
-        pass
+        self._validate_32_bit_value(address)
+        self._validate_32_bit_value(data)
+        self._write_memory(address, data)
 
     @abstractmethod
     def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None) -> None:

--- a/ttexalens/hardware/rocket_core_debug.py
+++ b/ttexalens/hardware/rocket_core_debug.py
@@ -30,10 +30,8 @@ class RocketCoreDebug(RiscDebug):
         raise NotImplementedError("set_reset_signal must be implemented by subclasses of RocketCoreDebug")
 
     @contextmanager
-    def ensure_debug_module_out_of_reset(self) -> Generator[None, Any, None]:
-        raise NotImplementedError(
-            "ensure_debug_module_out_of_reset must be implemented by subclasses of RocketCoreDebug"
-        )
+    def ensure_debug_module_is_active(self) -> Generator[None, Any, None]:
+        raise NotImplementedError("ensure_debug_module_is_active must be implemented by subclasses of RocketCoreDebug")
 
     def is_halted(self) -> bool:
         raise NotImplementedError("is_halted must be implemented by subclasses of RocketCoreDebug")
@@ -67,14 +65,14 @@ class RocketCoreDebug(RiscDebug):
     def get_pc(self) -> int:
         raise NotImplementedError("get_pc must be implemented by subclasses of RocketCoreDebug")
 
-    def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
-        raise NotImplementedError("read_memory must be implemented by subclasses of RocketCoreDebug")
+    def _read_memory(self, address: int) -> int:
+        raise NotImplementedError("_read_memory must be implemented by subclasses of RocketCoreDebug")
 
     def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
         raise NotImplementedError("read_memory_bytes must be implemented by subclasses of RocketCoreDebug")
 
-    def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
-        raise NotImplementedError("write_memory must be implemented by subclasses of RocketCoreDebug")
+    def _write_memory(self, address: int, data: int) -> None:
+        raise NotImplementedError("_write_memory must be implemented by subclasses of RocketCoreDebug")
 
     def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None) -> None:
         raise NotImplementedError("write_memory_bytes must be implemented by subclasses of RocketCoreDebug")


### PR DESCRIPTION
Closes #980 

Enabling reading/writing via debug modul's system bus in overlay block. This should allow us coherent access to rocket core's private memory (this is still under investigation #1057). If this does not happen to provide coherent access we need to investigate possibility of adding reading via hart #1058.