### PR TITLE
Enhance UmdApi for QUASAR architecture support in core reset logic

### DIFF
--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -90,11 +90,13 @@ class UmdApi:
             # and take all cores out of reset. Downstream test harnesses then re-assert specific
             # cores, load their ELFs, and re-deassert. This keeps cores from executing garbage
             # between tt-exalens init and the harness taking over.
-            if tt_device.get_arch() == tt_umd.ARCH.BLACKHOLE:
-                for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
-                    core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
+            for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
+                core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
+                if tt_device.get_arch() == tt_umd.ARCH.BLACKHOLE:
                     tt_device.noc_write32(core_noc0.x, core_noc0.y, 0, 0x6F)
                     tt_device.deassert_risc_reset(tt_umd.tt_xy_pair(core.x, core.y), tt_umd.RiscType.BRISC)
+                elif tt_device.get_arch() == tt_umd.ARCH.QUASAR:
+                    tt_device.deassert_risc_reset(tt_umd.tt_xy_pair(core.x, core.y), tt_umd.RiscType.ALL)
             cluster_descriptor_content = create_simulation_cluster_descriptor(tt_device.get_arch())
             self.cluster_descriptor = tt_umd.ClusterDescriptor.create_from_yaml_content(cluster_descriptor_content)
             self.devices[0] = UmdDevice(


### PR DESCRIPTION
Update the core reset logic in UmdApi to accommodate the QUASAR architecture, allowing for proper handling of core resets alongside existing BLACKHOLE architecture support.