### PR TITLE
Fix ROUTER_ONLY base address for BH

### DIFF
--- a/ttexalens/hardware/blackhole/router_only_block.py
+++ b/ttexalens/hardware/blackhole/router_only_block.py
@@ -4,16 +4,28 @@
 
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.hardware.blackhole.noc_block import BlackholeNocBlock
+from ttexalens.hardware.blackhole.niu_registers import get_niu_register_store_initialization
 from ttexalens.hardware.device_address import DeviceAddress
 from ttexalens.hardware.memory_block import MemoryBlock
 from ttexalens.memory_map import MemoryMap, MemoryMapBlockInfo
+from ttexalens.register_store import RegisterStore
+
+_register_store_noc0_initialization = get_niu_register_store_initialization(
+    DeviceAddress(noc_address=0xFF000000, noc_id=0)
+)
+_register_store_noc1_initialization = get_niu_register_store_initialization(
+    DeviceAddress(noc_address=0xFF000000, noc_id=1)
+)
 
 
 class BlackholeRouterOnlyBlock(BlackholeNocBlock):
     def __init__(self, location: OnChipCoordinate):
         super().__init__(location, block_type="router_only")
 
-        self.noc_regs = MemoryBlock(size=0x10000, address=DeviceAddress(noc_address=0xFFFFFFFF_FF000000))
+        self.register_store_noc0 = RegisterStore(_register_store_noc0_initialization, self.location)
+        self.register_store_noc1 = RegisterStore(_register_store_noc1_initialization, self.location)
+
+        self.noc_regs = MemoryBlock(size=0x10000, address=DeviceAddress(noc_address=0xFF000000))
         self.noc_memory_map = MemoryMap.get_memory_map_from_cache(
             BlackholeRouterOnlyBlock,
             "noc_memory_map",


### PR DESCRIPTION
This pull request refactors the initialization of NOC register stores in the `BlackholeRouterOnlyBlock` class to use the correct address. The main change is the introduction of separate `RegisterStore` instances for NOC0 and NOC1, initialized using a helper function and specific device addresses.

Key changes:

**Register Store Initialization:**

* Added imports for `get_niu_register_store_initialization` and `RegisterStore` to support new initialization logic.
* Defined `_register_store_noc0_initialization` and `_register_store_noc1_initialization` using `get_niu_register_store_initialization` with explicit `DeviceAddress` values for NOC0 and NOC1.
* In the `BlackholeRouterOnlyBlock` constructor, created `register_store_noc0` and `register_store_noc1` as `RegisterStore` instances, initialized with the corresponding values and the block's location.
* Updated the address for `noc_regs` to use `0xFF000000` instead of the previous 64-bit address, aligning with the new initialization approach.