### PR TITLE
Guarding logging with flags

### DIFF
--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -135,7 +135,8 @@ def import_commands(reload: bool = False) -> list[CommandMetadata]:
         # Make the module name the default 'long' invocation string
         if not command_metadata.long_name:
             command_metadata.long_name = cmd_module.__name__
-        util.VERBOSE(f"Importing command {command_metadata.long_name} from '{cmd_module.__name__}'")
+        if util.VERBOSE_ENABLED:
+            util.VERBOSE(f"Importing command {command_metadata.long_name} from '{cmd_module.__name__}'")
 
         if reload:
             importlib.reload(cmd_module)
@@ -342,11 +343,13 @@ def main_loop(args, context: Context):
         try:
             ui_state.stop_server()
         except Exception:
-            util.DEBUG(f"Exception during server shutdown:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Exception during server shutdown:\n{traceback.format_exc()}")
         try:
             ui_state.stop_gdb()
         except Exception:
-            util.DEBUG(f"Exception during GDB shutdown:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Exception during GDB shutdown:\n{traceback.format_exc()}")
 
 
 def main():
@@ -384,8 +387,10 @@ def main():
     except (TypeError, ValueError):
         util.WARN("Verbosity level must be an integer. Falling back to default value.")
     except Exception:
-        util.DEBUG(f"Failed to set verbosity level:\n{traceback.format_exc()}")
-    util.VERBOSE(f"Verbosity level: {util.Verbosity.get().name} ({util.Verbosity.get().value})")
+        if util.DEBUG_ENABLED:
+            util.DEBUG(f"Failed to set verbosity level:\n{traceback.format_exc()}")
+    if util.VERBOSE_ENABLED:
+        util.VERBOSE(f"Verbosity level: {util.Verbosity.get().name} ({util.Verbosity.get().value})")
 
     use_4B_mode = False if args["--disable-4B-mode"] else True
     safe_mode = False if args["--unsafe-mode"] else True
@@ -447,7 +452,8 @@ def main():
     # Main function
     exit_code = main_loop(args, context)
 
-    util.VERBOSE(f"Exiting with code {exit_code} ")
+    if util.VERBOSE_ENABLED:
+        util.VERBOSE(f"Exiting with code {exit_code} ")
     sys.exit(exit_code)
 
 

--- a/ttexalens/cli_commands/device_summary.py
+++ b/ttexalens/cli_commands/device_summary.py
@@ -74,7 +74,8 @@ def get_riscv_run_status(device: Device, loc: OnChipCoordinate) -> str:
                 status_str += "-" if risc.is_in_reset() else "R"
             return status_str
     except Exception:
-        util.DEBUG(f"Unexpected exception getting risc status:\n{traceback.format_exc()}")
+        if util.DEBUG_ENABLED:
+            util.DEBUG(f"Unexpected exception getting risc status:\n{traceback.format_exc()}")
     return device.get_block_type(loc)
 
 

--- a/ttexalens/cli_commands/dump_coverage.py
+++ b/ttexalens/cli_commands/dump_coverage.py
@@ -52,10 +52,13 @@ def run(cmd_text: str, context: Context, ui_state: UIState) -> list[dict[str, st
         for loc in dopt.for_each(CommonCommandOptions.Location, context, ui_state, device=device):
             try:
                 dump_coverage(elf, loc, gcda_path, gcno_path)
-                util.VERBOSE(f"Coverage data dumped for device {device.id} loc {loc}:")
+                if util.VERBOSE_ENABLED:
+                    util.VERBOSE(f"Coverage data dumped for device {device.id} loc {loc}:")
                 if gcno_path:
-                    util.VERBOSE(gcno_path)
-                util.VERBOSE(gcda_path)
+                    if util.VERBOSE_ENABLED:
+                        util.VERBOSE(gcno_path)
+                if util.VERBOSE_ENABLED:
+                    util.VERBOSE(gcda_path)
             except Exception as e:
                 util.ERROR(f"dump-coverage: {e}")
 

--- a/ttexalens/cli_commands/dump_gpr.py
+++ b/ttexalens/cli_commands/dump_gpr.py
@@ -98,7 +98,8 @@ def get_register_data(device: Device, context: Context, loc: OnChipCoordinate, a
                     elf = lib.parse_elf(elf_path, context)
                     callstack_value[risc_name] = lib.top_callstack(risc.get_pc(), elf, None, context)
             except Exception:
-                util.DEBUG(f"Unable to load ELF file for RISC {risc_name}:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Unable to load ELF file for RISC {risc_name}:\n{traceback.format_exc()}")
         else:
             util.ERROR(f"Core {risc_name} cannot be halted.")
 

--- a/ttexalens/cli_commands/search-memory.py
+++ b/ttexalens/cli_commands/search-memory.py
@@ -194,7 +194,8 @@ def _search_in_range(
             else:
                 data, _ = execute_safe_read(location, current_addr, chunk_size, risc_name)
         except TTException as e:
-            util.DEBUG(f"search: skipping 0x{current_addr:08x}: {e}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"search: skipping 0x{current_addr:08x}: {e}")
             break
 
         if not data:

--- a/ttexalens/command_parser.py
+++ b/ttexalens/command_parser.py
@@ -115,7 +115,8 @@ class tt_docopt:
                 for risc in riscs:
                     yield risc.risc_location.risc_name
             except Exception:
-                util.DEBUG(f"Could not enumerate RISC names for location {location}:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Could not enumerate RISC names for location {location}:\n{traceback.format_exc()}")
         else:
             for name in risc_name.split(","):
                 yield name

--- a/ttexalens/context.py
+++ b/ttexalens/context.py
@@ -75,7 +75,8 @@ class Context:
         device_ids = self.device_ids
         devices: dict[int, Device] = dict()
         for device_id in device_ids:
-            util.DEBUG(f"Loading device {device_id}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Loading device {device_id}")
             devices[device_id] = Device.create(device_id, self)
         return devices
 
@@ -89,7 +90,8 @@ class Context:
         try:
             device_ids = self.cluster_descriptor.get_all_chips()
         except Exception:
-            util.DEBUG(f"Could not get device IDs from cluster descriptor:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Could not get device IDs from cluster descriptor:\n{traceback.format_exc()}")
             device_ids = []
         return SortedSet(d for d in device_ids)
 

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -414,9 +414,10 @@ class Device:
                     if coord_system in unique_coordinates:
                         self._to_noc0[(converted_location, coord_system, "any")] = noc0_location
                 except Exception:
-                    util.DEBUG(
-                        f"Could not convert noc0 {noc0_location} to {coord_system}/{core_type}:\n{traceback.format_exc()}"
-                    )
+                    if util.DEBUG_ENABLED:
+                        util.DEBUG(
+                            f"Could not convert noc0 {noc0_location} to {coord_system}/{core_type}:\n{traceback.format_exc()}"
+                        )
 
             # Add coordinate systems that UMD does not support
 
@@ -613,7 +614,8 @@ class Device:
                     )
                     all_block_locs[(ui_hor, ui_ver)] = loc
                 except Exception:
-                    util.DEBUG(f"Could not compute grid location for display:\n{traceback.format_exc()}")
+                    if util.DEBUG_ENABLED:
+                        util.DEBUG(f"Could not compute grid location for display:\n{traceback.format_exc()}")
 
         screen_row_y = 0
         C = util.CLR_INFO

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -183,9 +183,10 @@ class ElfLoader:
                     if section.name == ".init":
                         init_section_address = address
 
-                    util.VERBOSE(
-                        f"Writing section {section.name} to address 0x{address:08x}. Size: {len(section.data)} bytes"
-                    )
+                    if util.VERBOSE_ENABLED:
+                        util.VERBOSE(
+                            f"Writing section {section.name} to address 0x{address:08x}. Size: {len(section.data)} bytes"
+                        )
                     self.write_block(address, section.data)
 
                     # Check that what we have written is correct
@@ -196,9 +197,10 @@ class ElfLoader:
                             util.ERROR(f"Error writing section {section.name} to address 0x{address:08x}.")
                             continue
                         else:
-                            util.VERBOSE(
-                                f"Section {section.name} loaded successfully to address 0x{address:08x}. Size: {len(section.data)} bytes"
-                            )
+                            if util.VERBOSE_ENABLED:
+                                util.VERBOSE(
+                                    f"Section {section.name} loaded successfully to address 0x{address:08x}. Size: {len(section.data)} bytes"
+                                )
         except Exception as e:
             util.ERROR(e)
             raise TTException(f"Error loading elf file {elf_path}")

--- a/ttexalens/gdb/gdb_client.py
+++ b/ttexalens/gdb/gdb_client.py
@@ -37,16 +37,20 @@ def get_gdb_client_path() -> str:
     for sfpi_root in sfpi_roots:
         gdb_client_path = os.path.abspath(os.path.join(sfpi_root, GDB_CLIENT_SFPI_RELATIVE_PATH))
         searched.append(gdb_client_path)
-        TRACE(f"Looking for gdb client at {gdb_client_path}")
+        if util.TRACE_ENABLED:
+            TRACE(f"Looking for gdb client at {gdb_client_path}")
         if os.path.isfile(gdb_client_path):
-            DEBUG(f"Found gdb client at {gdb_client_path}")
+            if util.DEBUG_ENABLED:
+                DEBUG(f"Found gdb client at {gdb_client_path}")
             return gdb_client_path
 
     # Finally, fall back to whatever gdb client is found on PATH.
-    TRACE(f"Looking for gdb client on PATH")
+    if util.TRACE_ENABLED:
+        TRACE(f"Looking for gdb client on PATH")
     gdb_client_path = shutil.which(GDB_CLIENT_BINARY_NAME)
     if gdb_client_path is not None:
-        DEBUG(f"Found gdb client at {gdb_client_path}")
+        if util.DEBUG_ENABLED:
+            DEBUG(f"Found gdb client at {gdb_client_path}")
         return gdb_client_path
 
     raise FileNotFoundError(

--- a/ttexalens/gdb/gdb_communication.py
+++ b/ttexalens/gdb/gdb_communication.py
@@ -47,7 +47,8 @@ class ClientSocket:
             except OSError:
                 pass
             except Exception:
-                util.DEBUG(f"Unexpected exception closing client socket:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Unexpected exception closing client socket:\n{traceback.format_exc()}")
             self.socket = None
 
     def input_ready(self, timeout: float = 0):
@@ -104,7 +105,8 @@ class ServerSocket:
         except OSError:
             return None
         except Exception:
-            util.DEBUG(f"Unexpected exception in server socket accept:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Unexpected exception in server socket accept:\n{traceback.format_exc()}")
             return None
 
     def close(self):

--- a/ttexalens/gdb/gdb_file_server.py
+++ b/ttexalens/gdb/gdb_file_server.py
@@ -48,7 +48,8 @@ class GdbFileServer:
             except OSError:
                 return "-1, Exception while reading."
             except Exception:
-                util.DEBUG(f"Unexpected exception in pread:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Unexpected exception in pread:\n{traceback.format_exc()}")
                 return "-1, Exception while reading."
         else:
             return "-1"
@@ -62,7 +63,8 @@ class GdbFileServer:
             except OSError:
                 return "-2,Error while writing."
             except Exception:
-                util.DEBUG(f"Unexpected exception in pwrite:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Unexpected exception in pwrite:\n{traceback.format_exc()}")
                 return "-2,Error while writing."
         else:
             return "-1"

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -106,9 +106,10 @@ class GdbServer(threading.Thread):
                     try:
                         elf_path = self.context.get_risc_elf_path(risc_debug.risc_location)
                     except Exception:
-                        util.DEBUG(
-                            f"Could not get ELF path for {risc_debug.risc_location}, running without it:\n{traceback.format_exc()}"
-                        )
+                        if util.DEBUG_ENABLED:
+                            util.DEBUG(
+                                f"Could not get ELF path for {risc_debug.risc_location}, running without it:\n{traceback.format_exc()}"
+                            )
                         elf_path = None
 
                     # Check if process is in self._last_available_processes and reuse it if it is
@@ -163,7 +164,8 @@ class GdbServer(threading.Thread):
                 self.file_server.close_all()
 
     def process_client(self, client: ClientSocket):
-        util.VERBOSE("GDB client connected")
+        if util.VERBOSE_ENABLED:
+            util.VERBOSE("GDB client connected")
         self.current_process = None
         self.debugging_threads.clear()
         input_stream = GdbInputStream(client, self.error_stream)
@@ -177,18 +179,22 @@ class GdbServer(threading.Thread):
                 if self.process_message(parser, writer):
                     if should_ack:
                         client.write(b"+")
-                        util.VERBOSE(f"sent response to GDB: +")
+                        if util.VERBOSE_ENABLED:
+                            util.VERBOSE(f"sent response to GDB: +")
                     try:
-                        util.VERBOSE(f"sent response to GDB: {writer.data.decode()}")
+                        if util.VERBOSE_ENABLED:
+                            util.VERBOSE(f"sent response to GDB: {writer.data.decode()}")
                     except UnicodeDecodeError:
                         # We ignore error if we cannot decode message
                         pass
                     writer.send()
             except Exception as e:
                 client.write(b"-")
-                util.VERBOSE(f"sent response to GDB: -")
+                if util.VERBOSE_ENABLED:
+                    util.VERBOSE(f"sent response to GDB: -")
                 util.ERROR(f"GDB exception: {e}", file=self.error_stream)
-        util.VERBOSE("GDB client closed")
+        if util.VERBOSE_ENABLED:
+            util.VERBOSE("GDB client closed")
 
     def process_message(self, parser: GdbMessageParser, writer: GdbMessageWriter):
         if parser.is_ack_ok:
@@ -201,7 +207,8 @@ class GdbServer(threading.Thread):
             return False
 
         try:
-            util.VERBOSE(f"processing GDB message: {parser.data.decode()}")
+            if util.VERBOSE_ENABLED:
+                util.VERBOSE(f"processing GDB message: {parser.data.decode()}")
         except UnicodeDecodeError:
             # We ignore error if we cannot decode message
             pass
@@ -314,7 +321,8 @@ class GdbServer(threading.Thread):
             # ‘H op thread-id’
             op = parser.read_char()
             thread_id = parser.parse_thread_id()
-            util.VERBOSE(f"GDB: Set thread {thread_id} and prepare for op '{chr(op) if op else '[EOM]'}'")
+            if util.VERBOSE_ENABLED:
+                util.VERBOSE(f"GDB: Set thread {thread_id} and prepare for op '{chr(op) if op else '[EOM]'}'")
             if self.current_process is None:
                 # Respond that we are not debugging anything at the moment
                 writer.append(b"E01")
@@ -443,7 +451,8 @@ class GdbServer(threading.Thread):
         ):  # Tell the remote stub about features supported by GDB, and query the stub for features it supports.
             # Read supported gdb client features
             if parser.parse(b":"):
-                util.VERBOSE("GDB: client features:")
+                if util.VERBOSE_ENABLED:
+                    util.VERBOSE("GDB: client features:")
                 while True:
                     feature = parser.read_until(GDB_ASCII_SEMICOLON)
                     if not feature:
@@ -453,11 +462,13 @@ class GdbServer(threading.Thread):
                         value = feature.endswith("+")
                         feature = feature[:-1]
                         self.client_features[feature] = value
-                        util.VERBOSE(f"     - {feature} = {value}")
+                        if util.VERBOSE_ENABLED:
+                            util.VERBOSE(f"     - {feature} = {value}")
                     else:
                         feature, value = feature.split("=")
                         self.client_features[feature] = value
-                        util.VERBOSE(f"     - {feature} = {value}")
+                        if util.VERBOSE_ENABLED:
+                            util.VERBOSE(f"     - {feature} = {value}")
 
             # Return supported features
             writer.append(b"PacketSize=")
@@ -975,7 +986,8 @@ class GdbServer(threading.Thread):
                         util.ERROR(str(e), file=self.error_stream)
                         writer.append(b"E04")  # restricted memory access
             except Exception:
-                util.DEBUG(f"Unexpected exception handling GDB memory write:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Unexpected exception handling GDB memory write:\n{traceback.format_exc()}")
                 writer.append(b"E03")
         elif parser.parse(b"z0,"):  # Remove a software breakpoint at address of type kind.
             # ‘z0,addr,kind’

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -252,46 +252,55 @@ class BabyRiscDebugHardware:
             return f"Unknown register {address}"
 
     def __write(self, address: int, data: int):
-        util.TRACE(f"{self._get_reg_name_for_address(address)} <- WR   0x{data:08x}")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"{self._get_reg_name_for_address(address)} <- WR   0x{data:08x}")
         self.risc_info.noc_block.location.noc_write32(address, data)
 
     def __read(self, address: int) -> int:
         data = self.risc_info.noc_block.location.noc_read32(address)
-        util.TRACE(f"{self._get_reg_name_for_address(address)} -> RD == 0x{data:08x}")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"{self._get_reg_name_for_address(address)} -> RD == 0x{data:08x}")
         return data
 
     def __trigger_write(self, reg_addr):
-        util.TRACE(f"      __trigger_write({reg_addr})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"      __trigger_write({reg_addr})")
         self.__write(self.RISC_DBG_CNTL0, self.CONTROL0_WRITE + reg_addr)
         self.__write(self.RISC_DBG_CNTL0, 0)
 
     def __trigger_read(self, reg_addr):
-        util.TRACE(f"      __trigger_read({reg_addr})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"      __trigger_read({reg_addr})")
         self.__write(self.RISC_DBG_CNTL0, self.CONTROL0_READ + reg_addr)
         self.__write(self.RISC_DBG_CNTL0, 0)
 
     def __riscv_write(self, reg_addr, value):
-        util.TRACE(f"    __riscv_write({reg_addr}, 0x{value:08x})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"    __riscv_write({reg_addr}, 0x{value:08x})")
         # set wrdata
         self.__write(self.RISC_DBG_CNTL1, value)
         self.__trigger_write(reg_addr)
 
     def __is_read_valid(self):
-        util.TRACE("  __is_read_valid()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  __is_read_valid()")
         status0 = self.__read(self.RISC_DBG_STATUS0)
         return (status0 & self.risc_info.status_read_valid_mask) == self.risc_info.status_read_valid_mask
 
     def __riscv_read(self, reg_addr) -> int:
-        util.TRACE(f"  __riscv_read({reg_addr})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  __riscv_read({reg_addr})")
         self.__trigger_read(reg_addr)
 
         if self.enable_asserts:
             if not self.__is_read_valid():
-                util.DEBUG(f"Reading from RiscV debug registers failed (debug read valid bit is set to 0).")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Reading from RiscV debug registers failed (debug read valid bit is set to 0).")
         return self.__read(self.RISC_DBG_STATUS1)
 
     def enable_debug(self):
-        util.TRACE("  enable_debug()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  enable_debug()")
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE)
 
     def _halt_command(self):
@@ -299,9 +308,13 @@ class BabyRiscDebugHardware:
 
     def halt(self):
         if self.is_halted():
-            util.WARN(f"Halt: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already halted")
+            if util.WARN_ENABLED:
+                util.WARN(
+                    f"Halt: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already halted"
+                )
             return
-        util.TRACE("  halt()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  halt()")
         self._halt_command()
         if not self.is_halted():
             raise RiscHaltError(self.risc_info.risc_name, self.risc_info.noc_block.location)
@@ -313,7 +326,8 @@ class BabyRiscDebugHardware:
         Args:
             pc_address (int): The address to set the PC to after flushing
         """
-        util.TRACE(f"  flush(0x{pc_address:08x})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  flush(0x{pc_address:08x})")
 
         # Set the PC address in COMMAND_ARG_1
         self.__riscv_write(REG_COMMAND_ARG_1, pc_address)
@@ -336,16 +350,19 @@ class BabyRiscDebugHardware:
                 self.cont()
 
     def step(self):
-        util.TRACE("  step()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  step()")
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_STEP)
 
     def cont(self):
         if not self.is_halted():
-            util.WARN(
-                f"Continue: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already running"
-            )
+            if util.WARN_ENABLED:
+                util.WARN(
+                    f"Continue: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already running"
+                )
             return
-        util.TRACE("  cont()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  cont()")
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_CONTINUE)
 
     def continue_without_debug(self):
@@ -361,24 +378,29 @@ class BabyRiscDebugHardware:
             - Writes to RISC-V command register
         """
         if not self.is_halted():
-            util.WARN(
-                f"Continue: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already running"
-            )
+            if util.WARN_ENABLED:
+                util.WARN(
+                    f"Continue: {self.risc_info.risc_name} core at {self.risc_info.noc_block.location} is already running"
+                )
             return
-        util.TRACE("  continue_without_debug()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  continue_without_debug()")
         self.__riscv_write(REG_COMMAND, COMMAND_CONTINUE)
 
     def read_status(self) -> BabyRiscDebugStatus:
-        util.TRACE("  read_status()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  read_status()")
         status = self.__riscv_read(REG_STATUS)
         return BabyRiscDebugStatus.from_register(status, self.risc_info.max_watchpoints)
 
     def is_halted(self) -> bool:
-        util.TRACE("  is_halted()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  is_halted()")
         return self.read_status().is_halted
 
     def is_pc_watchpoint_hit(self) -> bool:
-        util.TRACE("  is_pc_watchpoint_hit()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  is_pc_watchpoint_hit()")
         return self.read_status().is_pc_watchpoint_hit
 
     def assert_halted(self, message=""):
@@ -392,19 +414,22 @@ class BabyRiscDebugHardware:
             raise ValueError(exception_message)
 
     def is_memory_watchpoint_hit(self):
-        util.TRACE("  is_memory_watchpoint_hit()")
+        if util.TRACE_ENABLED:
+            util.TRACE("  is_memory_watchpoint_hit()")
         return self.read_status().is_memory_watchpoint_hit
 
     def read_gpr(self, reg_index) -> int:
         if not 0 <= reg_index <= 32:
             raise ValueError(f"Invalid register index {reg_index}. Must be between 0 and 32.")
-        util.TRACE(f"  read_gpr({reg_index})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  read_gpr({reg_index})")
         self.__riscv_write(REG_COMMAND_ARG_0, reg_index)
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_READ_REGISTER)
         return self.__riscv_read(REG_COMMAND_RETURN_VALUE)
 
     def write_gpr(self, reg_index, value):
-        util.TRACE(f"  write_gpr({reg_index}, 0x{value:08x})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  write_gpr({reg_index}, 0x{value:08x})")
         self.__riscv_write(REG_COMMAND_ARG_1, value)
         self.__riscv_write(REG_COMMAND_ARG_0, reg_index)
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_WRITE_REGISTER)
@@ -412,17 +437,20 @@ class BabyRiscDebugHardware:
     def read_memory(self, addr) -> int:
         if self.enable_asserts:
             self.assert_halted()
-        util.TRACE(f"  read_memory(0x{addr:08x})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  read_memory(0x{addr:08x})")
         self.__riscv_write(REG_COMMAND_ARG_0, addr)
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_READ_MEMORY)
         data = self.__riscv_read(REG_COMMAND_RETURN_VALUE)
-        util.TRACE(f"                             read -> 0x{data:08x}")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"                             read -> 0x{data:08x}")
         return data
 
     def write_memory(self, addr, value):
         if self.enable_asserts:
             self.assert_halted()
-        util.TRACE(f"  write_memory(0x{addr:08x}, 0x{value:08x})")
+        if util.TRACE_ENABLED:
+            util.TRACE(f"  write_memory(0x{addr:08x}, 0x{value:08x})")
         self.__riscv_write(REG_COMMAND_ARG_1, value)
         self.__riscv_write(REG_COMMAND_ARG_0, addr)
         self.__riscv_write(REG_COMMAND, COMMAND_DEBUG_MODE + COMMAND_WRITE_MEMORY)
@@ -677,7 +705,8 @@ class BabyRiscDebug(RiscDebug):
             if self.risc_info.noc_block.debug_bus is not None:
                 return self.risc_info.noc_block.debug_bus.get_signal_description(self.risc_info.risc_name + "_pc")
         except Exception:
-            util.DEBUG(f"Unexpected exception getting debug bus PC signal:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Unexpected exception getting debug bus PC signal:\n{traceback.format_exc()}")
         return None
 
     def get_pc(self) -> int:

--- a/ttexalens/server.py
+++ b/ttexalens/server.py
@@ -314,7 +314,8 @@ def connect_to_server(server_host="localhost", port=5555) -> tuple[UmdApi, FileA
     try:
         # Connect to UmdApi
         pyro_umd_api_address = f"PYRO:umd_api@{server_host}:{port}"
-        util.VERBOSE(f"Connecting UMD API to ttexalens-server at {pyro_umd_api_address}...")
+        if util.VERBOSE_ENABLED:
+            util.VERBOSE(f"Connecting UMD API to ttexalens-server at {pyro_umd_api_address}...")
         # We are returning a wrapper around the Pyro5 proxy to provide UmdApi-like behavior.
         proxy = Pyro5.api.Proxy(pyro_umd_api_address)
         proxy._pyroSerializer = "serpent"
@@ -322,7 +323,8 @@ def connect_to_server(server_host="localhost", port=5555) -> tuple[UmdApi, FileA
 
         # Connect to FileAccessApi
         pyro_file_api_address = f"PYRO:file_api@{server_host}:{port}"
-        util.VERBOSE(f"Connecting FileAccess API to ttexalens-server at {pyro_file_api_address}...")
+        if util.VERBOSE_ENABLED:
+            util.VERBOSE(f"Connecting FileAccess API to ttexalens-server at {pyro_file_api_address}...")
 
         # We are returning a wrapper around the Pyro5 proxy to provide FileAccessApi-like behavior.
         # Since this is not a direct instance of FileAccessApi, mypy will warn; hence the ignore.

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -876,7 +876,8 @@ def get_tensix_state(
         else debug_bus.read_signal_group_unsafe(signal_group)
     )
     if l1_address is None:
-        util.DEBUG("No L1 address provided. Disabling atomic group reading ADC and RWC groups.")
+        if util.DEBUG_ENABLED:
+            util.DEBUG("No L1 address provided. Disabling atomic group reading ADC and RWC groups.")
     rwc = _read_signal_groups(tensix_debug_bus_desc.register_window_counter_groups, group_reader)
     adc = _read_signal_groups(tensix_debug_bus_desc.address_counter_groups, group_reader)
     return TensixState(

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -206,5 +206,6 @@ class UmdApi:
 
 def local_init(init_jtag=False, initialize_with_noc1=False, simulation_directory: str | None = None):
     communicator = UmdApi(init_jtag, initialize_with_noc1, simulation_directory)
-    util.VERBOSE("Device opened successfully.")
+    if util.VERBOSE_ENABLED:
+        util.VERBOSE("Device opened successfully.")
     return communicator

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -136,7 +136,10 @@ class UmdDevice:
                 self.__read_from_device_reg(tensix_translated_coord, 0, buffer, 8)
                 return
             except Exception:
-                util.DEBUG(f"Active ETH core {translated_coord} not working, trying next:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(
+                        f"Active ETH core {translated_coord} not working, trying next:\n{traceback.format_exc()}"
+                    )
                 continue
         raise RuntimeError("Failed to configure working active Ethernet")  # TODO: Improve error message
 
@@ -273,7 +276,8 @@ class UmdDevice:
         except Exception:
             if self._is_simulation or self._is_mmio_capable:
                 raise
-            util.DEBUG(f"Read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
             self.__configure_working_active_eth()
             self.__read_from_device_reg_unaligned_helper(coord, address, buffer, use_4B_mode, dma_threshold)
 
@@ -346,7 +350,8 @@ class UmdDevice:
         except Exception:
             if self._is_simulation or self._is_mmio_capable:
                 raise
-            util.DEBUG(f"Write failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
+            if util.DEBUG_ENABLED:
+                util.DEBUG(f"Write failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
             self.__configure_working_active_eth()
             self.__write_to_device_reg_unaligned_helper(coord, address, data, use_4B_mode, dma_threshold)
 
@@ -374,7 +379,8 @@ class UmdDevice:
             self.__select_noc_id(noc_id)
             self.__read_from_device_reg_unaligned(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during noc_read, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during noc_read, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             self.noc_read(noc_id, noc0_x, noc0_y, address, buffer, use_4B_mode, dma_threshold)
 
@@ -408,7 +414,8 @@ class UmdDevice:
             self.__select_noc_id(noc_id)
             self.__write_to_device_reg_unaligned(noc_id, noc0_x, noc0_y, address, data, use_4B_mode, dma_threshold)
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during noc_write, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during noc_write, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             self.noc_write(noc_id, noc0_x, noc0_y, address, data, use_4B_mode, dma_threshold)
 
@@ -419,7 +426,8 @@ class UmdDevice:
         try:
             return self.__device.bar_read32(address)
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during bar0_read32, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during bar0_read32, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             return self.__device.bar_read32(address)
 
@@ -430,7 +438,8 @@ class UmdDevice:
         try:
             self.__device.bar_write32(address, data)
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during bar0_write32, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during bar0_write32, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             self.__device.bar_write32(address, data)
 
@@ -459,7 +468,8 @@ class UmdDevice:
             timeout_ms = timeout.total_seconds() * 1000 if isinstance(timeout, datetime.timedelta) else timeout * 1000
             return self.__device.arc_msg(msg_code, wait_for_done, args, int(timeout_ms))
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during arc_msg, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during arc_msg, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             return self.arc_msg(noc_id, msg_code, wait_for_done, args, timeout)
 
@@ -476,19 +486,22 @@ class UmdDevice:
         try:
             return do_read(telemetry_tag)
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during read_arc_telemetry_entry, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during read_arc_telemetry_entry, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             return self.read_arc_telemetry_entry(noc_id, telemetry_tag)
         except Exception:
             if not self._is_mmio_capable:
                 raise
             try:
-                util.DEBUG(f"Telemetry read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(f"Telemetry read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
                 # TODO: We should retry only if it was remote read error
                 self.__configure_working_active_eth()
                 return do_read(telemetry_tag)
             except tt_umd.SigbusError:
-                util.DEBUG("Reset detected during read_arc_telemetry_entry, reinitializing device and retrying...")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG("Reset detected during read_arc_telemetry_entry, reinitializing device and retrying...")
                 self.__reinit_device_after_sigbus()
                 return self.read_arc_telemetry_entry(noc_id, telemetry_tag)
 
@@ -503,19 +516,24 @@ class UmdDevice:
         try:
             firmware_version = do_read()
         except tt_umd.SigbusError:
-            util.DEBUG("Reset detected during get_firmware_version, reinitializing device and retrying...")
+            if util.DEBUG_ENABLED:
+                util.DEBUG("Reset detected during get_firmware_version, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
             return self.get_firmware_version(noc_id)
         except Exception:
             if not self._is_mmio_capable:
                 raise
             try:
-                util.DEBUG(f"Firmware version read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG(
+                        f"Firmware version read failed, retrying via ETH reconfiguration:\n{traceback.format_exc()}"
+                    )
                 # TODO: We should retry only if it was remote read error
                 self.__configure_working_active_eth()
                 firmware_version = do_read()
             except tt_umd.SigbusError:
-                util.DEBUG("Reset detected during get_firmware_version, reinitializing device and retrying...")
+                if util.DEBUG_ENABLED:
+                    util.DEBUG("Reset detected during get_firmware_version, reinitializing device and retrying...")
                 self.__reinit_device_after_sigbus()
                 return self.get_firmware_version(noc_id)
         return firmware_version

--- a/ttexalens/util.py
+++ b/ttexalens/util.py
@@ -42,9 +42,16 @@ class Verbosity(Enum):
                 5: DEBUG
                 6: TRACE
         """
-        global VERBOSITY_VALUE
+        global VERBOSITY_VALUE, VERBOSITY_LEVEL, ERROR_ENABLED, WARN_ENABLED, INFO_ENABLED, VERBOSE_ENABLED, DEBUG_ENABLED, TRACE_ENABLED
 
         VERBOSITY_VALUE = Verbosity(verbosity)
+        VERBOSITY_LEVEL = VERBOSITY_VALUE.value
+        ERROR_ENABLED = Verbosity.ERROR.value <= VERBOSITY_LEVEL
+        WARN_ENABLED = Verbosity.WARN.value <= VERBOSITY_LEVEL
+        INFO_ENABLED = Verbosity.INFO.value <= VERBOSITY_LEVEL
+        VERBOSE_ENABLED = Verbosity.VERBOSE.value <= VERBOSITY_LEVEL
+        DEBUG_ENABLED = Verbosity.DEBUG.value <= VERBOSITY_LEVEL
+        TRACE_ENABLED = Verbosity.TRACE.value <= VERBOSITY_LEVEL
 
     @staticmethod
     def get() -> "Verbosity":
@@ -70,12 +77,17 @@ class Verbosity(Enum):
         Returns:
             bool: True if supported, False otherwise.
         """
-        global VERBOSITY_VALUE
-
-        return VERBOSITY_VALUE.value >= verbosity.value
+        return VERBOSITY_LEVEL >= verbosity.value
 
 
 VERBOSITY_VALUE: Verbosity = Verbosity.ERROR
+VERBOSITY_LEVEL: int = VERBOSITY_VALUE.value
+ERROR_ENABLED: bool = True
+WARN_ENABLED: bool = False
+INFO_ENABLED: bool = False
+VERBOSE_ENABLED: bool = False
+DEBUG_ENABLED: bool = False
+TRACE_ENABLED: bool = False
 
 # Pretty print exceptions (traceback)
 def notify_exception(exc_type, exc_value, tb):
@@ -192,32 +204,32 @@ def FATAL(s, **kwargs):
 
 
 def ERROR(s, **kwargs):
-    if Verbosity.supports(Verbosity.ERROR):
+    if ERROR_ENABLED:
         print(f"{CLR_ERR}{s}{CLR_END}", **kwargs)
 
 
 def WARN(s, **kwargs):
-    if Verbosity.supports(Verbosity.WARN):
+    if WARN_ENABLED:
         print(f"{CLR_WARN}{s}{CLR_END}", **kwargs)
 
 
 def DEBUG(s, **kwargs):
-    if Verbosity.supports(Verbosity.DEBUG):
+    if DEBUG_ENABLED:
         print(f"{CLR_DEBUG}{s}{CLR_END}", **kwargs)
 
 
 def TRACE(s, **kwargs):
-    if Verbosity.supports(Verbosity.TRACE):
+    if TRACE_ENABLED:
         print(f"{CLR_TRACE}{s}{CLR_END}", **kwargs)
 
 
 def INFO(s, **kwargs):
-    if Verbosity.supports(Verbosity.INFO):
+    if INFO_ENABLED:
         print(f"{CLR_INFO}{s}{CLR_END}", **kwargs)
 
 
 def VERBOSE(s, **kwargs):
-    if Verbosity.supports(Verbosity.VERBOSE):
+    if VERBOSE_ENABLED:
         print(f"{CLR_VERBOSE}{s}{CLR_END}", **kwargs)
 
 


### PR DESCRIPTION
Guard protects lower level logging (TRACE, VERBOSE, DEBUG) and doesn't execute string format at all.

It speeds up full test execution by 0.5s. 

Lets vote if it makes sense to do this change!