### PR TITLE
Fix GDB memory access tests

### DIFF
--- a/test/ttexalens/unit_tests/test_base.py
+++ b/test/ttexalens/unit_tests/test_base.py
@@ -5,7 +5,9 @@ import os
 from ttexalens import init_ttexalens_remote, init_ttexalens, OnChipCoordinate, Device
 from ttexalens.elf import ElfFile, read_elf
 from ttexalens.server import FileAccessApi
+from ttexalens.hardware.baby_risc_debug import BabyRiscDebugHardware
 
+BabyRiscDebugHardware.ENABLE_ASSERTS = os.getenv("TTEXALENS_TESTS_ENABLE_DEBUG_HARDWARE_ASSERTS", "0") == "1"
 
 # Global cache for simulator context to ensure only one simulator process
 # is created when TTEXALENS_SIMULATOR is set, preventing conflicts between

--- a/test/ttexalens/unit_tests/test_gdb_mem_access.py
+++ b/test/ttexalens/unit_tests/test_gdb_mem_access.py
@@ -123,10 +123,11 @@ class TestGdbMemAccessFromClient(unittest.TestCase):
         """
         proc = subprocess.run(
             [self.gdb_bin, "-q", "-x", script_path],
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=False,  # capture raw bytes
-            timeout=60,
+            timeout=2,
         )
         output = proc.stdout.decode("utf-8", errors="replace")
         return proc.returncode, output

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -509,7 +509,7 @@ class BabyRiscDebug(RiscDebug):
             if risc_info.debug_hardware_present
             else None
         )
-        self.enable_asserts = enable_asserts
+        self.enable_asserts = self.debug_hardware.enable_asserts if self.debug_hardware is not None else True
 
         self.RISC_DBG_SOFT_RESET0 = register_store.get_register_noc_address("RISCV_DEBUG_REG_SOFT_RESET_0")
 

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -217,12 +217,16 @@ class BabyRiscDebugWatchpointState(RiscDebugWatchpointState):
 
 
 class BabyRiscDebugHardware:
+    ENABLE_ASSERTS: bool = True
+
     def __init__(
         self,
         register_store: RegisterStore,
         risc_info: BabyRiscInfo,
-        enable_asserts: bool = True,
+        enable_asserts: bool | None = None,
     ):
+        if enable_asserts is None:
+            enable_asserts = BabyRiscDebugHardware.ENABLE_ASSERTS
         self.register_store = register_store
         self.risc_info = risc_info
         self.enable_asserts = enable_asserts
@@ -495,7 +499,7 @@ class BabyRiscDebugHardware:
 
 
 class BabyRiscDebug(RiscDebug):
-    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool = True):
+    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool | None = None):
         super().__init__(RiscLocation(risc_info.noc_block.location, risc_info.neo_id, risc_info.risc_name), risc_info)
         register_store = risc_info.noc_block.get_register_store(neo_id=risc_info.neo_id)
         self.baby_risc_info = risc_info

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -8,7 +8,7 @@ from ttexalens.exceptions import TTException
 
 
 class BlackholeBabyRiscDebug(BabyRiscDebug):
-    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool = True):
+    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool | None = None):
         super().__init__(risc_info, enable_asserts)
 
     def step(self):

--- a/ttexalens/hardware/quasar/baby_risc_debug.py
+++ b/ttexalens/hardware/quasar/baby_risc_debug.py
@@ -7,7 +7,7 @@ from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 
 
 class QuasarBabyRiscDebug(BabyRiscDebug):
-    def __init__(self, risc_info: BabyRiscInfo, neo_block, enable_asserts: bool = True):
+    def __init__(self, risc_info: BabyRiscInfo, neo_block, enable_asserts: bool | None = None):
         self.neo_block = neo_block
         super().__init__(risc_info, enable_asserts)
 

--- a/ttexalens/hardware/wormhole/baby_risc_debug.py
+++ b/ttexalens/hardware/wormhole/baby_risc_debug.py
@@ -7,7 +7,7 @@ from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 
 
 class WormholeBabyRiscDebug(BabyRiscDebug):
-    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool = True):
+    def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool | None = None):
         super().__init__(risc_info, enable_asserts)
 
     def cont(self):


### PR DESCRIPTION
GDB client was having STDIN as process that ran it. Since unittest forwards its STDIN, GDB client decided to return control to the user. Here we disable it byt using NULL pipe. Also, reducing script time to 2 seconds.

Disabling RiscDebug asserts in tests as tests always verify that something happened right after. This speeds BH tests by 20%.