### PR TITLE
Speeding up MemoryMap

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -216,12 +216,9 @@ distributed as part of the software:
 | Dependency                  | License                                                                                                     |
 |-----------------------------|-------------------------------------------------------------------------------------------------------------|
 | `yaml-cpp`                  | [MIT License](https://github.com/jbeder/yaml-cpp/blob/master/LICENSE)                                       |
-| `deprecation`               | [Apache License 2.0](https://github.com/briancurtin/deprecation/blob/master/LICENSE)                        |
 | `docopt`                    | [MIT License](https://github.com/docopt/docopt/blob/master/LICENSE-MIT)                                     |
 | `fastnumbers`               | [MIT License](https://github.com/SethMMorton/fastnumbers/blob/main/LICENSE)                                 |
-| `fuzzywuzzy`                | [GNU General Public License v2 (GPLv2)](https://github.com/seatgeek/fuzzywuzzy/blob/master/LICENSE.txt)     |
 | `prompt-toolkit`            | [BSD License](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/LICENSE)                  |
-| `python-levenshtein`        | [GNU General Public License v2 or later](https://github.com/rapidfuzz/python-Levenshtein/blob/main/COPYING) |
 | `pyyaml`                    | [MIT License](https://github.com/yaml/pyyaml/blob/main/LICENSE)                                             |
 | `rapidyaml`                 | [MIT License](https://github.com/biojppm/rapidyaml/blob/master/LICENSE.txt)                                 |
 | `sortedcontainers`          | [Apache License 2.0](https://grantjenks.com/docs/sortedcontainers/#sorted-containers-license)               |

--- a/ttexalens/hardware/blackhole/functional_worker_block.py
+++ b/ttexalens/hardware/blackhole/functional_worker_block.py
@@ -235,7 +235,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
         raise ValueError(f"RISC debug for {risc_name} is not supported in Blackhole functional worker block.")
 
     def _update_memory_maps(self):
-        self.noc_memory_map.add_blocks(
+        self.noc_memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("debug_regs", self.debug_regs, safe_to_write=True),
@@ -252,7 +252,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             ]
         )
 
-        self.brisc.memory_map.add_blocks(
+        self.brisc.memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("data_private_memory", self.brisc.data_private_memory, access_check=lambda: not self.get_risc_debug("brisc").is_in_reset()),  # type: ignore
@@ -326,7 +326,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             ]
         )
 
-        self.trisc0.memory_map.add_blocks(
+        self.trisc0.memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("data_private_memory", self.trisc0.data_private_memory, access_check=lambda: not self.get_risc_debug("trisc0").is_in_reset()),  # type: ignore
@@ -389,7 +389,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             ]
         )
 
-        self.trisc1.memory_map.add_blocks(
+        self.trisc1.memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("data_private_memory", self.trisc1.data_private_memory, access_check=lambda: not self.get_risc_debug("trisc1").is_in_reset()),  # type: ignore
@@ -452,7 +452,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             ]
         )
 
-        self.trisc2.memory_map.add_blocks(
+        self.trisc2.memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("data_private_memory", self.trisc2.data_private_memory, access_check=lambda: not self.get_risc_debug("trisc2").is_in_reset()),  # type: ignore
@@ -515,7 +515,7 @@ class BlackholeFunctionalWorkerBlock(BlackholeNocBlock):
             ]
         )
 
-        self.ncrisc.memory_map.add_blocks(
+        self.ncrisc.memory_map.initialize_blocks(
             [
                 MemoryMapBlockInfo("l1", self.l1, safe_to_write=True),
                 MemoryMapBlockInfo("data_private_memory", self.ncrisc.data_private_memory, access_check=lambda: not self.get_risc_debug("ncrisc").is_in_reset()),  # type: ignore

--- a/ttexalens/hardware/quasar/functional_worker_block.py
+++ b/ttexalens/hardware/quasar/functional_worker_block.py
@@ -53,11 +53,13 @@ class QuasarFunctionalWorkerBlock(QuasarNocBlock):
 
         self.overlay = QuasarFunctionalOverlayBlock(noc_block=self)
 
-        self.noc_memory_map.add_block(MemoryMapBlockInfo("l1", self.l1, safe_to_write=True))
-        self.noc_memory_map.add_blocks(self.neo0.noc_memory_list)
-        self.noc_memory_map.add_blocks(self.neo1.noc_memory_list)
-        self.noc_memory_map.add_blocks(self.neo2.noc_memory_list)
-        self.noc_memory_map.add_blocks(self.neo3.noc_memory_list)
+        self.noc_memory_map.initialize_blocks(
+            [MemoryMapBlockInfo("l1", self.l1, safe_to_write=True)]
+            + self.neo0.noc_memory_list
+            + self.neo1.noc_memory_list
+            + self.neo2.noc_memory_list
+            + self.neo3.noc_memory_list
+        )
 
     def get_debug_bus(self, neo_id: int | None = None) -> DebugBusSignalStore | None:
         if neo_id == 0:

--- a/ttexalens/hardware/wormhole/arc_block.py
+++ b/ttexalens/hardware/wormhole/arc_block.py
@@ -85,14 +85,8 @@ class WormholeArcBlock(ArcBlock):
         if self.device.is_local:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_local, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_local, self.location)
-            self.noc0_bar_regs = MemoryBlock(size=0x10000, address=DeviceAddress(bar0_address=0x1FF50000))
-            self.noc1_bar_regs = MemoryBlock(size=0x10000, address=DeviceAddress(bar0_address=0x1FF58000))
-            self.noc_memory_map.add_blocks(
-                [
-                    MemoryMapBlockInfo("noc0_bar_regs", self.noc0_bar_regs),
-                    MemoryMapBlockInfo("noc1_bar_regs", self.noc1_bar_regs),
-                ]
-            )
+            self.noc0_bar_regs = MemoryBlock(size=0x8000, address=DeviceAddress(bar0_address=0x1FF50000))
+            self.noc1_bar_regs = MemoryBlock(size=0x8000, address=DeviceAddress(bar0_address=0x1FF58000))
         else:
             self.register_store_noc0 = RegisterStore(register_store_noc0_initialization_remote, self.location)
             self.register_store_noc1 = RegisterStore(register_store_noc1_initialization_remote, self.location)
@@ -104,15 +98,23 @@ class WormholeArcBlock(ArcBlock):
         self.noc_regs = MemoryBlock(
             size=0x10000, address=DeviceAddress(private_address=0xFFFB20000, noc_address=0xFFFB20000)
         )
-        self.noc_memory_map = MemoryMap.get_memory_map_from_cache(
-            WormholeArcBlock,
-            "noc_memory_map",
-            block_list_lambda=lambda: [
+
+        def build_blocks() -> list[MemoryMapBlockInfo]:
+            blocks = [
                 MemoryMapBlockInfo("arc_reset_regs", self.arc_reset_regs, safe_to_write=True),
                 MemoryMapBlockInfo("arc_csm", self.arc_csm, safe_to_write=True),
                 MemoryMapBlockInfo("arc_rom", self.arc_rom, safe_to_write=True),
                 MemoryMapBlockInfo("noc_regs", self.noc_regs),
-            ],
+            ]
+            if self.device.is_local:
+                blocks.append(MemoryMapBlockInfo("noc0_bar_regs", self.noc0_bar_regs))
+                blocks.append(MemoryMapBlockInfo("noc1_bar_regs", self.noc1_bar_regs))
+            return blocks
+
+        self.noc_memory_map = MemoryMap.get_memory_map_from_cache(
+            WormholeArcBlock,
+            "noc_memory_map_local" if self.device.is_local else "noc_memory_map_remote",
+            block_list_lambda=build_blocks,
         )
 
     def get_register_store(self, noc_id: int = 0, neo_id: int | None = None) -> RegisterStore:

--- a/ttexalens/memory_map.py
+++ b/ttexalens/memory_map.py
@@ -3,11 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+from bisect import bisect_right
 from dataclasses import dataclass
 import threading
 from typing import Callable
 from ttexalens.hardware.memory_block import MemoryBlock
-from intervaltree import Interval, IntervalTree
 
 
 @dataclass
@@ -35,6 +35,60 @@ class MemoryMapBlockInfo:
         return self.access_check()
 
 
+@dataclass
+class Interval:
+    """A half-open address range ``[start, end)`` (start inclusive, end exclusive) and the block mapped to it."""
+
+    start: int
+    end: int
+    block: MemoryMapBlockInfo
+
+
+class IntervalMap:
+    """Sorted, non-overlapping address intervals supporting binary-search lookup."""
+
+    def __init__(self, intervals: list[Interval]):
+        self._intervals = sorted(intervals, key=lambda interval: interval.start)
+        self._starts = [interval.start for interval in self._intervals]
+        for i in range(len(self._intervals) - 1):
+            current = self._intervals[i]
+            following = self._intervals[i + 1]
+            assert current.end <= following.start, (
+                f"MemoryMap cannot have overlapping memory blocks: "
+                f"'{current.block.name}' [{current.start:#x}, {current.end:#x}) overlaps "
+                f"'{following.block.name}' [{following.start:#x}, {following.end:#x})"
+            )
+        # Cache the last interval a lookup landed in; callers usually hit the same block repeatedly.
+        self._last_found: Interval | None = None
+
+    def _find_index(self, address: int) -> int:
+        # Index of the rightmost interval whose start is <= address (-1 if address precedes all).
+        return bisect_right(self._starts, address) - 1
+
+    def find(self, address: int) -> MemoryMapBlockInfo | None:
+        # Fast path: the previous lookup's interval often contains this address too.
+        cached = self._last_found
+        if cached is not None and cached.start <= address < cached.end:
+            return cached.block
+
+        # Only the rightmost interval starting at or before the address can contain it.
+        index = self._find_index(address)
+        if index < 0:
+            return None
+        interval = self._intervals[index]
+        if address < interval.end:
+            self._last_found = interval
+            return interval.block
+        return None
+
+    def find_next(self, address: int) -> MemoryMapBlockInfo | None:
+        # First interval whose start is strictly greater than address.
+        index = self._find_index(address) + 1
+        if index < len(self._intervals):
+            return self._intervals[index].block
+        return None
+
+
 class MemoryMap:
     """Catalog of memory blocks with address or name based lookup."""
 
@@ -42,93 +96,54 @@ class MemoryMap:
     __cache_lock: threading.Lock = threading.Lock()
 
     def __init__(self):
-        self._noc_addresses = IntervalTree()
-        self._private_addresses = IntervalTree()
-        self._bar0_addresses = IntervalTree()
+        self._noc_addresses = IntervalMap([])
+        self._private_addresses = IntervalMap([])
+        self._bar0_addresses = IntervalMap([])
         self._blocks_info: dict[str, MemoryMapBlockInfo] = {}
 
-    def add_block(self, block_info: MemoryMapBlockInfo):
-        if block_info.name in self._blocks_info:
-            raise ValueError(f"Memory block with name '{block_info.name}' is already mapped")
-        self._blocks_info[block_info.name] = block_info
+    def initialize_blocks(self, blocks: list[MemoryMapBlockInfo]) -> None:
+        noc_intervals: list[Interval] = []
+        private_intervals: list[Interval] = []
+        bar0_intervals: list[Interval] = []
 
-        # Add to appropriate interval tree(s)
-        if block_info.memory_block.address.noc_address is not None:
-            self._noc_addresses.addi(
-                block_info.memory_block.address.noc_address,
-                block_info.memory_block.address.noc_address + block_info.memory_block.size - 1,
-                block_info,
-            )
-        if block_info.memory_block.address.private_address is not None:
-            self._private_addresses.addi(
-                block_info.memory_block.address.private_address,
-                block_info.memory_block.address.private_address + block_info.memory_block.size - 1,
-                block_info,
-            )
-        if block_info.memory_block.address.bar0_address is not None:
-            self._bar0_addresses.addi(
-                block_info.memory_block.address.bar0_address,
-                block_info.memory_block.address.bar0_address + block_info.memory_block.size - 1,
-                block_info,
-            )
-
-    def add_blocks(self, blocks: list[MemoryMapBlockInfo]) -> None:
         for block_info in blocks:
-            self.add_block(block_info)
+            if block_info.name in self._blocks_info:
+                raise ValueError(f"Memory block with name '{block_info.name}' is already mapped")
+            self._blocks_info[block_info.name] = block_info
 
-    def map_block(
-        self,
-        name: str,
-        memory_block: MemoryBlock,
-        safe_to_read: Callable[[int, int], bool] | bool | None = None,
-        safe_to_write: Callable[[int, int], bool] | bool | None = None,
-        access_check: Callable[[], bool] | None = None,
-    ) -> None:
-        self.add_block(
-            MemoryMapBlockInfo(
-                name, memory_block, safe_to_read=safe_to_read, safe_to_write=safe_to_write, access_check=access_check
-            )
-        )
+            address = block_info.memory_block.address
+            size = block_info.memory_block.size
+            if address.noc_address is not None:
+                noc_intervals.append(Interval(address.noc_address, address.noc_address + size, block_info))
+            if address.private_address is not None:
+                private_intervals.append(Interval(address.private_address, address.private_address + size, block_info))
+            if address.bar0_address is not None:
+                bar0_intervals.append(Interval(address.bar0_address, address.bar0_address + size, block_info))
+
+        self._noc_addresses = IntervalMap(noc_intervals)
+        self._private_addresses = IntervalMap(private_intervals)
+        self._bar0_addresses = IntervalMap(bar0_intervals)
 
     def find_by_noc_address(self, noc_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_by_address(noc_address, self._noc_addresses)
+        return self._noc_addresses.find(noc_address)
 
     def find_next_by_noc_address(self, noc_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_next_block(noc_address, self._noc_addresses)
+        return self._noc_addresses.find_next(noc_address)
 
     def find_by_private_address(self, private_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_by_address(private_address, self._private_addresses)
+        return self._private_addresses.find(private_address)
 
     def find_next_by_private_address(self, private_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_next_block(private_address, self._private_addresses)
+        return self._private_addresses.find_next(private_address)
 
     def find_by_bar0_address(self, bar0_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_by_address(bar0_address, self._bar0_addresses)
+        return self._bar0_addresses.find(bar0_address)
 
     def find_next_by_bar0_address(self, bar0_address: int) -> MemoryMapBlockInfo | None:
-        return MemoryMap._find_next_block(bar0_address, self._bar0_addresses)
+        return self._bar0_addresses.find_next(bar0_address)
 
     def find_by_name(self, name: str) -> MemoryMapBlockInfo | None:
         return self._blocks_info.get(name, None)
-
-    @staticmethod
-    def _find_by_address(address: int, tree: IntervalTree) -> MemoryMapBlockInfo | None:
-        intervals: set[Interval] = tree.at(address)
-        if not intervals:
-            return None
-
-        assert len(intervals) == 1, "MemoryMap cannot have overlapping memory blocks"
-        result: MemoryMapBlockInfo = next(iter(intervals)).data
-        return result
-
-    @staticmethod
-    def _find_next_block(address: int, tree: IntervalTree) -> MemoryMapBlockInfo | None:
-        next: Interval | None = None
-        for interval in tree:
-            if interval.begin > address:
-                if next is None or interval.begin < next.begin:
-                    next = interval
-        return next.data if next is not None else None
 
     @staticmethod
     def get_memory_map_from_cache(
@@ -138,6 +153,6 @@ class MemoryMap:
             memory_map = MemoryMap.__cache_of_memory_maps.get((type_to_cache, cache_key))
             if memory_map is None:
                 memory_map = MemoryMap()
-                memory_map.add_blocks(block_list_lambda())
+                memory_map.initialize_blocks(block_list_lambda())
                 MemoryMap.__cache_of_memory_maps[(type_to_cache, cache_key)] = memory_map
             return memory_map

--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,15 +1,10 @@
 tt-umd==0.9.6
-deprecation==2.1.0
 docopt==0.6.2
 fastnumbers==5.1.1
-fuzzywuzzy==0.18.0
-intervaltree==3.2.1
 prompt-toolkit==3.0.52
-python-levenshtein==0.27.3
 pyyaml==6.0.3
 Pyro5==5.16
 rapidyaml==0.12.0
 sortedcontainers==2.4.0
 tabulate==0.9.0
 rich==15.0.0
-cxxfilt==0.3.0


### PR DESCRIPTION
Replacing IntervalTree with simple array and binary search.

Adding simple cache that helps testing from same memory block.

Removing unused packages from `requirements.txt`.