### PR TITLE
Various small perf improvements

### DIFF
--- a/test/ttexalens/unit_tests/test_coverage.py
+++ b/test/ttexalens/unit_tests/test_coverage.py
@@ -117,10 +117,10 @@ class TestCoverage(unittest.TestCase):
                 self.skipTest("ETH core is not available on this platform")
         elif self.core_desc.startswith("FW"):
             # Ask device for all ETH cores and get first one
-            eth_cores = self.device.get_block_locations(block_type="functional_workers")
+            fw_cores = self.device.get_block_locations(block_type="functional_workers")
             core_index = int(self.core_desc[2:])
-            if len(eth_cores) > core_index:
-                self.core_loc = eth_cores[core_index].to_str()
+            if len(fw_cores) > core_index:
+                self.core_loc = fw_cores[core_index].to_str()
             else:
                 # If not found, we should skip the test
                 self.skipTest("FW core is not available on this platform")
@@ -128,7 +128,7 @@ class TestCoverage(unittest.TestCase):
             self.fail(f"Unknown core description {self.core_desc}")
 
         self.location = OnChipCoordinate.create(self.core_loc, device=self.device)
-        noc_block = self.location._device.get_block(self.location)
+        noc_block = self.location.device.get_block(self.location)
         try:
             self.risc_debug = noc_block.get_risc_debug(self.risc_name)
         except ValueError:

--- a/test/ttexalens/unit_tests/test_gdb_mem_access.py
+++ b/test/ttexalens/unit_tests/test_gdb_mem_access.py
@@ -100,7 +100,7 @@ class TestGdbMemAccessFromClient(unittest.TestCase):
         # Start GdbServer on a free port
         cls.server_socket = ServerSocket(port=None)
         cls.server_socket.start()
-        cls.gdb_server = GdbServer(cls.context, cls.server_socket)
+        cls.gdb_server = GdbServer(cls.context, cls.server_socket, skip_detach=True, debug_only_with_elfs=True)
         cls.gdb_server.start()
 
         # Small delay to ensure the server is listening

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -586,7 +586,7 @@ class TestReadWrite(unittest.TestCase):
         """Testing read_memory and write_memory through debugging interface on private core memory range."""
 
         loc = OnChipCoordinate.create(location, device=self.context.devices[0])
-        risc_debug = loc._device.get_block(loc).get_risc_debug(risc_name)
+        risc_debug = loc.device.get_block(loc).get_risc_debug(risc_name)
 
         private_memory = risc_debug.get_data_private_memory()
         assert private_memory is not None, "Private memory is not available."
@@ -649,7 +649,7 @@ class TestReadWrite(unittest.TestCase):
             self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
 
         location = OnChipCoordinate.create(loc_str, device)
-        risc_debug = location._device.get_block(location).get_risc_debug(risc_name)
+        risc_debug = location.device.get_block(location).get_risc_debug(risc_name)
         with risc_debug.ensure_private_memory_access():
             private_memory = risc_debug.get_data_private_memory()
             assert private_memory is not None, "Private memory is not available."
@@ -705,7 +705,7 @@ class TestReadWrite(unittest.TestCase):
             self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
 
         location = OnChipCoordinate.create(loc_str, device)
-        risc_debug = location._device.get_block(location).get_risc_debug(risc_name)
+        risc_debug = location.device.get_block(location).get_risc_debug(risc_name)
         with risc_debug.ensure_private_memory_access():
             private_memory = risc_debug.get_data_private_memory()
             assert private_memory is not None, "Private memory is not available."
@@ -1240,7 +1240,7 @@ class TestRunElf(unittest.TestCase):
 
         # Testing
         loc = OnChipCoordinate.create(location, device=self.device)
-        device = loc._device
+        device = loc.device
         noc_block = device.get_block(loc)
         risc_debug = noc_block.get_risc_debug(risc_name)
         assert isinstance(risc_debug, BabyRiscDebug), f"Expected BabyRiscDebug, got {type(risc_debug)}"
@@ -1506,7 +1506,7 @@ class TestCallStack(unittest.TestCase):
             # If not found, we should skip the test
             self.skipTest("Location is not available on this platform")
 
-        noc_block = self.location._device.get_block(self.location)
+        noc_block = self.location.device.get_block(self.location)
         try:
             self.risc_debug = noc_block.get_risc_debug(self.risc_name)
             self.risc_name = self.risc_debug.risc_location.risc_name

--- a/ttexalens/_lib_helpers.py
+++ b/ttexalens/_lib_helpers.py
@@ -10,7 +10,7 @@ from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.device import Device
 from ttexalens.tt_exalens_init import init_ttexalens
 from ttexalens.exceptions import TTException
-from ttexalens.util import Verbosity, TRACE
+from ttexalens import util
 
 # Parameter name to formatter function mapping for trace_api decorator
 _TRACE_FORMATTERS = {
@@ -25,7 +25,7 @@ def trace_api(func: F) -> F:
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        if Verbosity.supports(Verbosity.TRACE):
+        if util.TRACE_ENABLED:
             sig = inspect.signature(func)
             bound_args = sig.bind(*args, **kwargs)
             bound_args.apply_defaults()
@@ -34,7 +34,7 @@ def trace_api(func: F) -> F:
             for k, v in bound_args.arguments.items():
                 formatter = _TRACE_FORMATTERS.get(k, repr)
                 formatted_args.append(f"{k}={formatter(v)}")
-            TRACE(f"[API] {func.__name__}({', '.join(formatted_args)})")
+            util.TRACE(f"[API] {func.__name__}({', '.join(formatted_args)})")
         return func(*args, **kwargs)
 
     return cast(F, wrapper)

--- a/ttexalens/context.py
+++ b/ttexalens/context.py
@@ -110,6 +110,9 @@ class Context:
     def get_risc_elf_path(self, risc_location: RiscLocation) -> str | None:
         return self.loaded_elfs.get(risc_location)
 
+    def get_loaded_elfs(self):
+        return self.loaded_elfs.items()
+
     def elf_loaded(self, risc_location: RiscLocation, elf_path: str):
         self.loaded_elfs[risc_location] = elf_path
 

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -42,6 +42,7 @@ The following coordinate systems are available to represent a grid location on t
 """
 
 from __future__ import annotations
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from ttexalens.exceptions import CoordinateTranslationError, TTException, UnknownCoordinateSystemError
 
@@ -120,7 +121,7 @@ class OnChipCoordinate:
     def device_id(self) -> int:
         return self._device.id
 
-    @property
+    @cached_property
     def noc_block(self) -> NocBlock:
         return self.device.get_block(self)
 

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -69,9 +69,6 @@ class OnChipCoordinate:
     coordinate systems we use.
     """
 
-    _noc0_coord: tuple[int, int]  # This uses noc0 coordinates: (X,Y)
-    _device: Device  # Used for conversions
-
     def __init__(self, x: int, y: int, input_type: str, device: Device, core_type: str = "any"):
         """
         Constructor for the Coordinate class.
@@ -95,31 +92,27 @@ class OnChipCoordinate:
             - If the device is not specified, coordinate conversion to other systems will not be possible.
         """
         assert device is not None
-        self._device = device
+        self.device = device
         if input_type == "noc0" or input_type == "physical":
             self._noc0_coord = (x, y)
         elif input_type == "noc1":
-            self._noc0_coord = self._device.to_noc0((x, y), "noc1", core_type)
+            self._noc0_coord = self.device.to_noc0((x, y), "noc1", core_type)
         elif input_type == "die":
-            self._noc0_coord = self._device.to_noc0((x, y), "die", core_type)
+            self._noc0_coord = self.device.to_noc0((x, y), "die", core_type)
         elif input_type == "logical":
-            self._noc0_coord = self._device.to_noc0((x, y), "logical", core_type)
+            self._noc0_coord = self.device.to_noc0((x, y), "logical", core_type)
         elif input_type == "translated":
-            self._noc0_coord = self._device.to_noc0((x, y), "translated", core_type)
+            self._noc0_coord = self.device.to_noc0((x, y), "translated", core_type)
         else:
             raise UnknownCoordinateSystemError(input_type)
 
     @property
     def context(self) -> Context:
-        return self._device._context
-
-    @property
-    def device(self) -> Device:
-        return self._device
+        return self.device._context
 
     @property
     def device_id(self) -> int:
-        return self._device.id
+        return self.device.id
 
     @cached_property
     def noc_block(self) -> NocBlock:
@@ -142,16 +135,16 @@ class OnChipCoordinate:
         if output_type == "noc0" or output_type == "physical":
             return self._noc0_coord
         elif output_type == "noc1":
-            return self._device.from_noc0(self._noc0_coord, "noc1")[0]
+            return self.device.from_noc0(self._noc0_coord, "noc1")[0]
         elif output_type == "die":
-            return self._device.from_noc0(self._noc0_coord, "die")[0]
+            return self.device.from_noc0(self._noc0_coord, "die")[0]
         elif output_type == "logical":
-            return self._device.from_noc0(self._noc0_coord, "logical")
+            return self.device.from_noc0(self._noc0_coord, "logical")
         elif output_type == "translated":
-            return self._device.from_noc0(self._noc0_coord, "translated")[0]
+            return self.device.from_noc0(self._noc0_coord, "translated")[0]
         elif output_type.startswith("logical-"):
             core_type = output_type.split("-")[1]
-            coord = self._device.from_noc0(self._noc0_coord, "logical")
+            coord = self.device.from_noc0(self._noc0_coord, "logical")
             if coord[1] == core_type:
                 return coord[0]
             else:
@@ -213,7 +206,7 @@ class OnChipCoordinate:
             OnChipCoordinate: The new coordinate object for the specified device.
         """
         # If the device is the same, return the same object
-        if device == self._device:
+        if device == self.device:
             return self
 
         # Try to convert to logical coordinates. If that fails, fallback to translated coordinates.
@@ -231,7 +224,7 @@ class OnChipCoordinate:
         return self.to_str("logical")
 
     def __hash__(self):
-        return hash((self._noc0_coord, self._device.id))
+        return hash((self._noc0_coord, self.device.id))
 
     # The debug string representation also has the translated coordinate.
     def __repr__(self) -> str:
@@ -243,13 +236,13 @@ class OnChipCoordinate:
     # == operator
     def __eq__(self, other):
         # util.DEBUG("Comparing coordinates: " + str(self) + " ?= " + str(other))
-        return (self._noc0_coord == other._noc0_coord) and (self._device == other._device)
+        return (self._noc0_coord == other._noc0_coord) and (self.device == other.device)
 
     def __lt__(self, other):
-        if self._device.id == other._device.id:
+        if self.device.id == other.device.id:
             return self._noc0_coord < other._noc0_coord
         else:
-            return self._device.id < other._device.id
+            return self.device.id < other.device.id
 
     @staticmethod
     def create(coord_str, device, coord_type=None) -> OnChipCoordinate:

--- a/ttexalens/elf_loader.py
+++ b/ttexalens/elf_loader.py
@@ -165,15 +165,19 @@ class ElfLoader:
             loader_code_address = loader_code if isinstance(loader_code, int) else None
 
             # Try to find address mapping for loader_data and loader_code
-            for section in elf.iter_sections():
-                if section.name == loader_data:
+            if isinstance(loader_data, str):
+                section = elf.get_section_by_name(loader_data)
+                if section:
                     loader_data_address = section.address
-                elif section.name == loader_code:
+            if isinstance(loader_code, str):
+                section = elf.get_section_by_name(loader_code)
+                if section:
                     loader_code_address = section.address
 
             # Load section into memory
-            for section in elf.iter_sections():
-                if section.name in self.SECTIONS_TO_LOAD and section.data:
+            for section_name in ElfLoader.SECTIONS_TO_LOAD:
+                section = elf.get_section_by_name(section_name)
+                if section and section.data:
                     if section.address % 4 != 0:
                         raise ValueError(
                             f"{elf_path}: section {section.name} (0x{section.address:08x}) is not 32-bit aligned"

--- a/ttexalens/gdb/gdb_communication.py
+++ b/ttexalens/gdb/gdb_communication.py
@@ -243,7 +243,7 @@ class GdbMessageParser:
     # Verifies next characters in the message and advances position if they match
     def parse(self, value: bytes):
         length = len(value)
-        if self.position + len(value) > len(self.data):
+        if self.position + length > len(self.data):
             return False
         value_position = 0
         data_position = self.position

--- a/ttexalens/gdb/gdb_server.py
+++ b/ttexalens/gdb/gdb_server.py
@@ -21,7 +21,7 @@ from ttexalens.gdb.gdb_data import GdbProcess, GdbThreadId
 from ttexalens.gdb.gdb_file_server import GdbFileServer
 from ttexalens.context import Context
 from ttexalens import util as util
-from ttexalens.hardware.risc_debug import RiscLocation
+from ttexalens.hardware.risc_debug import RiscDebug, RiscLocation
 from ttexalens.memory_access import RestrictedMemoryAccessError
 
 # Helper class returns currently debugging list of threads to gdb client in paged manner
@@ -110,37 +110,47 @@ class GdbServer(threading.Thread):
             int, GdbProcess
         ] = {}  # Dictionary of available processes that can be debugged (key: pid)
         last_available_processes: dict[RiscLocation, GdbProcess] = {}
-        for device_id in self.context.device_ids:
-            device = self.context.find_device_by_id(device_id)
-            for risc_debug in device.debuggable_cores:
-                # Try to get elf path for the risc core
-                try:
-                    elf_path = self.context.get_risc_elf_path(risc_debug.risc_location)
-                except Exception:
-                    if util.DEBUG_ENABLED:
-                        util.DEBUG(
-                            f"Could not get ELF path for {risc_debug.risc_location}, running without it:\n{traceback.format_exc()}"
-                        )
-                    elf_path = None
-                if (not self.debug_only_with_elfs or elf_path is not None) and not risc_debug.is_in_reset():
-                    # Check if process is in self._last_available_processes and reuse it if it is
-                    # TODO: In ideal world, we would have "start time" for a core (time when core was taken out of reset) and use that as a key for reusing process id; for now, we can just check if elf path is the same
-                    last_process = self._last_available_processes.get(risc_debug.risc_location)
-                    if last_process is None or last_process.elf_path != elf_path:
-                        block_type = device.get_block_type(risc_debug.risc_location.location)
-                        # Shorten long core type for cleaner output
-                        if block_type == "functional_workers":
-                            block_type = "worker"
-                        pid = self.next_pid
-                        self.next_pid += 1
-                        virtual_core = (
-                            pid  # TODO: Maybe we should actually have some mapping from RiscLoc to virtual core
-                        )
-                        process = GdbProcess(pid, elf_path, risc_debug, virtual_core, block_type)
-                    else:
-                        process = last_process
-                    available_processes[process.process_id] = process
-                    last_available_processes[risc_debug.risc_location] = process
+
+        def add_process(risc_debug: RiscDebug, elf_path: str | None):
+            # Check if process is in self._last_available_processes and reuse it if it is
+            # TODO: In ideal world, we would have "start time" for a core (time when core was taken out of reset) and use that as a key for reusing process id; for now, we can just check if elf path is the same
+            last_process = self._last_available_processes.get(risc_debug.risc_location)
+            if last_process is None or last_process.elf_path != elf_path:
+                block_type = risc_debug.risc_location.location.device.get_block_type(risc_debug.risc_location.location)
+                # Shorten long core type for cleaner output
+                if block_type == "functional_workers":
+                    block_type = "worker"
+                pid = self.next_pid
+                self.next_pid += 1
+                virtual_core = pid  # TODO: Maybe we should actually have some mapping from RiscLoc to virtual core
+                process = GdbProcess(pid, elf_path, risc_debug, virtual_core, block_type)
+            else:
+                process = last_process
+            available_processes[process.process_id] = process
+            last_available_processes[risc_debug.risc_location] = process
+
+        if self.debug_only_with_elfs:
+            for risc_location, elf_path in self.context.get_loaded_elfs():
+                risc_debug = risc_location.location.noc_block.get_risc_debug(
+                    risc_location.risc_name, risc_location.neo_id
+                )
+                if not risc_debug.is_in_reset():
+                    add_process(risc_debug, elf_path)
+        else:
+            for device_id in self.context.device_ids:
+                device = self.context.find_device_by_id(device_id)
+                for risc_debug in device.debuggable_cores:
+                    # Try to get elf path for the risc core
+                    try:
+                        elf_path = self.context.get_risc_elf_path(risc_debug.risc_location)
+                    except Exception:
+                        if util.DEBUG_ENABLED:
+                            util.DEBUG(
+                                f"Could not get ELF path for {risc_debug.risc_location}, running without it:\n{traceback.format_exc()}"
+                            )
+                        elf_path = None
+                    if elf_path is not None and not risc_debug.is_in_reset():
+                        add_process(risc_debug, elf_path)
         self._last_available_processes = last_available_processes
         return available_processes
 
@@ -271,9 +281,9 @@ class GdbServer(threading.Thread):
                 pid = parser.parse_hex()
                 if pid in self.debugging_threads:
                     thread_id = self.debugging_threads.pop(pid)
-                    process = self.available_processes.get(pid)
-                    if process is not None:
-                        if not self.skip_detach:
+                    if not self.skip_detach:
+                        process = self.available_processes.get(pid)
+                        if process is not None:
                             # Remove all break points from the process
                             watchpoints_state = process.risc_debug.read_watchpoints_state()
                             for bid in range(0, len(watchpoints_state)):
@@ -287,10 +297,10 @@ class GdbServer(threading.Thread):
                     writer.append(b"E01")
             else:
                 # We should detach all processes that we are debugging
-                for pid in self.debugging_threads.keys():
-                    process = self.available_processes.get(pid)
-                    if process is not None:
-                        if not self.skip_detach:
+                if not self.skip_detach:
+                    for pid in self.debugging_threads.keys():
+                        process = self.available_processes.get(pid)
+                        if process is not None:
                             # Remove all break points from the process
                             watchpoints_state = process.risc_debug.read_watchpoints_state()
                             for bid in range(0, len(watchpoints_state)):

--- a/ttexalens/hardware/baby_risc_info.py
+++ b/ttexalens/hardware/baby_risc_info.py
@@ -73,19 +73,24 @@ class BabyRiscInfo(RiscInfo):
         elif address is not None:
             if self.code_start_address_enable_register is not None and self.code_start_address_enable_bit is not None:
                 enabled_register_value = register_store.read_register(self.code_start_address_enable_register)
-                register_store.write_register(
-                    self.code_start_address_enable_register, enabled_register_value | self.code_start_address_enable_bit
-                )
+                if (enabled_register_value & self.code_start_address_enable_bit) == 0:
+                    register_store.write_register(
+                        self.code_start_address_enable_register,
+                        enabled_register_value | self.code_start_address_enable_bit,
+                    )
             assert self.code_start_address_register is not None
-            register_store.write_register(self.code_start_address_register, address)
+            if address != register_store.read_register(self.code_start_address_register):
+                register_store.write_register(self.code_start_address_register, address)
         else:
             assert (
                 self.code_start_address_enable_register is not None and self.code_start_address_enable_bit is not None
             )
             enabled_register_value = register_store.read_register(self.code_start_address_enable_register)
-            register_store.write_register(
-                self.code_start_address_enable_register, enabled_register_value & ~self.code_start_address_enable_bit
-            )
+            if (enabled_register_value & self.code_start_address_enable_bit) != 0:
+                register_store.write_register(
+                    self.code_start_address_enable_register,
+                    enabled_register_value & ~self.code_start_address_enable_bit,
+                )
 
     def translate_to_noc_address(self, addr: int) -> int | None:
         # Try data-private, then L1

--- a/ttexalens/hardware/noc_block.py
+++ b/ttexalens/hardware/noc_block.py
@@ -35,7 +35,7 @@ class NocBlock:
 
     @property
     def device(self) -> Device:
-        return self.location._device
+        return self.location.device
 
     @abstractmethod
     def get_register_store(self, noc_id: int = 0, neo_id: int | None = None) -> RegisterStore:

--- a/ttexalens/hardware/risc_debug.py
+++ b/ttexalens/hardware/risc_debug.py
@@ -61,7 +61,7 @@ class RiscDebug:
 
     @staticmethod
     def get_instance(risc_location: RiscLocation) -> "RiscDebug":
-        noc_block = risc_location.location._device.get_block(risc_location.location)
+        noc_block = risc_location.location.device.get_block(risc_location.location)
         return noc_block.get_risc_debug(risc_location.risc_name, risc_location.neo_id)
 
     @abstractmethod

--- a/ttexalens/register_store.py
+++ b/ttexalens/register_store.py
@@ -177,7 +177,7 @@ class RegisterStore:
 
     @property
     def device(self) -> Device:
-        return self.location._device
+        return self.location.device
 
     @property
     def context(self) -> Context:

--- a/ttexalens/server.py
+++ b/ttexalens/server.py
@@ -55,6 +55,7 @@ class TTExaLensServer:
         self.thread: threading.Thread | None = None
         self.umd_registered_objects: dict[int, TTExaLensServer.UmdRegisteredObject] = {}
         self.umd_registered_objects_lock = threading.Lock()
+        self._wrapper_classes: dict[type, type] = {}
 
     def start(self):
         if self.daemon or self.thread:
@@ -80,70 +81,87 @@ class TTExaLensServer:
         self.daemon = None
         self.thread = None
 
+    def _wrap_result(self, result):
+        """Prepares a method/property result for transport over Pyro5.
+
+        Native types and known serializable types are returned as-is so Pyro5/serpent
+        forwards them directly. Any other object is wrapped, registered with the daemon
+        (once per object), and returned as a proxy.
+        """
+        result_type = type(result)
+        # Check if result_type is simple type
+        if result_type in (int, float, str, bool, type(None), list, dict, set, tuple, bytes):
+            return result
+        # Check if result_type is in known serializable types
+        if result_type in UMD_SERIALIZABLE_TYPES:
+            return result
+        # For complex types, register them and return a proxy
+        with self.umd_registered_objects_lock:
+            object_id = id(result)
+            if object_id not in self.umd_registered_objects:
+                assert self.daemon is not None
+                wrapped_result = self._wrap_object(result)
+                pyro5_id = f"umd_obj_{object_id}"
+                self.daemon.register(wrapped_result, objectId=pyro5_id)
+                proxy = Pyro5.api.Proxy(f"PYRO:{pyro5_id}@localhost:{self.port}")
+                proxy._pyroSerializer = "serpent"
+                self.umd_registered_objects[object_id] = TTExaLensServer.UmdRegisteredObject(
+                    pyro5_id, wrapped_result, proxy
+                )
+            return self.umd_registered_objects[object_id].proxy
+
     def _wrap_object(self, obj: object):
+        """Wraps an object so its public API can be exposed over Pyro5.
+
+        The wrapper *type* is built once per wrapped object type and cached; each object of
+        that type is then wrapped by simply constructing the cached wrapper class around it.
+        """
+        wrapper_class = self._get_wrapper_class(type(obj))
+        return wrapper_class(obj, self)
+
+    def _get_wrapper_class(self, obj_type: type) -> type:
+        cached = self._wrapper_classes.get(obj_type)
+        if cached is not None:
+            return cached
+
         @Pyro5.api.expose
         class UmdApiWrapper:
             def __init__(self, obj, server: TTExaLensServer):
                 self.obj = obj
                 self.server = server
 
-            def _create_umd_method_wrapper(self, method, fget=None, fset=None):
-                def wrapper_method(*args, **kwargs):
-                    if fget is not None:
-                        result = fget(self.obj)
-                    elif fset is not None:
-                        result = fset(self.obj, *args[1:], **kwargs)
-                    else:
-                        result = method(*args, **kwargs)
-                    result_type = type(result)
-                    # Check if result_type is simple type
-                    if result_type in (int, float, str, bool, type(None), list, dict, set, tuple, bytes):
-                        return result
-                    # Check if result_type is in known serializable types
-                    global UMD_SERIALIZABLE_TYPES
-                    if result_type in UMD_SERIALIZABLE_TYPES:
-                        return result
-                    # For complex types, register them and return a proxy
-                    with self.server.umd_registered_objects_lock:
-                        object_id = id(result)
-                        if object_id not in self.server.umd_registered_objects:
-                            assert self.server.daemon is not None
-                            wrapped_result = self.server._wrap_object(result)
-                            pyro5_id = f"umd_obj_{object_id}"
-                            self.server.daemon.register(wrapped_result, objectId=pyro5_id)
-                            proxy = Pyro5.api.Proxy(f"PYRO:{pyro5_id}@localhost:{self.server.port}")
-                            proxy._pyroSerializer = "serpent"
-                            self.server.umd_registered_objects[object_id] = TTExaLensServer.UmdRegisteredObject(
-                                pyro5_id, wrapped_result, proxy
-                            )
-                        return self.server.umd_registered_objects[object_id].proxy
+        def create_method_wrapper(method_name: str | None = None, fget=None, fset=None):
+            def wrapper_method(self, *args, **kwargs):
+                if fget is not None:
+                    result = fget(self.obj)
+                elif fset is not None:
+                    return fset(self.obj, *args, **kwargs)
+                else:
+                    assert method_name is not None
+                    result = getattr(self.obj, method_name)(*args, **kwargs)
+                return self.server._wrap_result(result)
 
-                return wrapper_method
+            return wrapper_method
 
-        wrapper = UmdApiWrapper(obj, self)
-        wrapper_type = type(wrapper)
-        obj_type = type(obj)
         for method_name in obj_type.__dict__:
             if method_name.startswith("_"):
                 continue
-            method = getattr(obj, method_name)
-            if callable(method):
-                new_method = Pyro5.api.expose(wrapper._create_umd_method_wrapper(method))
-                setattr(wrapper, method_name, new_method)
-                setattr(wrapper_type, method_name, new_method)
-            else:
-                method = getattr(obj_type, method_name)
-                if inspect.isdatadescriptor(method):
-                    getter = None
-                    setter = None
-                    if getattr(method, "fset", None):
-                        setter = Pyro5.api.expose(wrapper._create_umd_method_wrapper(None, fset=method.fset))  # type: ignore
-                    if getattr(method, "fget", None):
-                        getter = Pyro5.api.expose(wrapper._create_umd_method_wrapper(None, fget=method.fget))  # type: ignore
-                    new_property = property(getter, setter)  # pyright: ignore[reportArgumentType]
-                    setattr(wrapper, method_name, new_property)
-                    setattr(wrapper_type, method_name, new_property)
-        return wrapper
+            attribute = getattr(obj_type, method_name)
+            if inspect.isdatadescriptor(attribute):
+                getter = None
+                setter = None
+                if getattr(attribute, "fset", None):
+                    setter = Pyro5.api.expose(create_method_wrapper(fset=attribute.fset))  # type: ignore
+                if getattr(attribute, "fget", None):
+                    getter = Pyro5.api.expose(create_method_wrapper(fget=attribute.fget))  # type: ignore
+                new_property = property(getter, setter)  # pyright: ignore[reportArgumentType]
+                setattr(UmdApiWrapper, method_name, new_property)
+            elif callable(attribute):
+                new_method = Pyro5.api.expose(create_method_wrapper(method_name=method_name))
+                setattr(UmdApiWrapper, method_name, new_method)
+
+        self._wrapper_classes[obj_type] = UmdApiWrapper
+        return UmdApiWrapper
 
 
 UMD_SERIALIZABLE_TYPES = {

--- a/ttexalens/server.py
+++ b/ttexalens/server.py
@@ -88,9 +88,11 @@ class TTExaLensServer:
         forwards them directly. Any other object is wrapped, registered with the daemon
         (once per object), and returned as a proxy.
         """
+        global SIMPLE_TYPES, UMD_SERIALIZABLE_TYPES
+
         result_type = type(result)
         # Check if result_type is simple type
-        if result_type in (int, float, str, bool, type(None), list, dict, set, tuple, bytes):
+        if result_type in SIMPLE_TYPES:
             return result
         # Check if result_type is in known serializable types
         if result_type in UMD_SERIALIZABLE_TYPES:
@@ -164,6 +166,7 @@ class TTExaLensServer:
         return UmdApiWrapper
 
 
+SIMPLE_TYPES = (int, float, str, bool, type(None), list, dict, set, tuple, bytes)
 UMD_SERIALIZABLE_TYPES = {
     tt_umd.ARCH,
     tt_umd.BoardType,

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
 import os
-import threading
 import Pyro5.api
+import threading
 import tt_umd
+from typing import TYPE_CHECKING
 
 from ttexalens import util as util
-from ttexalens.umd_device import UmdDevice
+
+if TYPE_CHECKING:
+    from ttexalens.umd_device import UmdDevice
 
 
 def create_simulation_cluster_descriptor(arch: tt_umd.ARCH) -> str:
@@ -39,6 +43,9 @@ io_device_type: SIMULATION
 """
 
 
+TLS_FOR_NOC_ID = threading.local()
+
+
 @Pyro5.api.expose
 class UmdApi:
     @staticmethod
@@ -47,6 +54,10 @@ class UmdApi:
         Selects the NOC ID to be used for communication with the device by the current thread.
         This method should be called before any UMD API calls are made.
         """
+        global TLS_FOR_NOC_ID
+        if getattr(TLS_FOR_NOC_ID, "noc_id", -1) == noc_id:
+            return
+        TLS_FOR_NOC_ID.noc_id = noc_id
         if noc_id == 0:
             tt_umd.set_thread_noc_id(tt_umd.NocId.NOC0)
         else:
@@ -61,6 +72,8 @@ class UmdApi:
         initialize_with_noc1=False,
         simulation_directory: str | None = None,
     ):
+        from ttexalens.umd_device import UmdDevice
+
         self.devices: dict[int, UmdDevice] = {}
         self.reset_lock = threading.Lock()
 

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -1,19 +1,16 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
 import datetime
 import os
 import threading
 import time
 import traceback
-from typing import TYPE_CHECKING, Sequence
+from typing import Sequence
 import tt_umd
 from ttexalens import util
 from ttexalens.exceptions import TimeoutDeviceRegisterError
-
-if TYPE_CHECKING:
-    from ttexalens.umd_api import UmdApi
+from ttexalens.umd_api import UmdApi
 
 
 class UmdDevice:
@@ -67,7 +64,6 @@ class UmdDevice:
         all_cores = soc_descriptor.get_all_cores(
             coord_system=tt_umd.CoordSystem.NOC0
         ) + soc_descriptor.get_all_harvested_cores(coord_system=tt_umd.CoordSystem.NOC0)
-        from ttexalens.umd_api import UmdApi
 
         max_x = max(core.x for core in all_cores) + 1
         max_y = max(core.y for core in all_cores) + 1
@@ -122,8 +118,6 @@ class UmdDevice:
         return self._arch != tt_umd.ARCH.BLACKHOLE and self._is_mmio_capable and not self._is_simulation
 
     def __select_noc_id(self, noc_id: int):
-        from ttexalens.umd_api import UmdApi
-
         UmdApi.select_noc_id(noc_id, self._arch)
 
     def __configure_working_active_eth(self):
@@ -149,6 +143,15 @@ class UmdDevice:
     READ_TIMEOUT = float(os.environ.get("TT_EXALENS_READ_TIMEOUT_MS", 2)) / 1_000  # seconds
     WRITE_TIMEOUT = float(os.environ.get("TT_EXALENS_WRITE_TIMEOUT_MS", 2)) / 1_000  # seconds
     NUM_OF_CONSECUTIVE_TIMEOUTS = int(os.environ.get("TT_EXALENS_NUM_OF_CONSECUTIVE_TIMEOUTS", 5))
+
+    def __read_from_device_reg_no_timeout(
+        self, coord: tt_umd.CoreCoord, address: int, buffer: bytearray | memoryview, dma_threshold: int
+    ) -> None:
+        # Check if we can use DMA read
+        if len(buffer) >= dma_threshold and self.can_use_dma:
+            self.__device.dma_read_from_device(0, coord.x, coord.y, address, buffer)
+        else:
+            self.__device.noc_read(0, coord.x, coord.y, address, buffer)
 
     def __read_from_device_reg(
         self, coord: tt_umd.CoreCoord, address: int, buffer: bytearray | memoryview, dma_threshold: int
@@ -178,6 +181,15 @@ class UmdDevice:
                 except Exception:
                     translated_coord = coord
             raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, len(buffer), True, elapsed_time)
+
+    def __write_to_device_reg_no_timeout(
+        self, coord: tt_umd.CoreCoord, address: int, data: bytes | bytearray | memoryview, dma_threshold: int
+    ):
+        # Check if we can use DMA write
+        if len(data) >= dma_threshold and self.can_use_dma:
+            self.__device.dma_write_to_device(coord.x, coord.y, address, data)
+        else:
+            self.__device.noc_write(coord.x, coord.y, address, data)
 
     def __write_to_device_reg(
         self, coord: tt_umd.CoreCoord, address: int, data: bytes | bytearray | memoryview, dma_threshold: int
@@ -223,13 +235,14 @@ class UmdDevice:
         use_4B_mode: bool,
         dma_threshold: int,
     ) -> None:
+        do_read = self.__read_from_device_reg_no_timeout if use_4B_mode else self.__read_from_device_reg
         # Read first unaligned word
         first_unaligned_index = address % 4
         size = len(buffer)
         offset = 0
         if first_unaligned_index != 0:
             temp = bytearray(4)
-            self.__read_from_device_reg(coord, address - first_unaligned_index, temp, dma_threshold)
+            do_read(coord, address - first_unaligned_index, temp, dma_threshold)
             if first_unaligned_index + size <= 4:
                 buffer[:size] = temp[first_unaligned_index : first_unaligned_index + size]
                 return
@@ -244,7 +257,7 @@ class UmdDevice:
         aligned_size = size - (size % 4)
         block_size = 4 if use_4B_mode and self._is_mmio_capable and not self._is_simulation else aligned_size
         while aligned_size > 0:
-            self.__read_from_device_reg(coord, address, view[offset : offset + block_size], dma_threshold)
+            do_read(coord, address, view[offset : offset + block_size], dma_threshold)
             aligned_size -= block_size
             offset += block_size
             address += block_size
@@ -254,7 +267,7 @@ class UmdDevice:
         last_unaligned_size = size
         if last_unaligned_size != 0:
             temp = bytearray(4)
-            self.__read_from_device_reg(coord, address, temp, dma_threshold)
+            do_read(coord, address, temp, dma_threshold)
             buffer[offset : offset + last_unaligned_size] = temp[:last_unaligned_size]
 
     def __read_from_device_reg_unaligned(
@@ -290,23 +303,25 @@ class UmdDevice:
         dma_threshold: int,
     ):
         size_in_bytes = len(data)
+        do_write = self.__write_to_device_reg_no_timeout if use_4B_mode else self.__write_to_device_reg
+        do_read = self.__read_from_device_reg_no_timeout if use_4B_mode else self.__read_from_device_reg
 
         # Read/Write first unaligned word
         first_unaligned_index = address % 4
         if first_unaligned_index != 0:
             aligned_address = address - first_unaligned_index
             temp = bytearray(4)
-            self.__read_from_device_reg(coord, aligned_address, temp, dma_threshold)
+            do_read(coord, aligned_address, temp, dma_threshold)
             if first_unaligned_index + size_in_bytes <= 4:
                 temp = (
                     temp[0:first_unaligned_index]
                     + data[0:size_in_bytes]
                     + temp[first_unaligned_index + size_in_bytes : 4]
                 )
-                self.__write_to_device_reg(coord, aligned_address, temp, dma_threshold)
+                do_write(coord, aligned_address, temp, dma_threshold)
                 return
             temp = temp[0:first_unaligned_index] + data[0 : 4 - first_unaligned_index]
-            self.__write_to_device_reg(coord, aligned_address, temp, dma_threshold)
+            do_write(coord, aligned_address, temp, dma_threshold)
             data = data[4 - first_unaligned_index :]
             address += 4 - first_unaligned_index
             size_in_bytes -= 4 - first_unaligned_index
@@ -316,7 +331,7 @@ class UmdDevice:
         block_size = 4 if use_4B_mode and self._is_mmio_capable and not self._is_simulation else aligned_size
         offset = 0
         while aligned_size > 0:
-            self.__write_to_device_reg(coord, address, data[offset : offset + block_size], dma_threshold)
+            do_write(coord, address, data[offset : offset + block_size], dma_threshold)
             aligned_size -= block_size
             offset += block_size
             address += block_size
@@ -327,9 +342,9 @@ class UmdDevice:
         last_unaligned_size = size_in_bytes
         if last_unaligned_size != 0:
             temp = bytearray(4)
-            self.__read_from_device_reg(coord, address, temp, dma_threshold)
+            do_read(coord, address, temp, dma_threshold)
             temp[0:last_unaligned_size] = data[0:last_unaligned_size]
-            self.__write_to_device_reg(coord, address, temp, dma_threshold)
+            do_write(coord, address, temp, dma_threshold)
 
     def __write_to_device_reg_unaligned(
         self,

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -235,7 +235,7 @@ class UmdDevice:
         use_4B_mode: bool,
         dma_threshold: int,
     ) -> None:
-        do_read = self.__read_from_device_reg_no_timeout if use_4B_mode else self.__read_from_device_reg
+        do_read = self.__read_from_device_reg_no_timeout if not use_4B_mode else self.__read_from_device_reg
         # Read first unaligned word
         first_unaligned_index = address % 4
         size = len(buffer)
@@ -303,8 +303,8 @@ class UmdDevice:
         dma_threshold: int,
     ):
         size_in_bytes = len(data)
-        do_write = self.__write_to_device_reg_no_timeout if use_4B_mode else self.__write_to_device_reg
-        do_read = self.__read_from_device_reg_no_timeout if use_4B_mode else self.__read_from_device_reg
+        do_write = self.__write_to_device_reg_no_timeout if not use_4B_mode else self.__write_to_device_reg
+        do_read = self.__read_from_device_reg_no_timeout if not use_4B_mode else self.__read_from_device_reg
 
         # Read/Write first unaligned word
         first_unaligned_index = address % 4


### PR DESCRIPTION
- Changed how Pyro5 native objects are exposed. Previously we would create new type for every object. Now we create type for every type and just instantiate for objects.
- Changed how we enumerate GDB server available processes in tests. If `debug_only_with_elfs` is specified, we don't iterate over riscs to look for elfs, but other way around: we iterate over elfs and then check riscs.
- Replacing how we choose NOC ID in `umd_device.py` and `umd_api.py`. It is faster to cache it in Python TLS than to go all the way to C++. Will be changed with next UMD bump (end of next week, or the week after)
- If 4 byte mode is disabled, there is no need to do timeout detection (as timings are wrong).
- Settings code start address in baby risc info is changing configuration register. It is faster to read value (as we can do this over debug registers) and then to update only if it has changed.
- Don't go over all sections in elf loader. Use `get_section_by_name()` instead.
- Caching `noc_block` property in `OnChipCoordinate`.
- Updating GDB memory access tests to use `skip_detach` and `debug_only_with_elfs` as they are not testing general GDB server behavior.
- Removing `device()` property in `OnChipCoordinate` as it is being called 900K times in tt-triage on T3K. It was only forwarding to field, so upgrading field to be public.