### PR TITLE
Add fixes for Wormhole/Blackhole hardware bugs

### DIFF
--- a/riscv-src/CMakeLists.txt
+++ b/riscv-src/CMakeLists.txt
@@ -96,6 +96,13 @@ function(create_riscv_target ARCH APP CORE BUILD_TYPE)
         set(LINK_OPTIONS ${OPTIONS_ALL} ${OPTIONS_LINK})
     endif()
 
+    # -mtt-fix-whbhebreak emits the Wormhole/Blackhole ebreak hardware-bug workaround
+    # (8 NOPs after every ebreak; the fetch pipeline has already prefetched the
+    # instructions following an ebreak, so on WH/BH those must be NOPs).
+    if(ARCH STREQUAL "wormhole" OR ARCH STREQUAL "blackhole")
+        list(APPEND LINK_OPTIONS -mtt-fix-whbhebreak)
+    endif()
+
     set(OUTPUT_ELF "${RISCV_OUTPUT}/${ARCH}/${APP}.${BUILD_TYPE}.${CORE}.elf")
     set(OUTPUT_OBJDUMP "${RISCV_OUTPUT}/${ARCH}/${APP}.${BUILD_TYPE}.${CORE}.objdump")
     set(OUTPUT_DWARF "${RISCV_OUTPUT}/${ARCH}/${APP}.${BUILD_TYPE}.${CORE}.dwarf")

--- a/test/ttexalens/unit_tests/program_writer.py
+++ b/test/ttexalens/unit_tests/program_writer.py
@@ -13,6 +13,13 @@ class RiscvProgramWriter:
         self.start_address = core_simulator.program_base_address
         self.instructions: list[int] = []
 
+        # Wormhole/Blackhole have an ebreak hardware bug: the fetch pipeline prefetches (and on
+        # resume re-runs) the instructions following an ebreak, so those must be NOPs. The compiler
+        # emits this workaround via -mtt-fix-whbhebreak (8 trailing NOPs); hand-written programs must
+        # do the same. Other architectures don't need the padding.
+        device = core_simulator.device
+        self.ebreak_nop_padding = 8 if device.is_wormhole() or device.is_blackhole() else 0
+
     @property
     def current_address(self) -> int:
         return self.start_address + len(self.instructions) * 4
@@ -31,9 +38,11 @@ class RiscvProgramWriter:
         self.append(0x00000013)
 
     def append_ebreak(self):
-        """Append an EBREAK instruction."""
+        """Append an EBREAK instruction followed by the Wormhole/Blackhole ebreak NOP padding."""
         # https://riscv-software-src.github.io/riscv-unified-db/manual/html/isa/isa_20240411/insts/ebreak.html
         self.append(0x00100073)
+        for _ in range(self.ebreak_nop_padding):
+            self.append_nop()
 
     def append_lui(self, register: int, value: int):
         """Load the zero-extended value into register."""

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -1661,10 +1661,21 @@ class TestCallStack(unittest.TestCase):
             pc = self.risc_debug.read_gpr(32)
         callstack: list[CallstackEntry] = lib.top_callstack(pc, parsed_elf, None, self.context)
 
-        self.assertEqual(len(callstack), expected_f1_on_callstack_count + 1)
-        for i in range(0, expected_f1_on_callstack_count):
-            self.assertEqual(callstack[i].function_name, "f1")
-        self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
+        if self.device.is_blackhole() or self.device.is_wormhole():
+            # The core halts on the ebreak inside halt(). The reported PC is the instruction after the
+            # ebreak, which lands in the NOP padding emitted by -mtt-fix-whbhebreak; that padding is
+            # attributed to halt() (callstack.cc:30), so halt() is the innermost (inlined) frame,
+            # followed by the f1 frame(s) and recurse.
+            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 2)
+            self.assertEqual(callstack[0].function_name, "halt")
+            for i in range(0, expected_f1_on_callstack_count):
+                self.assertEqual(callstack[1 + i].function_name, "f1")
+            self.assertEqual(callstack[1 + expected_f1_on_callstack_count].function_name, "recurse")
+        else:
+            self.assertEqual(len(callstack), expected_f1_on_callstack_count + 1)
+            for i in range(0, expected_f1_on_callstack_count):
+                self.assertEqual(callstack[i].function_name, "f1")
+            self.assertEqual(callstack[expected_f1_on_callstack_count + 0].function_name, "recurse")
 
     @parameterized.expand(CALLSTACK_ELFS)
     def test_template_arguments(self, elf_name):

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -897,9 +897,6 @@ class TestDebugging(unittest.TestCase):
         if self.core_sim.risc_debug.baby_risc_info.max_watchpoints == 0:
             self.skipTest("Watchpoints are disabled for this RISC.")
 
-        if self.core_sim.is_eth_block() and self.device.is_wormhole():
-            self.skipTest("This test ND fails in CI. Issue: #770")
-
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -496,25 +496,27 @@ class TestDebugging(unittest.TestCase):
         self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
         self.assertPcEquals(4)
 
-        # Step through the NOP padding and the first LUI (load address); PC advances one instruction
-        # at a time and memory stays unchanged until the store commits.
+        # Go through NOPs
         pc = 4
-        for _ in range(self.program_writer.ebreak_nop_padding + 1):
+        for _ in range(self.program_writer.ebreak_nop_padding):
             self.core_sim.step()
             pc += 4
             self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
             self.assertPcEquals(pc)
 
-        # Next step commits the store; memory now holds the new value.
+        # 3 instructions for store
         self.core_sim.step()
         pc += 4
+        self.assertPcEquals(pc)
+        self.core_sim.step()
+        pc += 4
+        self.assertPcEquals(pc)
+        self.core_sim.step()
+        pc += 4
+        self.assertPcEquals(pc)
         self.assertEqual(self.core_sim.read_data(noc_addr), 0x87654000)
-        self.assertPcEquals(pc)
 
-        # One more step reaches the infinite loop, which we can never advance past.
-        self.core_sim.step()
-        pc += 4
-        self.assertPcEquals(pc)
+        # Do 10 steps in the infinite loop
         for _ in range(10):
             self.core_sim.step()
             self.assertPcEquals(pc)

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -462,6 +462,12 @@ class TestDebugging(unittest.TestCase):
 
     def test_ebreak_and_step(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
+
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
+
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."
@@ -515,6 +521,12 @@ class TestDebugging(unittest.TestCase):
 
     def test_continue(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
+
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
+
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."
@@ -584,6 +596,12 @@ class TestDebugging(unittest.TestCase):
 
     def test_halt_continue(self):
         """Test running 28 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
+
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
+
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."
@@ -639,6 +657,12 @@ class TestDebugging(unittest.TestCase):
 
     def test_halt_status(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
+
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
+
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."
@@ -897,6 +921,11 @@ class TestDebugging(unittest.TestCase):
         if self.core_sim.risc_debug.baby_risc_info.max_watchpoints == 0:
             self.skipTest("Watchpoints are disabled for this RISC.")
 
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
+
         addr = 0x10000
         noc_addr = self.core_sim.risc_debug.baby_risc_info.l1.translate_to_noc_address(addr)
         assert noc_addr is not None, "Translated NOC address should not be None."
@@ -1145,6 +1174,11 @@ class TestDebugging(unittest.TestCase):
 
         if self.core_sim.risc_debug.baby_risc_info.max_watchpoints == 0:
             self.skipTest("Watchpoints are disabled for this RISC.")
+
+        if self.core_sim.is_eth_block() and self.device.is_wormhole():
+            self.skipTest(
+                "Resuming/stepping past an ebreak is unreliable on the Wormhole erisc (cannot disable branch prediction). See #762."
+            )
 
         addresses = [0x10000, 0x11000, 0x12000, 0x13000]
         noc_addresses: list[int] = []

--- a/test/ttexalens/unit_tests/test_risc_debug.py
+++ b/test/ttexalens/unit_tests/test_risc_debug.py
@@ -484,26 +484,34 @@ class TestDebugging(unittest.TestCase):
 
         self.core_sim.set_reset(False)
 
-        # On blackhole, we need to step one more time...
+        # Layout: ebreak@0, ebreak_nop_padding NOPs, LUI(addr), LUI(value), SW, while(true).
 
         # Verify value at address, value should not be changed and should stay the same since core is in halt
         self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
         self.assertPcEquals(4)
-        # Step and verify that pc is 8 and value is not changed
-        self.core_sim.step()
-        self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
-        self.assertPcEquals(8)
-        # Adding two steps since logic in hw automatically updates register and memory values
-        self.core_sim.step()
-        self.core_sim.step()
-        # Verify that pc is 16 and value has changed
-        self.assertEqual(self.core_sim.read_data(noc_addr), 0x87654000)
-        self.assertPcEquals(16)
-        # Since we are on endless loop, we should never go past 16
-        for _ in range(10):
-            # Step and verify that pc is 16 and value has changed
+
+        # Step through the NOP padding and the first LUI (load address); PC advances one instruction
+        # at a time and memory stays unchanged until the store commits.
+        pc = 4
+        for _ in range(self.program_writer.ebreak_nop_padding + 1):
             self.core_sim.step()
-            self.assertPcEquals(16)
+            pc += 4
+            self.assertEqual(self.core_sim.read_data(noc_addr), 0x12345678)
+            self.assertPcEquals(pc)
+
+        # Next step commits the store; memory now holds the new value.
+        self.core_sim.step()
+        pc += 4
+        self.assertEqual(self.core_sim.read_data(noc_addr), 0x87654000)
+        self.assertPcEquals(pc)
+
+        # One more step reaches the infinite loop, which we can never advance past.
+        self.core_sim.step()
+        pc += 4
+        self.assertPcEquals(pc)
+        for _ in range(10):
+            self.core_sim.step()
+            self.assertPcEquals(pc)
 
     def test_continue(self):
         """Test running 20 bytes of generated code that just write data on memory and does infinite loop. All that is done on brisc."""
@@ -901,19 +909,11 @@ class TestDebugging(unittest.TestCase):
 
         # Write code for brisc core at address 0
         # C++:
-        #   asm volatile ("ebreak");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
+        #   asm volatile ("ebreak");  // append_ebreak() also emits the WH/BH ebreak NOP padding
         #   int* a = (int*)0x10000;
         #   *a = 0x87654000;
         #   while (true);
         self.program_writer.append_ebreak()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
         self.program_writer.append_store_word_to_memory(
             0x10000, 0x87654000, 10, 11
         )  # Load address into x10, data into x11, store word
@@ -930,9 +930,11 @@ class TestDebugging(unittest.TestCase):
         self.assertFalse(self.core_sim.read_status().is_pc_watchpoint_hit, "PC watchpoint should not be the cause.")
         self.assertPcEquals(4)
 
-        # Set watchpoint on address 12 and 32
+        # Layout: ebreak@0, `padding` NOPs, LUI(addr), LUI(value), SW, while(true)@(16 + 4*padding).
+        # Watch a NOP within the padding and the final infinite loop.
+        loop_offset = 16 + 4 * self.program_writer.ebreak_nop_padding
         self.core_sim.debug_hardware.set_watchpoint_on_pc_address(0, self.core_sim.program_base_address + 12)
-        self.core_sim.debug_hardware.set_watchpoint_on_pc_address(1, self.core_sim.program_base_address + 32)
+        self.core_sim.debug_hardware.set_watchpoint_on_pc_address(1, self.core_sim.program_base_address + loop_offset)
 
         # Continue and verify that we hit first watchpoint
         self.core_sim.continue_execution()
@@ -958,7 +960,7 @@ class TestDebugging(unittest.TestCase):
         )
         self.assertFalse(self.core_sim.read_status().watchpoints_hit[0], "Watchpoint 0 should not be hit.")
         self.assertTrue(self.core_sim.read_status().watchpoints_hit[1], "Watchpoint 1 should be hit.")
-        self.assertPcEquals(32)
+        self.assertPcEquals(loop_offset)
         self.assertEqual(self.core_sim.read_data(noc_addr), 0x87654000)
 
     def test_watchpoint_address(self):
@@ -1161,11 +1163,7 @@ class TestDebugging(unittest.TestCase):
 
         # Write code for brisc core at address 0
         # C++:
-        #   asm volatile ("ebreak");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
-        #   asm volatile ("nop");
+        #   asm volatile ("ebreak");  // append_ebreak() also emits the WH/BH ebreak NOP padding
         #   int* a = (int*)0x10000;
         #   *a = 0x45678000;
         #   int* c = (int*)0x20000;
@@ -1176,10 +1174,6 @@ class TestDebugging(unittest.TestCase):
         #   d = *c;
         #   while (true);
         self.program_writer.append_ebreak()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
-        self.program_writer.append_nop()
         self.program_writer.append_store_word_to_memory(addresses[0], 0x45678000, 10, 11)  # First write
         self.program_writer.append_load_word_from_memory_to_register(12, addresses[1], 10)  # First read
         self.program_writer.append_store_word_to_memory(addresses[2], 0x87654000, 10, 11)  # Second write

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -16,6 +16,17 @@ class BlackholeBabyRiscDebug(BabyRiscDebug):
         super().step()
         super().step()
 
+    def cont(self):
+        # There is a bug in hardware: resuming from an ebreak with a plain CONTINUE
+        # re-asserts the ebreak. The fetch pipeline re-runs the window after the ebreak
+        # (the NOPs emitted by -mtt-fix-whbhebreak) and the core re-halts at the end of
+        # that pad with ebreak still set. Flushing the pipeline to the current PC clears
+        # the latched ebreak so execution resumes cleanly past it.
+        if self.is_halted() and self.is_ebreak_hit():
+            assert self.debug_hardware is not None, "Debug hardware is not initialized"
+            self.debug_hardware.flush(self.get_pc())
+        super().cont()
+
     def read_gpr(self, register_index: int) -> int:
         if register_index != 32:
             return super().read_gpr(register_index)

--- a/ttexalens/hardware/wormhole/baby_risc_debug.py
+++ b/ttexalens/hardware/wormhole/baby_risc_debug.py
@@ -14,14 +14,17 @@ class WormholeBabyRiscDebug(BabyRiscDebug):
         # If this is functional worker core, we need to disable branch prediction as a hardware workaround
         if self.baby_risc_info.branch_prediction_register is not None:
             self.set_branch_prediction(False)
-            super().cont()
         else:
-            # For erisc, we don't have option to disable branch prediction, so we should continue without debug
-            if self.enable_asserts:
-                self.assert_not_in_reset()
-            self.assert_debug_hardware()
-            assert self.debug_hardware is not None, "Debug hardware is not initialized"
-            self.debug_hardware.continue_without_debug()
+            # erisc has no branch-prediction register to disable. Resuming from an ebreak with a plain
+            # CONTINUE re-asserts the ebreak (Wormhole/Blackhole ebreak hardware bug): the fetch pipeline
+            # re-runs the window after the ebreak and the core re-halts with ebreak still set. Flushing
+            # the pipeline to the current PC clears the latched ebreak so we can continue in debug mode
+            # (which keeps watchpoints active), instead of falling back to continue_without_debug().
+            if self.is_halted() and self.is_ebreak_hit():
+                self.assert_debug_hardware()
+                assert self.debug_hardware is not None, "Debug hardware is not initialized"
+                self.debug_hardware.flush(self.get_pc())
+        super().cont()
 
     def step(self):
         # We need to disable branch prediction as a hardware workaround, if there is an option to do so

--- a/ttexalens/hardware/wormhole/baby_risc_debug.py
+++ b/ttexalens/hardware/wormhole/baby_risc_debug.py
@@ -14,17 +14,19 @@ class WormholeBabyRiscDebug(BabyRiscDebug):
         # If this is functional worker core, we need to disable branch prediction as a hardware workaround
         if self.baby_risc_info.branch_prediction_register is not None:
             self.set_branch_prediction(False)
+            super().cont()
         else:
-            # erisc has no branch-prediction register to disable. Resuming from an ebreak with a plain
-            # CONTINUE re-asserts the ebreak (Wormhole/Blackhole ebreak hardware bug): the fetch pipeline
-            # re-runs the window after the ebreak and the core re-halts with ebreak still set. Flushing
-            # the pipeline to the current PC clears the latched ebreak so we can continue in debug mode
-            # (which keeps watchpoints active), instead of falling back to continue_without_debug().
-            if self.is_halted() and self.is_ebreak_hit():
-                self.assert_debug_hardware()
-                assert self.debug_hardware is not None, "Debug hardware is not initialized"
-                self.debug_hardware.flush(self.get_pc())
-        super().cont()
+            # For erisc we cannot disable branch prediction: the eth tile has no DISABLE_RISC_BP config
+            # register, the RISC debug module cannot reach CSRs to set cfg0.DisBp (its register-access
+            # command masks the index to the GPR file), and a `csr` instruction in a debugger-loaded
+            # program traps. A debug-mode CONTINUE with branch prediction enabled corrupts the core
+            # (subsequent NoC writes to its L1 intermittently fail), so we continue without debug mode.
+            # This is stable but means hardware watchpoints cannot halt the erisc (see #762).
+            if self.enable_asserts:
+                self.assert_not_in_reset()
+            self.assert_debug_hardware()
+            assert self.debug_hardware is not None, "Debug hardware is not initialized"
+            self.debug_hardware.continue_without_debug()
 
     def step(self):
         # We need to disable branch prediction as a hardware workaround, if there is an option to do so

--- a/ttexalens/hardware/wormhole/eth_block.py
+++ b/ttexalens/hardware/wormhole/eth_block.py
@@ -172,7 +172,7 @@ class WormholeEthBlock(WormholeNocBlock):
             noc_block=self,
             neo_id=None,  # NEO ID is not applicable for Wormhole
             l1=self.l1,
-            max_watchpoints=0,  # Due to #762, we disable watchpoints for erisc
+            max_watchpoints=8,
             reset_flag_shift=11,
             branch_prediction_register=None,  # We don't have a branch prediction register on erisc
             default_code_start_address=0,


### PR DESCRIPTION
Implement workarounds for hardware bugs related to the ebreak instruction and the CONTINUE operation in the Blackhole architecture. These changes ensure proper execution flow and prevent erroneous halting during debugging.