### PR TITLE
Refactor CMake configuration to support tt-metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,5 @@ if(NOT BUILD_PYTHON_WHEEL)
     add_subdirectory(${PROJECT_SOURCE_DIR}/riscv-src)
 endif()
 
-# Dependencies for the _native_ttexalens Python extension module, and the module itself.
-include(${PROJECT_SOURCE_DIR}/cmake/native_elf.cmake)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttexalens/cpp/elf)
 add_subdirectory(${PROJECT_SOURCE_DIR}/ttexalens/cpp/nanobind)

--- a/cmake/nanobind.cmake
+++ b/cmake/nanobind.cmake
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+include_guard(GLOBAL)
+
+# CPM is already available under the exalens build and CPM-based parents; pull it
+# in otherwise so this file also works when included on its own.
+if(NOT COMMAND CPMAddPackage)
+    include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
+endif()
+
+# Python development headers (needed by nanobind)
+set(Python3_FIND_STRATEGY LOCATION)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
+
+# nanobind expects "Python_*" variables — mirror them from Python3_*.
+if(Python3_FOUND AND NOT Python_FOUND)
+    set(Python_FOUND ${Python3_FOUND})
+    set(Python_EXECUTABLE ${Python3_EXECUTABLE})
+    set(Python_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
+    set(Python_LIBRARIES ${Python3_LIBRARIES})
+    set(Python_Development_FOUND ${Python3_Development_FOUND})
+endif()
+
+CPMAddPackage(
+    NAME nanobind
+    GITHUB_REPOSITORY wjakob/nanobind
+    VERSION 2.9.2
+    OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+)

--- a/cmake/native_elf.cmake
+++ b/cmake/native_elf.cmake
@@ -1,64 +1,50 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 #
-# Dependencies for the _native_elf Python extension module:
-#   - Python development headers
-#   - nanobind (via CPM)
-#   - libdwarf (via CPM, static, PIC)
+# Third-party dependencies for the native ELF reader library (ttexalens_elf):
+#   - libdwarf (via CPM; static, PIC)
+#   - ELFIO    (header-only)
 
-include(${PROJECT_SOURCE_DIR}/cmake/CPM.cmake)
+include_guard(GLOBAL)
 
-# Python development headers (needed by nanobind)
-set(Python3_FIND_STRATEGY LOCATION)
-find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
-message(STATUS "Python3 include dirs: ${Python3_INCLUDE_DIRS}")
-
-# nanobind expects "Python_*" variables — mirror them from Python3_*.
-if(Python3_FOUND AND NOT Python_FOUND)
-    set(Python_FOUND ${Python3_FOUND})
-    set(Python_EXECUTABLE ${Python3_EXECUTABLE})
-    set(Python_INCLUDE_DIRS ${Python3_INCLUDE_DIRS})
-    set(Python_LIBRARIES ${Python3_LIBRARIES})
-    set(Python_Development_FOUND ${Python3_Development_FOUND})
+# CPM is already available under the exalens build and CPM-based parents; pull it
+# in otherwise so this file also works when included on its own.
+if(NOT COMMAND CPMAddPackage)
+    include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 endif()
 
-CPMAddPackage(
-    NAME nanobind
-    GITHUB_REPOSITORY wjakob/nanobind
-    VERSION 2.9.2
-    OPTIONS "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
-)
+# libdwarf — static archive, PIC so it can also link into a shared module.
+# dwarfdump/example/tests off to keep build time minimal. Decompression off to
+# avoid pulling in zlib/zstd (revisit if any ELFs we care about use SHF_COMPRESSED).
+if(NOT TARGET libdwarf::dwarf-static)
+    CPMAddPackage(
+        NAME libdwarf
+        GITHUB_REPOSITORY davea42/libdwarf-code
+        GIT_TAG v2.3.1
+        EXCLUDE_FROM_ALL YES
+        OPTIONS
+            "BUILD_NON_SHARED TRUE"
+            "BUILD_SHARED FALSE"
+            "BUILD_DWARFDUMP FALSE"
+            "BUILD_DWARFGEN FALSE"
+            "BUILD_DWARFEXAMPLE FALSE"
+            "DO_TESTING FALSE"
+            "PIC_ALWAYS TRUE"
+            "ENABLE_DECOMPRESSION FALSE"
+            "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
+    )
+endif()
 
-# libdwarf — static archive, PIC so it can link into a shared module.
-# We disable dwarfdump/dwarfexample/tests to keep build time minimal.
-# Decompression is disabled for the first build to avoid pulling in zlib/zstd
-# as transitive deps; revisit if any ELFs we care about use SHF_COMPRESSED.
-CPMAddPackage(
-    NAME libdwarf
-    GITHUB_REPOSITORY davea42/libdwarf-code
-    GIT_TAG v2.3.1
-    EXCLUDE_FROM_ALL YES
-    OPTIONS
-        "BUILD_NON_SHARED TRUE"
-        "BUILD_SHARED FALSE"
-        "BUILD_DWARFDUMP FALSE"
-        "BUILD_DWARFGEN FALSE"
-        "BUILD_DWARFEXAMPLE FALSE"
-        "DO_TESTING FALSE"
-        "PIC_ALWAYS TRUE"
-        "ENABLE_DECOMPRESSION FALSE"
-        "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
-)
-
-# ELFIO — header-only C++ ELF reader. Used for section list + symbol table
-# (libdwarf v2.x doesn't expose those publicly).
-CPMAddPackage(
-    NAME ELFIO
-    GITHUB_REPOSITORY serge1/ELFIO
-    GIT_TAG Release_3.12
-    EXCLUDE_FROM_ALL YES
-    DOWNLOAD_ONLY YES
-)
-# ELFIO's own CMakeLists creates a tests/examples — we only need the headers.
-add_library(elfio INTERFACE)
-target_include_directories(elfio INTERFACE "${ELFIO_SOURCE_DIR}")
+# ELFIO — header-only C++ ELF reader (section list + symbol table; libdwarf v2.x
+# doesn't expose those publicly). DOWNLOAD_ONLY: we only want the headers.
+if(NOT TARGET elfio)
+    CPMAddPackage(
+        NAME ELFIO
+        GITHUB_REPOSITORY serge1/ELFIO
+        GIT_TAG Release_3.12
+        EXCLUDE_FROM_ALL YES
+        DOWNLOAD_ONLY YES
+    )
+    add_library(elfio INTERFACE)
+    target_include_directories(elfio SYSTEM INTERFACE "${ELFIO_SOURCE_DIR}")
+endif()

--- a/ttexalens/cpp/elf/CMakeLists.txt
+++ b/ttexalens/cpp/elf/CMakeLists.txt
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-# Pure C++ ELF reader library — no Python / nanobind dependency. Wrapped for
-# Python in the sibling `native_elf` subproject.
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/native_elf.cmake)
 
 add_library(ttexalens_elf STATIC
     private/elf_file_impl.cpp

--- a/ttexalens/cpp/elf/CMakeLists.txt
+++ b/ttexalens/cpp/elf/CMakeLists.txt
@@ -21,3 +21,5 @@ target_link_libraries(ttexalens_elf
     PUBLIC elfio libdwarf::dwarf-static
 )
 set_target_properties(ttexalens_elf PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+add_library(ttexalens::elf ALIAS ttexalens_elf)

--- a/ttexalens/cpp/nanobind/CMakeLists.txt
+++ b/ttexalens/cpp/nanobind/CMakeLists.txt
@@ -19,7 +19,7 @@ nanobind_add_module(
     bind_variable.cpp
 )
 
-target_link_libraries(_native_ttexalens PRIVATE ttexalens_elf libdwarf::dwarf-static)
+target_link_libraries(_native_ttexalens PRIVATE ttexalens::elf libdwarf::dwarf-static)
 
 # scikit-build-core prepends `wheel.install-dir` (= "ttexalens") to DESTINATION,
 # so DESTINATION "." installs the .so at ttexalens/_native_ttexalens*.so inside the wheel.

--- a/ttexalens/cpp/nanobind/CMakeLists.txt
+++ b/ttexalens/cpp/nanobind/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/nanobind.cmake)
+
 # Nanobind wrapper exposing ttexalens' native code to Python.
 
 nanobind_add_module(


### PR DESCRIPTION
This enables tt-exalens becoming submodule of tt-metal. Now tt-metal tools (dprint server as the first one, then watcher) can use native_elf library from tt-exalens.