### PR TITLE
Removing unnecessary exception handler in test multicore

### DIFF
--- a/test/ttexalens/unit_tests/test_multicore.py
+++ b/test/ttexalens/unit_tests/test_multicore.py
@@ -14,8 +14,6 @@ class TestMulticore(unittest.TestCase):
 
     def setUp(self):
         self.context = init_cached_test_context()
-        if not self.context.devices[0].is_wormhole():
-            self.skipTest("Multi-core tests are only applicable for Wormhole devices.")
         self.brisc = RiscvCoreSimulator(self.context, "FW0", "BRISC")
         self.trisc0 = RiscvCoreSimulator(self.context, "FW0", "TRISC0")
 
@@ -51,6 +49,9 @@ class TestMulticore(unittest.TestCase):
             - Writes counter to mailbox
             - Jumps back to increment
         """
+        if not self.context.devices[0].is_wormhole():
+            self.skipTest("Multi-core tests are only applicable for Wormhole devices.")
+
         # Register numbers (RISC-V ABI): t0 = x5, t1 = x6, t3 = x28
         t0, t1, t3 = 5, 6, 28
         MAILBOX_READ_ADDRESS = 0xFFEC1000

--- a/test/ttexalens/unit_tests/test_multicore.py
+++ b/test/ttexalens/unit_tests/test_multicore.py
@@ -92,9 +92,6 @@ class TestMulticore(unittest.TestCase):
         except RiscHaltError as he:
             print(f"\nCore was locked up. {he}")
             self._verify_core_states()
-        except Exception as e:
-            print(f"\nExpected exception occurred: {e}")
-            self._verify_core_states()
 
 
 if __name__ == "__main__":

--- a/test/ttexalens/unit_tests/test_multicore.py
+++ b/test/ttexalens/unit_tests/test_multicore.py
@@ -14,6 +14,8 @@ class TestMulticore(unittest.TestCase):
 
     def setUp(self):
         self.context = init_cached_test_context()
+        if not self.context.devices[0].is_wormhole():
+            self.skipTest("Multi-core tests are only applicable for Wormhole devices.")
         self.brisc = RiscvCoreSimulator(self.context, "FW0", "BRISC")
         self.trisc0 = RiscvCoreSimulator(self.context, "FW0", "TRISC0")
 


### PR DESCRIPTION
Removed exception block in `test_multicore.py`. I assume this is old code left from time we did not have `RiscHaltError` but rather raised plain `Exception` in `halt` function. We only want to pass this test if we were unable to halt the core which will always raise `RiscHaltError` so this additional block handling `Exception` is not needed.

Moreover, this block is catching `self.fail` because that also raises `Exception` and this test is essentially always passing. It was passing even on blackhole which it should not have. Since this block is removed test started failing on blackhole so we are skipping it now since this is wormhole specific behaviour.