### PR TITLE
Remove GDB binary from wheel packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,38 +9,15 @@ project(ttexalens VERSION ${TT_EXALENS_VERSION})
 
 # Set default values for variables/options
 set(TTEXALENS_HOME "${PROJECT_SOURCE_DIR}")
-option(BUILD_PYTHON_WHEEL "Only download SFPI, skip RISCV kernel builds" OFF)
-option(STRIP_SYMBOLS "Strip symbols from GDB binary" OFF)
+option(BUILD_PYTHON_WHEEL "Skip SFPI download and RISCV kernel builds (pure-Python wheel)" OFF)
 
-# Check for SFPI release
-include(${PROJECT_SOURCE_DIR}/cmake/sfpi_release.cmake)
-
-# Build RISCV kernels unless building Python wheel
+# The Python wheel is pure Python: it no longer bundles the SFPI GDB client
+# (the binary is not portable across platforms; it is located at runtime via
+# the system install, SFPI_ROOT, or PATH instead - see get_gdb_client_path()).
+# So wheel builds skip both the SFPI download and the RISCV kernel build, which
+# also lets the wheel be built on hosts that SFPI does not ship binaries for.
 if(NOT BUILD_PYTHON_WHEEL)
+    # SFPI provides the RISCV toolchain used to build the test kernels.
+    include(${PROJECT_SOURCE_DIR}/cmake/sfpi_release.cmake)
     add_subdirectory(${PROJECT_SOURCE_DIR}/riscv-src)
-endif()
-
-# Install target for Python wheel: copy GDB binary to source tree
-set(SFPI_GDB_SOURCE "${SFPI_RELEASE_PATH}/compiler/bin/riscv-tt-elf-gdb")
-set(SFPI_GDB_DEST "${CMAKE_SOURCE_DIR}/build/stripped/riscv-tt-elf-gdb")
-
-add_custom_target(install-gdb-for-wheel ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_SOURCE_DIR}/build/stripped"
-    COMMAND ${CMAKE_COMMAND} -E copy "${SFPI_GDB_SOURCE}" "${SFPI_GDB_DEST}"
-    COMMENT "Copying GDB binary for Python wheel packaging"
-)
-
-# Add optional strip command if STRIP_SYMBOLS is enabled
-if(STRIP_SYMBOLS)
-    add_custom_command(TARGET install-gdb-for-wheel POST_BUILD
-        COMMAND strip "${SFPI_GDB_DEST}"
-        COMMENT "Stripping symbols from GDB binary"
-    )
-endif()
-
-# Install the GDB binary for the wheel when BUILD_PYTHON_WHEEL is enabled
-if(BUILD_PYTHON_WHEEL)
-    install(FILES "${SFPI_GDB_DEST}"
-            DESTINATION "sfpi/compiler/bin"
-            COMPONENT python_wheel)
 endif()

--- a/docs/gdb.md
+++ b/docs/gdb.md
@@ -15,10 +15,17 @@ After starting gdb server, you can stop it with `gdb` command. Run `gdb stop`.
 
 ## Getting gdb client
 
-There are three ways to obtain the GDB client:
+There are a few ways to obtain the GDB client:
 - Use the version that is automatically downloaded and extracted during the build process at `build/sfpi/compiler/bin/riscv-tt-elf-gdb`.
-- Use `tt-exalens --gdb` as a wrapper to start the GDB client (this uses the same binary as above). This is also available in the wheel.
+- Install sfpi on your system (the deb package installs to `/opt/tenstorrent/sfpi`).
 - Download your preferred version manually from https://github.com/tenstorrent/sfpi or build it yourself from source.
+
+The GDB client is **not** bundled in the wheel, since the binary is not portable across platforms. `tt-exalens --gdb` (a wrapper that starts the GDB client) and the call-stack support locate the client by searching, in order:
+1. The package's own `sfpi/compiler/bin/riscv-tt-elf-gdb` (in-tree layout).
+2. The local development build at `build/sfpi/compiler/bin/riscv-tt-elf-gdb`.
+3. The system install at `/opt/tenstorrent/sfpi/compiler/bin/riscv-tt-elf-gdb`.
+4. `$SFPI_ROOT/compiler/bin/riscv-tt-elf-gdb` (set `SFPI_ROOT` to your sfpi install root).
+5. `riscv-tt-elf-gdb` on your `PATH`.
 
 ## Connecting gdb client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,14 +37,12 @@ tt-exalens = "ttexalens.cli:main"
 
 [tool.scikit-build]
 cmake.build-type = "Release"
-cmake.args = ["-DBUILD_PYTHON_WHEEL=ON", "-DSTRIP_SYMBOLS=ON"]
+cmake.args = ["-DBUILD_PYTHON_WHEEL=ON"]
 wheel.install-dir = "ttexalens"
 wheel.packages = ["ttexalens"]
 wheel.py-api = "py3"
 wheel.platlib = false
 experimental = true
-# Install the python_wheel component for wheel packaging
-install.components = ["python_wheel"]
 
 [tool.scikit-build.metadata.version]
 provider = "scikit_build_core.metadata.regex"

--- a/ttexalens/gdb/gdb_client.py
+++ b/ttexalens/gdb/gdb_client.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import re
+import shutil
 import subprocess
 from ttexalens import util as util
 from ttexalens.context import Context
@@ -11,14 +12,48 @@ from ttexalens.gdb.gdb_communication import ServerSocket
 from ttexalens.gdb.gdb_server import GdbServer
 from ttexalens.hardware.risc_debug import CallstackEntry
 from ttexalens.tt_exalens_lib import check_context
+from ttexalens.util import DEBUG, TRACE
 
 
-def get_gdb_client_path():
-    sfpi_path = "sfpi/compiler/bin/riscv-tt-elf-gdb"
-    gdb_client_path = os.path.abspath(os.path.join(util.application_path(), sfpi_path))
-    if not os.path.isfile(gdb_client_path):
-        gdb_client_path = os.path.abspath(os.path.join(util.application_path(), "../build", sfpi_path))
-    return gdb_client_path
+# Path to the gdb client binary inside an sfpi release tree, and its bare name on PATH.
+GDB_CLIENT_SFPI_RELATIVE_PATH = os.path.join("compiler", "bin", "riscv-tt-elf-gdb")
+GDB_CLIENT_BINARY_NAME = "riscv-tt-elf-gdb"
+
+
+def get_gdb_client_path() -> str:
+    app_path = util.application_path()
+
+    sfpi_roots = [
+        os.path.join(app_path, "sfpi"),
+        os.path.join(app_path, "..", "build", "sfpi"),
+        "/opt/tenstorrent/sfpi",
+    ]
+    sfpi_root_env = os.environ.get("SFPI_ROOT")
+    if sfpi_root_env:
+        sfpi_roots.append(sfpi_root_env)
+
+    searched: list[str] = []
+    for sfpi_root in sfpi_roots:
+        gdb_client_path = os.path.abspath(os.path.join(sfpi_root, GDB_CLIENT_SFPI_RELATIVE_PATH))
+        searched.append(gdb_client_path)
+        TRACE(f"Looking for gdb client at {gdb_client_path}")
+        if os.path.isfile(gdb_client_path):
+            DEBUG(f"Found gdb client at {gdb_client_path}")
+            return gdb_client_path
+
+    # Finally, fall back to whatever gdb client is found on PATH.
+    TRACE(f"Looking for gdb client on PATH")
+    gdb_client_path = shutil.which(GDB_CLIENT_BINARY_NAME)
+    if gdb_client_path is not None:
+        DEBUG(f"Found gdb client at {gdb_client_path}")
+        return gdb_client_path
+
+    raise FileNotFoundError(
+        f"Could not find the '{GDB_CLIENT_BINARY_NAME}' gdb client. Searched: "
+        + ", ".join(searched)
+        + ", and PATH. Install sfpi (e.g. to /opt/tenstorrent/sfpi), set the "
+        f"SFPI_ROOT environment variable, or add '{GDB_CLIENT_BINARY_NAME}' to PATH."
+    )
 
 
 def make_add_symbol_file_command(paths: list[str], offsets: list[int | None]) -> str:

--- a/ttexalens/gdb/gdb_client.py
+++ b/ttexalens/gdb/gdb_client.py
@@ -33,6 +33,7 @@ def get_gdb_client_path() -> str:
         sfpi_roots.append(sfpi_root_env)
 
     searched: list[str] = []
+    gdb_client_path: str | None = None
     for sfpi_root in sfpi_roots:
         gdb_client_path = os.path.abspath(os.path.join(sfpi_root, GDB_CLIENT_SFPI_RELATIVE_PATH))
         searched.append(gdb_client_path)


### PR DESCRIPTION
Eliminate the GDB binary from the Python wheel packaging process. Update the logic for retrieving the GDB client to ensure it is located at runtime rather than bundled, enhancing portability across platforms. Adjust related documentation to reflect these changes.