### PR TITLE
Fixing BH tests when AI clock goes down to 800MHz

### DIFF
--- a/test/ttexalens/unit_tests/core_simulator.py
+++ b/test/ttexalens/unit_tests/core_simulator.py
@@ -99,6 +99,7 @@ class RiscvCoreSimulator:
     def set_reset(self, reset: bool):
         """Set or clear reset signal."""
         self.risc_debug.set_reset_signal(reset)
+        assert self.risc_debug.is_in_reset() == reset
 
     def is_in_reset(self) -> bool:
         """Check if core is in reset state."""


### PR DESCRIPTION
Somehow we have race condition between risc being taken out of reset, risc program writing data to L1 and host reading L1 data. This adds small delay and also does verification.