### PR TITLE
Bumping mypy to 2.1.0

### DIFF
--- a/ttexalens/dev-requirements.txt
+++ b/ttexalens/dev-requirements.txt
@@ -1,4 +1,4 @@
-mypy>=1.16.0
+mypy==2.1.0
 basedpyright
 diagrams
 pre-commit


### PR DESCRIPTION
Bumping `mypy` version to `2.1.0` to match one in `tt-triage`.