### PR TITLE
Bumping UMD version

### DIFF
--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -31,15 +31,15 @@ class MemoryAccessWrapper(MemoryAccess):
         self.write_count = 0
         self.total_bytes_written = 0
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
         self.read_count += 1
-        self.total_bytes_read += size_bytes
-        return self._mem_access.read(private_address, size_bytes)
+        self.total_bytes_read += len(buffer)
+        self._mem_access.read(private_address, buffer)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         self.write_count += 1
         self.total_bytes_written += len(data)
-        return self._mem_access.write(private_address, data)
+        self._mem_access.write(private_address, data)
 
     def reset_stats(self):
         """Reset all statistics counters."""
@@ -52,10 +52,10 @@ class MemoryAccessWrapper(MemoryAccess):
 class TimeoutMemoryAccess(MemoryAccess):
     _coord = tt_umd.CoreCoord(0, 0, tt_umd.CoreType.TENSIX, tt_umd.CoordSystem.LOGICAL)
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
-        raise TimeoutDeviceRegisterError(0, self._coord, private_address, size_bytes, True, 0.0)
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
+        raise TimeoutDeviceRegisterError(0, self._coord, private_address, len(buffer), True, 0.0)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         raise TimeoutDeviceRegisterError(0, self._coord, private_address, len(data), False, 0.0)
 
 
@@ -65,10 +65,10 @@ class RiscHaltErrorMemoryAccess(MemoryAccess):
         self._risc_name = "dummy risc"
         self._location = OnChipCoordinate.create("0,0", self._device)
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
         raise RiscHaltError(self._risc_name, self._location)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         raise RiscHaltError(self._risc_name, self._location)
 
 

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -131,6 +131,7 @@ class TestReadWrite(unittest.TestCase):
         location_str = "1,0"
         location = OnChipCoordinate.create(location_str, self.context.devices[0])
         data = b"test_me!" * 16  # 128 bytes
+        read_data = bytearray(len(data))
         for address in range(0, 128, 1):
             # Write over regular TLB access to clean any previous data
             location.noc_write(address, b"\x00" * len(data), use_4B_mode=False, dma_threshold=len(data) + 1)
@@ -139,11 +140,11 @@ class TestReadWrite(unittest.TestCase):
             location.noc_write(address, data, use_4B_mode=False, dma_threshold=0)
 
             # Read over regular TLB access
-            read_data = location.noc_read(address, len(data), use_4B_mode=False, dma_threshold=len(data) + 1)
+            location.noc_read(address, read_data, use_4B_mode=False, dma_threshold=len(data) + 1)
             self.assertEqual(read_data, data)
 
             # Read over DMA
-            read_data = location.noc_read(address, len(data), use_4B_mode=False, dma_threshold=0)
+            location.noc_read(address, read_data, use_4B_mode=False, dma_threshold=0)
             self.assertEqual(read_data, data)
 
     @parameterized.expand(

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -35,6 +35,13 @@ from ttexalens.gdb.gdb_communication import ServerSocket
 from ttexalens.gdb.gdb_server import GdbServer
 
 
+def _read_bytes(rd: RiscDebug, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
+    """Test helper: allocate a buffer, fill it via the buffer-based read_memory_bytes, and return bytes."""
+    buffer = bytearray(size_bytes)
+    rd.read_memory_bytes(address, buffer, safe_mode=safe_mode)
+    return bytes(buffer)
+
+
 def invalid_argument_decorator(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -649,35 +656,35 @@ class TestReadWrite(unittest.TestCase):
             address = private_memory.address.private_address
             risc_debug.write_memory_bytes(address, bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
+                _read_bytes(risc_debug, address, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
             )
-            self.assertEqual(risc_debug.read_memory_bytes(address + 0, 1), bytes([0x78]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 1, 1), bytes([0x56]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 2, 1), bytes([0x34]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 3, 1), bytes([0x12]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 4, 1), bytes([0xEF]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 5, 1), bytes([0xCD]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 6, 1), bytes([0xAB]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 7, 1), bytes([0x90]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 0, 2), bytes([0x78, 0x56]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 2, 2), bytes([0x34, 0x12]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 4, 2), bytes([0xEF, 0xCD]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 6, 2), bytes([0xAB, 0x90]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 0, 4), bytes([0x78, 0x56, 0x34, 0x12]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 4, 4), bytes([0xEF, 0xCD, 0xAB, 0x90]))
+            self.assertEqual(_read_bytes(risc_debug, address + 0, 1), bytes([0x78]))
+            self.assertEqual(_read_bytes(risc_debug, address + 1, 1), bytes([0x56]))
+            self.assertEqual(_read_bytes(risc_debug, address + 2, 1), bytes([0x34]))
+            self.assertEqual(_read_bytes(risc_debug, address + 3, 1), bytes([0x12]))
+            self.assertEqual(_read_bytes(risc_debug, address + 4, 1), bytes([0xEF]))
+            self.assertEqual(_read_bytes(risc_debug, address + 5, 1), bytes([0xCD]))
+            self.assertEqual(_read_bytes(risc_debug, address + 6, 1), bytes([0xAB]))
+            self.assertEqual(_read_bytes(risc_debug, address + 7, 1), bytes([0x90]))
+            self.assertEqual(_read_bytes(risc_debug, address + 0, 2), bytes([0x78, 0x56]))
+            self.assertEqual(_read_bytes(risc_debug, address + 2, 2), bytes([0x34, 0x12]))
+            self.assertEqual(_read_bytes(risc_debug, address + 4, 2), bytes([0xEF, 0xCD]))
+            self.assertEqual(_read_bytes(risc_debug, address + 6, 2), bytes([0xAB, 0x90]))
+            self.assertEqual(_read_bytes(risc_debug, address + 0, 4), bytes([0x78, 0x56, 0x34, 0x12]))
+            self.assertEqual(_read_bytes(risc_debug, address + 4, 4), bytes([0xEF, 0xCD, 0xAB, 0x90]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address + 0, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
+                _read_bytes(risc_debug, address + 0, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
             )
-            self.assertEqual(risc_debug.read_memory_bytes(address + 1, 2), bytes([0x56, 0x34]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 3, 2), bytes([0x12, 0xEF]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 5, 2), bytes([0xCD, 0xAB]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 1, 4), bytes([0x56, 0x34, 0x12, 0xEF]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 2, 4), bytes([0x34, 0x12, 0xEF, 0xCD]))
-            self.assertEqual(risc_debug.read_memory_bytes(address + 3, 4), bytes([0x12, 0xEF, 0xCD, 0xAB]))
+            self.assertEqual(_read_bytes(risc_debug, address + 1, 2), bytes([0x56, 0x34]))
+            self.assertEqual(_read_bytes(risc_debug, address + 3, 2), bytes([0x12, 0xEF]))
+            self.assertEqual(_read_bytes(risc_debug, address + 5, 2), bytes([0xCD, 0xAB]))
+            self.assertEqual(_read_bytes(risc_debug, address + 1, 4), bytes([0x56, 0x34, 0x12, 0xEF]))
+            self.assertEqual(_read_bytes(risc_debug, address + 2, 4), bytes([0x34, 0x12, 0xEF, 0xCD]))
+            self.assertEqual(_read_bytes(risc_debug, address + 3, 4), bytes([0x12, 0xEF, 0xCD, 0xAB]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address + 0, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
+                _read_bytes(risc_debug, address + 0, 8), bytes([0x78, 0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB, 0x90])
             )
-            self.assertEqual(risc_debug.read_memory_bytes(address + 1, 6), bytes([0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB]))
+            self.assertEqual(_read_bytes(risc_debug, address + 1, 6), bytes([0x56, 0x34, 0x12, 0xEF, 0xCD, 0xAB]))
 
     @parameterized.expand(
         [
@@ -705,79 +712,79 @@ class TestReadWrite(unittest.TestCase):
             address = private_memory.address.private_address
             risc_debug.write_memory_bytes(address, bytes([0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 0, bytes([0x12]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 1, bytes([0x34]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 2, bytes([0x56]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 3, bytes([0x78]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0xDE, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0xDE, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 4, bytes([0x90]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAD, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAD, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 5, bytes([0xAB]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xBE, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xBE, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 6, bytes([0xCD]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xEF])
             )
             risc_debug.write_memory_bytes(address + 7, bytes([0xFE]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xFE])
+                _read_bytes(risc_debug, address, 8), bytes([0x12, 0x34, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xFE])
             )
             risc_debug.write_memory_bytes(address + 0, bytes([0xAA, 0xBB]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0xBB, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xFE])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0xBB, 0x56, 0x78, 0x90, 0xAB, 0xCD, 0xFE])
             )
             risc_debug.write_memory_bytes(address + 2, bytes([0xCC, 0xDD]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0x90, 0xAB, 0xCD, 0xFE])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0x90, 0xAB, 0xCD, 0xFE])
             )
             risc_debug.write_memory_bytes(address + 4, bytes([0xEE, 0xFF]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0xCD, 0xFE])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0xCD, 0xFE])
             )
             risc_debug.write_memory_bytes(address + 6, bytes([0x00, 0x11]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11])
             )
             risc_debug.write_memory_bytes(address + 1, bytes([0x22, 0x33]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x22, 0x33, 0xDD, 0xEE, 0xFF, 0x00, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x22, 0x33, 0xDD, 0xEE, 0xFF, 0x00, 0x11])
             )
             risc_debug.write_memory_bytes(address + 3, bytes([0x44, 0x55]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x22, 0x33, 0x44, 0x55, 0xFF, 0x00, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x22, 0x33, 0x44, 0x55, 0xFF, 0x00, 0x11])
             )
             risc_debug.write_memory_bytes(address + 5, bytes([0x66, 0x77]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x11])
             )
             risc_debug.write_memory_bytes(address + 2, bytes([0x88, 0x99, 0xAA]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x22, 0x88, 0x99, 0xAA, 0x66, 0x77, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x22, 0x88, 0x99, 0xAA, 0x66, 0x77, 0x11])
             )
             risc_debug.write_memory_bytes(address + 3, bytes([0xBB, 0xCC, 0xDD]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x22, 0x88, 0xBB, 0xCC, 0xDD, 0x77, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x22, 0x88, 0xBB, 0xCC, 0xDD, 0x77, 0x11])
             )
             risc_debug.write_memory_bytes(address + 1, bytes([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]))
             self.assertEqual(
-                risc_debug.read_memory_bytes(address, 8), bytes([0xAA, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x11])
+                _read_bytes(risc_debug, address, 8), bytes([0xAA, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x11])
             )
 
 

--- a/test/ttexalens/unit_tests/test_noc_failover.py
+++ b/test/ttexalens/unit_tests/test_noc_failover.py
@@ -19,6 +19,24 @@ def create_timeout_error(chip_id=0, is_read=True):
     )
 
 
+def noc_read_outcomes(*outcomes):
+    """Build a side_effect for a mocked umd_device.noc_read.
+
+    Each outcome is consumed per call: an exception instance is raised, while a bytes value is
+    written into the caller's buffer argument, mirroring how the real noc_read fills the buffer
+    in place instead of returning the data.
+    """
+    remaining = list(outcomes)
+
+    def side_effect(noc_id, noc_x, noc_y, address, buffer, *args, **kwargs):
+        outcome = remaining.pop(0)
+        if isinstance(outcome, BaseException):
+            raise outcome
+        buffer[: len(outcome)] = outcome
+
+    return side_effect
+
+
 def setup_safe_mode_mocks(test_location):
     """Set up noc_block mock chain on test_location so safe mode validation passes."""
     mock_memory_block_info = Mock()
@@ -90,7 +108,7 @@ class TestNocFailoverDisabled(unittest.TestCase):
         self.mock_umd_device.noc_read.side_effect = create_timeout_error()
 
         with self.assertRaises(TimeoutDeviceRegisterError):
-            device.noc_read(self.test_location, 0x1000, 4)
+            device.noc_read(self.test_location, 0x1000, bytearray(4))
 
         # Should only try once (no failover)
         self.assertEqual(self.mock_umd_device.noc_read.call_count, 1)
@@ -127,11 +145,12 @@ class TestNocFailoverEnabled(unittest.TestCase):
     def test_noc_read_success_no_failover_triggered(self, _name, use_noc1, primary_noc):
         """Test successful read doesn't trigger failover."""
         device = self._create_device(use_noc1)
-        self.mock_umd_device.noc_read.return_value = b"\x00\x01\x02\x03"
+        self.mock_umd_device.noc_read.side_effect = noc_read_outcomes(b"\x00\x01\x02\x03")
 
-        result = device.noc_read(self.test_location, 0x1000, 4)
+        buffer = bytearray(4)
+        device.noc_read(self.test_location, 0x1000, buffer)
 
-        self.assertEqual(result, b"\x00\x01\x02\x03")
+        self.assertEqual(bytes(buffer), b"\x00\x01\x02\x03")
         self.assertEqual(self.mock_umd_device.noc_read.call_count, 1)
         # NOC order should remain unchanged (primary still first)
         self.assertEqual(device._noc_to_use[0], primary_noc)
@@ -147,11 +166,14 @@ class TestNocFailoverEnabled(unittest.TestCase):
         device = self._create_device(use_noc1)
 
         # First call (primary) times out, second call (other) succeeds
-        self.mock_umd_device.noc_read.side_effect = [create_timeout_error(is_read=True), b"\x00\x01\x02\x03"]
+        self.mock_umd_device.noc_read.side_effect = noc_read_outcomes(
+            create_timeout_error(is_read=True), b"\x00\x01\x02\x03"
+        )
 
-        result = device.noc_read(self.test_location, 0x1000, 4)
+        buffer = bytearray(4)
+        device.noc_read(self.test_location, 0x1000, buffer)
 
-        self.assertEqual(result, b"\x00\x01\x02\x03")
+        self.assertEqual(bytes(buffer), b"\x00\x01\x02\x03")
         self.assertEqual(self.mock_umd_device.noc_read.call_count, 2)
 
         # Verify NOC order was rotated (primary moved to back, other now first)
@@ -180,7 +202,7 @@ class TestNocFailoverEnabled(unittest.TestCase):
         ]
 
         with self.assertRaises(TimeoutDeviceRegisterError):
-            device.noc_read(self.test_location, 0x1000, 4)
+            device.noc_read(self.test_location, 0x1000, bytearray(4))
 
         # Should try both NOCs
         self.assertEqual(self.mock_umd_device.noc_read.call_count, 2)
@@ -218,7 +240,7 @@ class TestNocFailoverEnabled(unittest.TestCase):
         self.mock_umd_device.noc_read.side_effect = create_timeout_error()
 
         with self.assertRaises(TimeoutDeviceRegisterError):
-            device.noc_read(self.test_location, 0x1000, 4, noc_id=expected_noc)
+            device.noc_read(self.test_location, 0x1000, bytearray(4), noc_id=expected_noc)
 
         # Should only try once (no failover)
         self.assertEqual(self.mock_umd_device.noc_read.call_count, 1)
@@ -236,24 +258,25 @@ class TestNocFailoverEnabled(unittest.TestCase):
         device = self._create_device(use_noc1)
 
         # First call fails (primary), second succeeds (other)
-        self.mock_umd_device.noc_read.side_effect = [
+        self.mock_umd_device.noc_read.side_effect = noc_read_outcomes(
             create_timeout_error(is_read=True),
             b"\x00\x01\x02\x03",
-        ]
+        )
 
         # First read triggers failover
-        device.noc_read(self.test_location, 0x1000, 4)
+        device.noc_read(self.test_location, 0x1000, bytearray(4))
 
         # Verify NOC order changed
         self.assertEqual(device._noc_to_use[0], other_noc)
 
         # Reset side_effect for second read
-        self.mock_umd_device.noc_read.side_effect = [b"\x04\x05\x06\x07"]
+        self.mock_umd_device.noc_read.side_effect = noc_read_outcomes(b"\x04\x05\x06\x07")
 
         # Second read should use other NOC directly
-        result = device.noc_read(self.test_location, 0x2000, 4)
+        buffer = bytearray(4)
+        device.noc_read(self.test_location, 0x2000, buffer)
 
-        self.assertEqual(result, b"\x04\x05\x06\x07")
+        self.assertEqual(bytes(buffer), b"\x04\x05\x06\x07")
         # Verify it's using the other NOC
         last_call_args = self.mock_umd_device.noc_read.call_args[0]
         self.assertEqual(last_call_args[0], other_noc)

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -271,14 +271,15 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
 
         # Test reading initial data
-        data = self.core_sim.risc_debug.read_memory_bytes(addr, 8)
+        data = bytearray(8)
+        self.core_sim.risc_debug.read_memory_bytes(addr, data)
         self.assertEqual(data, b"\x44\x33\x22\x11\x88\x77\x66\x55", "Should read initial 8 bytes")
 
         # Test writing new data
         self.core_sim.risc_debug.write_memory_bytes(addr, b"\x78\x56\x34\x12\xdd\xcc\xbb\xaa")
 
         # Test reading back what we wrote
-        data = self.core_sim.risc_debug.read_memory_bytes(addr, 8)
+        self.core_sim.risc_debug.read_memory_bytes(addr, data)
         self.assertEqual(data, b"\x78\x56\x34\x12\xdd\xcc\xbb\xaa", "Should read/write 8 bytes correctly")
         self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
         self.assertEqual(self.core_sim.read_data(noc_addr + 4), 0xAABBCCDD)
@@ -350,7 +351,8 @@ class TestDebugging(unittest.TestCase):
         self.assertTrue(self.core_sim.is_halted(), "Core should be halted.")
 
         # Test unaligned read
-        data = self.core_sim.risc_debug.read_memory_bytes(addr + offset, size)
+        data = bytearray(size)
+        self.core_sim.risc_debug.read_memory_bytes(addr + offset, data)
         self.assertEqual(data, expected_read, f"Should read {size} bytes at offset {offset}")
 
         # Test unaligned write preserves surrounding data
@@ -358,7 +360,8 @@ class TestDebugging(unittest.TestCase):
         self.core_sim.risc_debug.write_memory_bytes(addr + offset, write_data)
 
         # Verify the write by reading back and comparing
-        read_back = self.core_sim.risc_debug.read_memory_bytes(addr + offset, size)
+        read_back = bytearray(size)
+        self.core_sim.risc_debug.read_memory_bytes(addr + offset, read_back)
         self.assertEqual(read_back, write_data, f"Read back data should match written data at offset {offset}")
 
         # Verify all three words to ensure proper boundary handling

--- a/ttexalens/cli_commands/read.py
+++ b/ttexalens/cli_commands/read.py
@@ -100,8 +100,9 @@ def execute_safe_read(
             raise TTException(f"Memory block '{memory_block_info.name}' does not have a NOC address")
         memory_block_end = memory_block_info.memory_block.address.noc_address + memory_block_info.memory_block.size
         read_size = min(bytes_to_read, memory_block_end - address)
-        bytes = location.noc_read(address, read_size)
-        return bytes, memory_block_info.name
+        data = bytearray(read_size)
+        location.noc_read(address, data)
+        return bytes(data), memory_block_info.name
     else:
         risc_debug = location.noc_block.get_risc_debug(risc_name)
         memory_block_info = risc_debug.risc_info.memory_map.find_by_private_address(address)
@@ -118,10 +119,11 @@ def execute_safe_read(
             noc_address = memory_block_info.memory_block.address.noc_address + (
                 address - memory_block_info.memory_block.address.private_address
             )
-            bytes = location.noc_read(noc_address, read_size)
+            data = bytearray(read_size)
+            location.noc_read(noc_address, data)
         else:
-            bytes = risc_debug.read_memory_bytes(address, read_size)
-        return bytes, memory_block_info.name
+            data = risc_debug.read_memory_bytes(address, read_size)
+        return bytes(data), memory_block_info.name
 
 
 def execute_unsafe_read(
@@ -133,8 +135,9 @@ def execute_unsafe_read(
         if memory_block_info is not None and memory_block_info.memory_block.address.noc_address is not None:
             memory_block_end = memory_block_info.memory_block.address.noc_address + memory_block_info.memory_block.size
             read_size = min(bytes_to_read, memory_block_end - address)
-            bytes = location.noc_read(address, read_size, safe_mode=False)
-            return bytes, memory_block_info.name
+            data = bytearray(read_size)
+            location.noc_read(address, data, safe_mode=False)
+            return bytes(data), memory_block_info.name
     else:
         risc_debug = location.noc_block.get_risc_debug(risc_name)
         memory_block_info = risc_debug.risc_info.memory_map.find_by_private_address(address)
@@ -148,10 +151,11 @@ def execute_unsafe_read(
                 noc_address = memory_block_info.memory_block.address.noc_address + (
                     address - memory_block_info.memory_block.address.private_address
                 )
-                bytes = location.noc_read(noc_address, read_size, safe_mode=False)
+                data = bytearray(read_size)
+                location.noc_read(noc_address, data, safe_mode=False)
             else:
-                bytes = risc_debug.read_memory_bytes(address, read_size)
-            return bytes, memory_block_info.name
+                data = risc_debug.read_memory_bytes(address, read_size)
+            return bytes(data), memory_block_info.name
 
     # Find end address of unknown block and limit read size to that
     if risc_debug is None:
@@ -168,7 +172,8 @@ def execute_unsafe_read(
     # Not found in known memory blocks, do direct read
     if risc_debug:
         with risc_debug.ensure_private_memory_access():
-            bytes = risc_debug.read_memory_bytes(address, bytes_to_read, safe_mode=False)
+            data = risc_debug.read_memory_bytes(address, bytes_to_read, safe_mode=False)
     else:
-        bytes = location.noc_read(address, bytes_to_read, safe_mode=False)
-    return bytes, "???"
+        data = bytearray(bytes_to_read)
+        location.noc_read(address, data, safe_mode=False)
+    return bytes(data), "???"

--- a/ttexalens/cli_commands/read.py
+++ b/ttexalens/cli_commands/read.py
@@ -122,7 +122,8 @@ def execute_safe_read(
             data = bytearray(read_size)
             location.noc_read(noc_address, data)
         else:
-            data = risc_debug.read_memory_bytes(address, read_size)
+            data = bytearray(read_size)
+            risc_debug.read_memory_bytes(address, data)
         return bytes(data), memory_block_info.name
 
 
@@ -154,7 +155,8 @@ def execute_unsafe_read(
                 data = bytearray(read_size)
                 location.noc_read(noc_address, data, safe_mode=False)
             else:
-                data = risc_debug.read_memory_bytes(address, read_size)
+                data = bytearray(read_size)
+                risc_debug.read_memory_bytes(address, data)
             return bytes(data), memory_block_info.name
 
     # Find end address of unknown block and limit read size to that
@@ -170,10 +172,10 @@ def execute_unsafe_read(
             bytes_to_read = min(bytes_to_read, next_block_start - address)
 
     # Not found in known memory blocks, do direct read
+    data = bytearray(bytes_to_read)
     if risc_debug:
         with risc_debug.ensure_private_memory_access():
-            data = risc_debug.read_memory_bytes(address, bytes_to_read, safe_mode=False)
+            risc_debug.read_memory_bytes(address, data, safe_mode=False)
     else:
-        data = bytearray(bytes_to_read)
         location.noc_read(address, data, safe_mode=False)
     return bytes(data), "???"

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -321,13 +321,13 @@ class OnChipCoordinate:
     def noc_read(
         self,
         address: int,
-        size_bytes: int,
+        buffer: bytearray | memoryview,
         noc_id: int | None = None,
         use_4B_mode: bool | None = None,
         dma_threshold: int | None = None,
         safe_mode: bool | None = None,
-    ) -> bytes:
-        return self.device.noc_read(self, address, size_bytes, noc_id, use_4B_mode, dma_threshold, safe_mode)
+    ) -> None:
+        self.device.noc_read(self, address, buffer, noc_id, use_4B_mode, dma_threshold, safe_mode)
 
     def noc_read32(self, address: int, noc_id: int | None = None, safe_mode: bool | None = None) -> int:
         return self.device.noc_read32(self, address, noc_id, safe_mode)
@@ -335,13 +335,13 @@ class OnChipCoordinate:
     def noc_write(
         self,
         address: int,
-        data: bytes,
+        data: bytes | bytearray | memoryview,
         noc_id: int | None = None,
         use_4B_mode: bool | None = None,
         dma_threshold: int | None = None,
         safe_mode: bool | None = None,
     ):
-        return self.device.noc_write(self, address, data, noc_id, use_4B_mode, dma_threshold, safe_mode)
+        self.device.noc_write(self, address, data, noc_id, use_4B_mode, dma_threshold, safe_mode)
 
     def noc_write32(self, address: int, data: int, noc_id: int | None = None, safe_mode: bool | None = None):
-        return self.device.noc_write32(self, address, data, noc_id, safe_mode)
+        self.device.noc_write32(self, address, data, noc_id, safe_mode)

--- a/ttexalens/coverage.py
+++ b/ttexalens/coverage.py
@@ -61,7 +61,9 @@ def dump_coverage(
         filename_len = coverage_header.filename_length.read_value()
         assert isinstance(filename_len, int)
         filename_addr = coverage_header.filename.dereference().get_address()
-        filename: str = location.noc_read(filename_addr, filename_len).decode("ascii")
+        filename_buffer = bytearray(filename_len)
+        location.noc_read(filename_addr, filename_buffer)
+        filename: str = filename_buffer.decode("ascii")
 
         # This points to the expected gcda file, which is in the same directory where the compiler placed the gcno,
         # so we just replace the extension and get the gcno path.
@@ -71,6 +73,7 @@ def dump_coverage(
             with open(gcno_copy_path, "wb") as f:
                 f.write(gcno_reader.read())
 
-    data = location.noc_read(coverage_start + header_size, length - header_size)
+    data = bytearray(length - header_size)
+    location.noc_read(coverage_start + header_size, data)
     with open(gcda_path, "wb") as f:
         f.write(data)

--- a/ttexalens/debug_bus_signal_store.py
+++ b/ttexalens/debug_bus_signal_store.py
@@ -390,8 +390,9 @@ class DebugBusSignalStore:
 
         def read_sample(addr: int) -> int:
             """Read 4x32-bit words and combine them into a single 128-bit integer"""
-            data = self.location.noc_read(addr, self.L1_SAMPLE_SIZE_BYTES)
-            return int.from_bytes(data, byteorder="little")
+            buffer = bytearray(self.L1_SAMPLE_SIZE_BYTES)
+            self.location.noc_read(addr, buffer)
+            return int.from_bytes(buffer, byteorder="little")
 
         # Read samples from L1 memory
         sample_values = [read_sample(l1_address + (i * self.L1_SAMPLE_SIZE_BYTES)) for i in range(samples)]

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -180,7 +180,8 @@ class TensixDebug:
         if size_bytes > dest_size:
             raise TTException(f"Size {size_bytes} bytes is out of bounds for destination memory block.")
 
-        bytes_data = self.mem_access.read(base_address, size_bytes)
+        bytes_data = bytearray(size_bytes)
+        self.mem_access.read(base_address, bytes_data)
         data.extend(int.from_bytes(bytes_data[i : i + 4], byteorder="little") for i in range(0, size_bytes, 4))
 
         return data

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -292,12 +292,12 @@ class Device:
         self,
         location: OnChipCoordinate,
         address: int,
-        size_bytes: int,
+        buffer: bytearray | memoryview,
         noc_id: int | None = None,
         use_4B_mode: bool | None = None,
         dma_threshold: int | None = None,
         safe_mode: bool | None = None,
-    ) -> bytes:
+    ) -> None:
         noc_x, noc_y = location._noc0_coord
 
         if use_4B_mode is None:
@@ -308,24 +308,25 @@ class Device:
             safe_mode = self._context.safe_mode
 
         if safe_mode:
-            self._validate_noc_access_is_safe(location, address, size_bytes, is_write=False)
+            self._validate_noc_access_is_safe(location, address, len(buffer), is_write=False)
 
-        def noc_operation(noc_id: int) -> bytes:
-            return self._umd_device.noc_read(noc_id, noc_x, noc_y, address, size_bytes, use_4B_mode, dma_threshold)
+        def noc_operation(noc_id: int) -> None:
+            self._umd_device.noc_read(noc_id, noc_x, noc_y, address, buffer, use_4B_mode, dma_threshold)
 
-        return self._with_noc_failover(noc_operation, noc_id)
+        self._with_noc_failover(noc_operation, noc_id)
 
     def noc_read32(
         self, location: OnChipCoordinate, address: int, noc_id: int | None = None, safe_mode: bool | None = None
     ) -> int:
-        result = self.noc_read(location, address, 4, noc_id, True, safe_mode=safe_mode)
-        return int.from_bytes(result, byteorder="little")
+        buffer = bytearray(4)
+        self.noc_read(location, address, buffer, noc_id, True, safe_mode=safe_mode)
+        return int.from_bytes(buffer, byteorder="little")
 
     def noc_write(
         self,
         location: OnChipCoordinate,
         address: int,
-        data: bytes,
+        data: bytes | bytearray | memoryview,
         noc_id: int | None = None,
         use_4B_mode: bool | None = None,
         dma_threshold: int | None = None,
@@ -346,7 +347,7 @@ class Device:
         def noc_operation(noc_id: int) -> None:
             self._umd_device.noc_write(noc_id, noc_x, noc_y, address, data, use_4B_mode, dma_threshold)
 
-        return self._with_noc_failover(noc_operation, noc_id)
+        self._with_noc_failover(noc_operation, noc_id)
 
     def noc_write32(
         self,
@@ -356,9 +357,7 @@ class Device:
         noc_id: int | None = None,
         safe_mode: bool | None = None,
     ):
-        return self.noc_write(
-            location, address, data.to_bytes(4, byteorder="little"), noc_id, True, safe_mode=safe_mode
-        )
+        self.noc_write(location, address, data.to_bytes(4, byteorder="little"), noc_id, True, safe_mode=safe_mode)
 
     def bar0_read32(self, address: int) -> int:
         return self._umd_device.bar0_read32(address)

--- a/ttexalens/elf/die.py
+++ b/ttexalens/elf/die.py
@@ -740,7 +740,9 @@ class ElfDie:
             if frame_inspection is None:
                 return None
             try:
-                return bytes(frame_inspection.mem_access.read(int(value), size))
+                buffer = bytearray(size)
+                frame_inspection.mem_access.read(int(value), buffer)
+                return bytes(buffer)
             except Exception:
                 util.DEBUG(f"Failed to read {size} bytes for location piece:\n{traceback.format_exc()}")
                 return None

--- a/ttexalens/elf/variable.py
+++ b/ttexalens/elf/variable.py
@@ -168,7 +168,8 @@ class ElfVariable:
             raise TypeMismatchError("dereference", self.__type_die.name)
         assert self.__type_die.size is not None
         assert self.__type_die.dereference_type is not None
-        address_bytes = self.__mem_access.read(self.__address, self.__type_die.size)
+        address_bytes = bytearray(self.__type_die.size)
+        self.__mem_access.read(self.__address, address_bytes)
         address = int.from_bytes(address_bytes, byteorder="little")
         return ElfVariable(self.__type_die.dereference_type, address, self.__mem_access)
 
@@ -197,9 +198,10 @@ class ElfVariable:
             address = self.dereference().get_address()
             limit = 1024 * 1024  # Arbitrary max length to prevent infinite loops on non-null-terminated data
         data = bytearray()
+        byte = bytearray(1)
         for offset in range(limit):
-            byte = self.__mem_access.read(address + offset, 1)
-            if len(byte) == 0 or byte[0] == 0:
+            self.__mem_access.read(address + offset, byte)
+            if byte[0] == 0:
                 break
             data.append(byte[0])
         return data.decode("utf-8", errors="replace")
@@ -220,7 +222,8 @@ class ElfVariable:
 
         # Read the value from memory
         assert type.size is not None
-        value_bytes = self.__mem_access.read(self.__address, type.size)
+        value_bytes = bytearray(type.size)
+        self.__mem_access.read(self.__address, value_bytes)
 
         # Convert the value to the appropriate type
         if type.tag_is("pointer_type"):
@@ -705,7 +708,9 @@ class ElfVariable:
         return self.__type_die.size
 
     def read_bytes(self) -> bytes:
-        return self.__mem_access.read(self.__address, self.get_size())
+        buffer = bytearray(self.get_size())
+        self.__mem_access.read(self.__address, buffer)
+        return bytes(buffer)
 
     def read(self) -> "ElfVariable":
         if self.__type_die.tag_is("pointer_type"):

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -66,11 +66,11 @@ class ElfLoader:
         """
         self.mem_access.write(address, data)
 
-    def read_block_through_debug(self, address: int, byte_count: int) -> bytes:
+    def read_block_through_debug(self, address: int, buffer: bytearray | memoryview) -> None:
         """
-        Reads a block of data from a given address through the debug interface.
+        Reads a block of data from a given address through the debug interface into 'buffer'.
         """
-        return self.mem_access.read(address, byte_count)
+        self.mem_access.read(address, buffer)
 
     @staticmethod
     def __inside_private_memory(memory_block: MemoryBlock | None, address: int) -> bool:
@@ -122,9 +122,9 @@ class ElfLoader:
             and private_code_memory.address.noc_address is None
         ):
             # Use debug interface
-            buffer[:] = self.read_block_through_debug(private_address, len(buffer))
+            self.read_block_through_debug(private_address, buffer)
         elif self.l1_block is not None and self.l1_block.memory_block.contains_private_address(private_address):
-            buffer[:] = self.l1_mem_access.read(private_address, len(buffer))
+            self.l1_mem_access.read(private_address, buffer)
         else:
             self.location.noc_read(private_address, buffer)
 

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -105,10 +105,10 @@ class ElfLoader:
         else:
             self.location.noc_write(private_address, data)
 
-    def read_block(self, private_address: int, byte_count: int) -> bytes:
+    def read_block(self, private_address: int, buffer: bytearray | memoryview) -> None:
         """
-        Reads a block of bytes from a given address. Knows about the sections not accessible through NOC (0xFFB00000 or 0xFFC00000), and uses
-        the debug interface to read them.
+        Reads a block of bytes from a given address into the provided buffer. Knows about the sections not accessible
+        through NOC (0xFFB00000 or 0xFFC00000), and uses the debug interface to read them.
         """
         private_data_memory = self.risc_debug.get_data_private_memory()
         private_code_memory = self.risc_debug.get_code_private_memory()
@@ -122,11 +122,11 @@ class ElfLoader:
             and private_code_memory.address.noc_address is None
         ):
             # Use debug interface
-            return self.read_block_through_debug(private_address, byte_count)
+            buffer[:] = self.read_block_through_debug(private_address, len(buffer))
         elif self.l1_block is not None and self.l1_block.memory_block.contains_private_address(private_address):
-            return self.l1_mem_access.read(private_address, byte_count)
+            buffer[:] = self.l1_mem_access.read(private_address, len(buffer))
         else:
-            return self.location.noc_read(private_address, byte_count)
+            self.location.noc_read(private_address, buffer)
 
     def remap_address(self, address: int, loader_data: int | None, loader_code: int | None):
         data_private_memory = self.risc_debug.get_data_private_memory()
@@ -190,7 +190,8 @@ class ElfLoader:
 
                     # Check that what we have written is correct
                     if verify_write:
-                        read_data = self.read_block(address, len(section.data))
+                        read_data = bytearray(len(section.data))
+                        self.read_block(address, read_data)
                         if read_data != section.data:
                             util.ERROR(f"Error writing section {section.name} to address 0x{address:08x}.")
                             continue

--- a/ttexalens/gdb/gdb_communication.py
+++ b/ttexalens/gdb/gdb_communication.py
@@ -376,7 +376,7 @@ class GdbMessageWriter:
             self.data.append(char)
             self.checksum += char
 
-    def append(self, data: bytes):
+    def append(self, data: bytes | bytearray | memoryview):
         length = len(data)
         position = 0
         while position < length:

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -377,7 +377,8 @@ class GdbServer(threading.Thread):
             else:
                 # Read memory bytes
                 try:
-                    buffer = self.current_process.mem_access.read(address, length)
+                    buffer = bytearray(length)
+                    self.current_process.mem_access.read(address, buffer)
                     writer.append_hex(int.from_bytes(buffer, byteorder="little"), 2 * length)
                 except RestrictedMemoryAccessError as e:
                     util.ERROR(str(e), file=self.error_stream)
@@ -943,7 +944,8 @@ class GdbServer(threading.Thread):
             else:
                 # Read memory bytes
                 try:
-                    buffer = self.current_process.mem_access.read(address, length)
+                    buffer = bytearray(length)
+                    self.current_process.mem_access.read(address, buffer)
                     writer.append(b"b")
                     writer.append(buffer)  # Reply with data should start with 'b'
                 except RestrictedMemoryAccessError as e:

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -696,12 +696,15 @@ class BabyRiscDebug(RiscDebug):
         pass
 
     def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
-        return int.from_bytes(self.read_memory_bytes(address, 4, safe_mode=safe_mode), byteorder="little")
+        buffer = bytearray(4)
+        self.read_memory_bytes(address, buffer, safe_mode=safe_mode)
+        return int.from_bytes(buffer, byteorder="little")
 
     def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
         self.write_memory_bytes(address, data.to_bytes(4, byteorder="little"), safe_mode=safe_mode)
 
-    def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
+    def read_memory_bytes(self, address: int, buffer: bytearray | memoryview, safe_mode: bool | None = None) -> None:
+        size_bytes = len(buffer)
         safe_mode = safe_mode if safe_mode is not None else self.device._context.safe_mode
         if safe_mode:
             self._validate_safe_access(address, size_bytes)
@@ -712,19 +715,20 @@ class BabyRiscDebug(RiscDebug):
         assert self.debug_hardware is not None, "Debug hardware is not initialized"
 
         word_size = 4
-        aligned_start = address - (address % word_size)
-        aligned_end = ((address + size_bytes + word_size - 1) // word_size) * word_size
+        pos = 0
+        while pos < size_bytes:
+            addr = address + pos
+            word_addr = addr - (addr % word_size)
+            word: int = self.debug_hardware.read_memory(word_addr)
+            word_bytes = word.to_bytes(word_size, byteorder="little")
+            start_in_word = addr - word_addr
+            n = min(word_size - start_in_word, size_bytes - pos)
+            buffer[pos : pos + n] = word_bytes[start_in_word : start_in_word + n]
+            pos += n
 
-        result = bytearray()
-        words_to_read = (aligned_end - aligned_start) // word_size
-        for offset in range(words_to_read):
-            new_addr = aligned_start + offset * word_size
-            word: int = self.debug_hardware.read_memory(new_addr)
-            result.extend(word.to_bytes(4, byteorder="little"))
-
-        return bytes(result[address - aligned_start : address - aligned_start + size_bytes])
-
-    def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None) -> None:
+    def write_memory_bytes(
+        self, address: int, data: bytes | bytearray | memoryview, safe_mode: bool | None = None
+    ) -> None:
         safe_mode = safe_mode if safe_mode is not None else self.device._context.safe_mode
         if safe_mode:
             self._validate_safe_access(address, len(data))

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -23,11 +23,11 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
             assert self.noc_block.debug_bus is not None, "Debug bus is not initialized."
             return int(self.noc_block.debug_bus.read_signal(self.risc_info.risc_name + "_pc"))
 
-    def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
+    def read_memory_bytes(self, address: int, buffer: bytearray | memoryview, safe_mode: bool | None = None) -> None:
         self.assert_trisc2_address(address)
-        return super().read_memory_bytes(address, size_bytes, safe_mode=safe_mode)
+        super().read_memory_bytes(address, buffer, safe_mode=safe_mode)
 
-    def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None):
+    def write_memory_bytes(self, address: int, data: bytes | bytearray | memoryview, safe_mode: bool | None = None):
         self.assert_trisc2_address(address)
         super().write_memory_bytes(address, data, safe_mode=safe_mode)
 

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -188,15 +188,13 @@ class RiscDebug:
         pass
 
     @abstractmethod
-    def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
+    def read_memory_bytes(self, address: int, buffer: bytearray | memoryview, safe_mode: bool | None = None) -> None:
         """
-        Read size_bytes bytes from a memory address.
+        Read len(buffer) bytes from a memory address into 'buffer'.
         Args:
             address (int): Memory address to read.
-            size_bytes (int): Number of bytes to read.
+            buffer (bytearray | memoryview): Destination buffer; exactly len(buffer) bytes are read into it.
             safe_mode (bool | None): If True, apply additional safety checks to prevent access to known unsafe memory regions.
-        Returns:
-            bytes: Size_bytes bytes at the memory address.
         """
         pass
 
@@ -212,12 +210,14 @@ class RiscDebug:
         pass
 
     @abstractmethod
-    def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None) -> None:
+    def write_memory_bytes(
+        self, address: int, data: bytes | bytearray | memoryview, safe_mode: bool | None = None
+    ) -> None:
         """
-        Write size_bytes bytes to a memory address.
+        Write len(data) bytes to a memory address.
         Args:
             address (int): Memory address to write.
-            data (bytes): Bytes to write to the memory address.
+            data (bytes | bytearray | memoryview): Bytes to write to the memory address.
             safe_mode (bool | None): If True, apply additional safety checks to prevent access to known unsafe memory regions.
         """
         pass

--- a/ttexalens/hardware/rocket_core_debug.py
+++ b/ttexalens/hardware/rocket_core_debug.py
@@ -70,13 +70,15 @@ class RocketCoreDebug(RiscDebug):
     def read_memory(self, address: int, safe_mode: bool | None = None) -> int:
         raise NotImplementedError("read_memory must be implemented by subclasses of RocketCoreDebug")
 
-    def read_memory_bytes(self, address: int, size_bytes: int, safe_mode: bool | None = None) -> bytes:
+    def read_memory_bytes(self, address: int, buffer: bytearray | memoryview, safe_mode: bool | None = None) -> None:
         raise NotImplementedError("read_memory_bytes must be implemented by subclasses of RocketCoreDebug")
 
     def write_memory(self, address: int, data: int, safe_mode: bool | None = None) -> None:
         raise NotImplementedError("write_memory must be implemented by subclasses of RocketCoreDebug")
 
-    def write_memory_bytes(self, address: int, data: bytes, safe_mode: bool | None = None) -> None:
+    def write_memory_bytes(
+        self, address: int, data: bytes | bytearray | memoryview, safe_mode: bool | None = None
+    ) -> None:
         raise NotImplementedError("write_memory_bytes must be implemented by subclasses of RocketCoreDebug")
 
     def read_status(self) -> RiscDebugStatus:

--- a/ttexalens/memory_access.py
+++ b/ttexalens/memory_access.py
@@ -101,7 +101,9 @@ class L1MemoryAccess(MemoryAccess):
     def read(self, private_address: int, size_bytes: int) -> bytes:
         self._validate_access(private_address, size_bytes)
         noc_address = self._tranlate_to_noc_address(private_address)
-        return self._location.noc_read(noc_address, size_bytes)
+        buffer = bytearray(size_bytes)
+        self._location.noc_read(noc_address, buffer)
+        return bytes(buffer)
 
     def write(self, private_address: int, data: bytes) -> None:
         self._validate_access(private_address, len(data))

--- a/ttexalens/memory_access.py
+++ b/ttexalens/memory_access.py
@@ -20,9 +20,9 @@ class MemoryAccess(ABC):
     """
 
     @abstractmethod
-    def read(self, private_address: int, size_bytes: int) -> bytes:
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
         """
-        Read 'size_bytes' bytes from 'private_address' and return them as bytes.
+        Read 'len(buffer)' bytes from 'private_address' into 'buffer'.
         'private_address' is the address as seen from the core's private address space, which may be translated to a NOC address by the implementation.
         """
         pass
@@ -32,11 +32,12 @@ class MemoryAccess(ABC):
         Read a word from 'private_address' and return it as an integer.
         'private_address' is the address as seen from the core's private address space, which may be translated to a NOC address by the implementation.
         """
-        data_bytes = self.read(private_address, 4)
-        return int.from_bytes(data_bytes, byteorder="little")
+        buffer = bytearray(4)
+        self.read(private_address, buffer)
+        return int.from_bytes(buffer, byteorder="little")
 
     @abstractmethod
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         """
         Write 'data' bytes to 'private_address'.
         'private_address' is the address as seen from the core's private address space, which may be translated to a NOC address by the implementation.
@@ -98,14 +99,12 @@ class L1MemoryAccess(MemoryAccess):
         offset = private_address - self.l1_block.address.private_address
         return self.l1_block.address.noc_address + offset
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
-        self._validate_access(private_address, size_bytes)
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
+        self._validate_access(private_address, len(buffer))
         noc_address = self._tranlate_to_noc_address(private_address)
-        buffer = bytearray(size_bytes)
         self._location.noc_read(noc_address, buffer)
-        return bytes(buffer)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         self._validate_access(private_address, len(data))
         noc_address = self._tranlate_to_noc_address(private_address)
         self._location.noc_write(noc_address, data)
@@ -132,10 +131,10 @@ class FixedMemoryAccess(MemoryAccess):
     def __init__(self, data: bytes):
         self._data = data
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
-        return self._data[private_address : private_address + size_bytes]
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
+        buffer[:] = self._data[private_address : private_address + len(buffer)]
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         raise ReadOnlyMemoryError(private_address, len(data))
 
 
@@ -165,16 +164,16 @@ class RiscDebugMemoryAccess(MemoryAccess):
         self._restricted_access = restricted_access  # restrict access to only L1 and Data Private Memory
         self._safe_mode = safe_mode  # additional safety checks to prevent access to known unsafe memory regions
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
-        self._validate_access(private_address, size_bytes)
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
+        self._validate_access(private_address, len(buffer))
 
         if self._ensure_halted_access or self._risc_debug.can_debug():
             with self._risc_debug.ensure_private_memory_access():
-                return self._risc_debug.read_memory_bytes(private_address, size_bytes, safe_mode=self._safe_mode)
+                self._risc_debug.read_memory_bytes(private_address, buffer, safe_mode=self._safe_mode)
         else:
-            return self._risc_debug.read_memory_bytes(private_address, size_bytes, safe_mode=self._safe_mode)
+            self._risc_debug.read_memory_bytes(private_address, buffer, safe_mode=self._safe_mode)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         self._validate_access(private_address, len(data))
 
         if self._ensure_halted_access or self._risc_debug.can_debug():
@@ -221,14 +220,15 @@ class CachedReadMemoryAccess(MemoryAccess):
         self._cached_address = cached_address
         self._cached_data = cached_data
 
-    def read(self, private_address: int, size_bytes: int) -> bytes:
+    def read(self, private_address: int, buffer: bytearray | memoryview) -> None:
+        size_bytes = len(buffer)
         if private_address >= self._cached_address and private_address + size_bytes <= self._cached_address + len(
             self._cached_data
         ):
             offset = private_address - self._cached_address
-            return self._cached_data[offset : offset + size_bytes]
+            buffer[:] = self._cached_data[offset : offset + size_bytes]
         else:
-            return self._base_mem_access.read(private_address, size_bytes)
+            self._base_mem_access.read(private_address, buffer)
 
-    def write(self, private_address: int, data: bytes) -> None:
+    def write(self, private_address: int, data: bytes | bytearray | memoryview) -> None:
         self._base_mem_access.write(private_address, data)

--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,4 +1,4 @@
-tt-umd==0.9.5
+tt-umd==0.9.6
 deprecation==2.1.0
 docopt==0.6.2
 fastnumbers==5.1.1

--- a/ttexalens/server.py
+++ b/ttexalens/server.py
@@ -241,6 +241,47 @@ def start_server(port: int, context: Context):
         raise util.TTFatalException("Could not start ttexalens-server.")
 
 
+class RemoteUmdDevice:
+    """
+    Client-side adapter around a Pyro5 UmdDevice proxy.
+    """
+
+    def __init__(self, proxy):
+        self._proxy = proxy
+
+    def noc_read(
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        buffer: bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
+    ) -> None:
+        data = self._proxy.noc_read_bytes(noc_id, noc0_x, noc0_y, address, len(buffer), use_4B_mode, dma_threshold)
+        # Pyro5/serpent returns bytes either as real bytes or as a base64-encoded dict.
+        buffer[:] = serpent.tobytes(data) if isinstance(data, dict) else data
+
+    def __getattr__(self, name):
+        return getattr(self._proxy, name)
+
+
+class RemoteUmdApiWrapper:
+    """
+    Client-side adapter around a Pyro5 UmdApi proxy.
+    """
+
+    def __init__(self, proxy):
+        self._proxy = proxy
+
+    def get_device(self, chip_id: int) -> RemoteUmdDevice:
+        return RemoteUmdDevice(self._proxy.get_device(chip_id))
+
+    def __getattr__(self, name):
+        return getattr(self._proxy, name)
+
+
 class FileAccessApiWrapper:
     """
     A wrapper around the Pyro5 proxy to convert base64-encoded bytes back to bytes.
@@ -271,7 +312,7 @@ def connect_to_server(server_host="localhost", port=5555) -> tuple[UmdApi, FileA
         # We are returning a wrapper around the Pyro5 proxy to provide UmdApi-like behavior.
         proxy = Pyro5.api.Proxy(pyro_umd_api_address)
         proxy._pyroSerializer = "serpent"
-        umd_api: UmdApi = proxy  # type: ignore
+        umd_api: UmdApi = RemoteUmdApiWrapper(proxy)  # type: ignore
 
         # Connect to FileAccessApi
         pyro_file_api_address = f"PYRO:file_api@{server_host}:{port}"

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -174,8 +174,9 @@ def read_words_from_device(
     if word_count <= 0:
         raise TTException("word_count must be greater than 0.")
 
-    bytes_data = coordinate.noc_read(addr, 4 * word_count, noc_id, use_4B_mode, safe_mode=safe_mode)
-    data = list(struct.unpack(f"<{word_count}I", bytes_data))
+    buffer = bytearray(4 * word_count)
+    coordinate.noc_read(addr, buffer, noc_id, use_4B_mode, safe_mode=safe_mode)
+    data = list(struct.unpack(f"<{word_count}I", buffer))
     return data
 
 
@@ -213,7 +214,9 @@ def read_from_device(
     if num_bytes <= 0:
         raise TTException("num_bytes must be greater than 0.")
 
-    return coordinate.noc_read(addr, num_bytes, noc_id, use_4B_mode, safe_mode=safe_mode)
+    buffer = bytearray(num_bytes)
+    coordinate.noc_read(addr, buffer, noc_id, use_4B_mode, safe_mode=safe_mode)
+    return bytes(buffer)
 
 
 @trace_api

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -90,12 +90,11 @@ class UmdApi:
             # and take all cores out of reset. Downstream test harnesses then re-assert specific
             # cores, load their ELFs, and re-deassert. This keeps cores from executing garbage
             # between tt-exalens init and the harness taking over.
-            for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
-                core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
-                tt_device.noc_write32(core_noc0.x, core_noc0.y, 0, 0x6F)
-                tt_device.send_tensix_risc_reset(
-                    tt_umd.tt_xy_pair(core.x, core.y), tt_umd.TensixSoftResetOptions.TENSIX_DEASSERT_SOFT_RESET
-                )
+            if tt_device.get_arch() == tt_umd.ARCH.BLACKHOLE:
+                for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
+                    core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
+                    tt_device.noc_write32(core_noc0.x, core_noc0.y, 0, 0x6F)
+                    tt_device.deassert_risc_reset(tt_umd.tt_xy_pair(core.x, core.y), tt_umd.RiscType.BRISC)
             cluster_descriptor_content = create_simulation_cluster_descriptor(tt_device.get_arch())
             self.cluster_descriptor = tt_umd.ClusterDescriptor.create_from_yaml_content(cluster_descriptor_content)
             self.devices[0] = UmdDevice(

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -164,7 +164,8 @@ class UmdDevice:
             self._is_mmio_capable
             and not self._is_simulation
             and elapsed_time > UmdDevice.READ_TIMEOUT
-            and bytes(buffer[-4:]) == b"\xFF\xFF\xFF\xFF"
+            and len(buffer) >= 4
+            and buffer[-4] == buffer[-3] == buffer[-2] == buffer[-1] == 0xFF
         ):
             try:
                 translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.LOGICAL)

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -129,10 +129,11 @@ class UmdDevice:
     def __configure_working_active_eth(self):
         tensix_coord = tt_umd.CoreCoord(0, 0, tt_umd.CoreType.TENSIX, tt_umd.CoordSystem.LOGICAL)
         tensix_translated_coord = self._soc_descriptor.translate_chip_coord_to_translated_coord(tensix_coord)
+        buffer = bytearray(4)
         for translated_coord in self._active_eth_coords_on_mmio_chip:
             self.__device.get_remote_communication().set_remote_transfer_ethernet_cores([translated_coord])
             try:
-                self.__read_from_device_reg(tensix_translated_coord, 0, 4, 8)
+                self.__read_from_device_reg(tensix_translated_coord, 0, buffer, 8)
                 return
             except Exception:
                 util.DEBUG(f"Active ETH core {translated_coord} not working, trying next:\n{traceback.format_exc()}")
@@ -146,21 +147,24 @@ class UmdDevice:
     WRITE_TIMEOUT = float(os.environ.get("TT_EXALENS_WRITE_TIMEOUT_MS", 2)) / 1_000  # seconds
     NUM_OF_CONSECUTIVE_TIMEOUTS = int(os.environ.get("TT_EXALENS_NUM_OF_CONSECUTIVE_TIMEOUTS", 5))
 
-    def __read_from_device_reg(self, coord: tt_umd.CoreCoord, address: int, size: int, dma_threshold: int) -> bytes:
+    def __read_from_device_reg(
+        self, coord: tt_umd.CoreCoord, address: int, buffer: bytearray | memoryview, dma_threshold: int
+    ) -> None:
         # Check if we can use DMA read
-        if size >= dma_threshold and self.can_use_dma:
-            return self.__device.dma_read_from_device(coord.x, coord.y, address, size)
+        if len(buffer) >= dma_threshold and self.can_use_dma:
+            self.__device.dma_read_from_device(0, coord.x, coord.y, address, buffer)
+            return
 
         # TODO: Until UMD implements timeout exception, we measure time here
         start_time = time.time()
-        result = self.__device.noc_read(coord.x, coord.y, address, size)
+        self.__device.noc_read(0, coord.x, coord.y, address, buffer)
         end_time = time.time()
         elapsed_time = end_time - start_time  # seconds
         if (
             self._is_mmio_capable
             and not self._is_simulation
             and elapsed_time > UmdDevice.READ_TIMEOUT
-            and result[-4:] == b"\xFF\xFF\xFF\xFF"
+            and bytes(buffer[-4:]) == b"\xFF\xFF\xFF\xFF"
         ):
             try:
                 translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.LOGICAL)
@@ -169,10 +173,11 @@ class UmdDevice:
                     translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.NOC0)
                 except Exception:
                     translated_coord = coord
-            raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, size, True, elapsed_time)
-        return result
+            raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, len(buffer), True, elapsed_time)
 
-    def __write_to_device_reg(self, coord: tt_umd.CoreCoord, address: int, data: bytes, dma_threshold: int):
+    def __write_to_device_reg(
+        self, coord: tt_umd.CoreCoord, address: int, data: bytes | bytearray | memoryview, dma_threshold: int
+    ):
         # Check if we can use DMA write
         if len(data) >= dma_threshold and self.can_use_dma:
             return self.__device.dma_write_to_device(coord.x, coord.y, address, data)
@@ -207,45 +212,61 @@ class UmdDevice:
                 self.__write_timeout_events.clear()
 
     def __read_from_device_reg_unaligned_helper(
-        self, coord: tt_umd.CoreCoord, address: int, size: int, use_4B_mode: bool, dma_threshold: int
-    ) -> bytes:
+        self,
+        coord: tt_umd.CoreCoord,
+        address: int,
+        buffer: bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
+    ) -> None:
         # Read first unaligned word
         first_unaligned_index = address % 4
+        size = len(buffer)
+        offset = 0
         if first_unaligned_index != 0:
-            temp = self.__read_from_device_reg(coord, address - first_unaligned_index, 4, dma_threshold)
+            temp = bytearray(4)
+            self.__read_from_device_reg(coord, address - first_unaligned_index, temp, dma_threshold)
             if first_unaligned_index + size <= 4:
-                return temp[first_unaligned_index : first_unaligned_index + size]
-            data = bytearray()
-            data.extend(temp[first_unaligned_index:4])
-            address += 4 - first_unaligned_index
-            size -= 4 - first_unaligned_index
-        else:
-            data = bytearray()
+                buffer[:size] = temp[first_unaligned_index : first_unaligned_index + size]
+                return
+            buffer[: 4 - first_unaligned_index] = temp[first_unaligned_index:4]
+            offset += 4 - first_unaligned_index
+            address += offset
+            size -= offset
 
-        # Read aligned bytes
+        # Read aligned bytes. Wrap in a memoryview so that slicing yields a view into the
+        # original buffer instead of a temporary copy (slicing a bytearray copies).
+        view = memoryview(buffer)
         aligned_size = size - (size % 4)
         block_size = 4 if use_4B_mode and self._is_mmio_capable and not self._is_simulation else aligned_size
         while aligned_size > 0:
-            data.extend(self.__read_from_device_reg(coord, address, block_size, dma_threshold))
+            self.__read_from_device_reg(coord, address, view[offset : offset + block_size], dma_threshold)
             aligned_size -= block_size
+            offset += block_size
             address += block_size
             size -= block_size
 
         # Read last unaligned word
         last_unaligned_size = size
         if last_unaligned_size != 0:
-            temp = self.__read_from_device_reg(coord, address, 4, dma_threshold)
-            data.extend(temp[:last_unaligned_size])
-
-        return bytes(data)
+            temp = bytearray(4)
+            self.__read_from_device_reg(coord, address, temp, dma_threshold)
+            buffer[offset : offset + last_unaligned_size] = temp[:last_unaligned_size]
 
     def __read_from_device_reg_unaligned(
-        self, noc_id: int, noc0_x: int, noc0_y: int, address: int, size: int, use_4B_mode: bool, dma_threshold: int
-    ) -> bytes:
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        buffer: bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
+    ) -> None:
         coord = self.__convert_noc0_to_device_coords(noc_id, noc0_x, noc0_y)
         assert coord is not None, f"Invalid NoC0 coordinates: ({noc0_x}, {noc0_y})"
         try:
-            return self.__read_from_device_reg_unaligned_helper(coord, address, size, use_4B_mode, dma_threshold)
+            self.__read_from_device_reg_unaligned_helper(coord, address, buffer, use_4B_mode, dma_threshold)
         except TimeoutDeviceRegisterError:
             raise
         except Exception:
@@ -253,10 +274,15 @@ class UmdDevice:
                 raise
             util.DEBUG(f"Read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
             self.__configure_working_active_eth()
-            return self.__read_from_device_reg_unaligned_helper(coord, address, size, use_4B_mode, dma_threshold)
+            self.__read_from_device_reg_unaligned_helper(coord, address, buffer, use_4B_mode, dma_threshold)
 
     def __write_to_device_reg_unaligned_helper(
-        self, coord: tt_umd.CoreCoord, address: int, data: bytes, use_4B_mode: bool, dma_threshold: int
+        self,
+        coord: tt_umd.CoreCoord,
+        address: int,
+        data: bytes | bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
     ):
         size_in_bytes = len(data)
 
@@ -264,7 +290,8 @@ class UmdDevice:
         first_unaligned_index = address % 4
         if first_unaligned_index != 0:
             aligned_address = address - first_unaligned_index
-            temp = self.__read_from_device_reg(coord, aligned_address, 4, dma_threshold)
+            temp = bytearray(4)
+            self.__read_from_device_reg(coord, aligned_address, temp, dma_threshold)
             if first_unaligned_index + size_in_bytes <= 4:
                 temp = (
                     temp[0:first_unaligned_index]
@@ -294,12 +321,20 @@ class UmdDevice:
         # Read/Write last unaligned word
         last_unaligned_size = size_in_bytes
         if last_unaligned_size != 0:
-            temp = self.__read_from_device_reg(coord, address, 4, dma_threshold)
-            temp = data[0:last_unaligned_size] + temp[last_unaligned_size:4]
+            temp = bytearray(4)
+            self.__read_from_device_reg(coord, address, temp, dma_threshold)
+            temp[0:last_unaligned_size] = data[0:last_unaligned_size]
             self.__write_to_device_reg(coord, address, temp, dma_threshold)
 
     def __write_to_device_reg_unaligned(
-        self, noc_id: int, noc0_x: int, noc0_y: int, address: int, data: bytes, use_4B_mode: bool, dma_threshold: int
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        data: bytes | bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
     ):
         coord = self.__convert_noc0_to_device_coords(noc_id, noc0_x, noc0_y)
         assert coord is not None, f"Invalid NoC0 coordinates: ({noc0_x}, {noc0_y})"
@@ -324,21 +359,33 @@ class UmdDevice:
         self.__api._reinit_devices_after_sigbus()
 
     def noc_read(
-        self, noc_id: int, noc0_x: int, noc0_y: int, address: int, size: int, use_4B_mode: bool, dma_threshold: int
-    ) -> bytes:
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        buffer: bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
+    ) -> None:
         try:
             """Reads data from address"""
             self.__select_noc_id(noc_id)
-            return self.__read_from_device_reg_unaligned(
-                noc_id, noc0_x, noc0_y, address, size, use_4B_mode, dma_threshold
-            )
+            self.__read_from_device_reg_unaligned(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
         except tt_umd.SigbusError:
             util.DEBUG("Reset detected during noc_read, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
-            return self.noc_read(noc_id, noc0_x, noc0_y, address, size, use_4B_mode, dma_threshold)
+            self.noc_read(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
 
     def noc_write(
-        self, noc_id: int, noc0_x: int, noc0_y: int, address: int, data: bytes, use_4B_mode: bool, dma_threshold: int
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        data: bytes | bytearray | memoryview,
+        use_4B_mode: bool,
+        dma_threshold: int,
     ):
         try:
             """Writes data to address"""

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -378,6 +378,21 @@ class UmdDevice:
             self.__reinit_device_after_sigbus()
             self.noc_read(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
 
+    def noc_read_bytes(
+        self,
+        noc_id: int,
+        noc0_x: int,
+        noc0_y: int,
+        address: int,
+        size: int,
+        use_4B_mode: bool,
+        dma_threshold: int,
+    ) -> bytes:
+        """Reads 'size' bytes from address and returns them. Avoid using this method if caller can provide buffer, to save extra copy."""
+        buffer = bytearray(size)
+        self.noc_read(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
+        return bytes(buffer)
+
     def noc_write(
         self,
         noc_id: int,


### PR DESCRIPTION
Bumping UMD version to 0.9.6.
This exposes ability to use `noc_read`/`noc_write` with providing `memoryview` buffers, so we can avoid unnecessary allocations.