### PR TITLE
Fixing overlapping intervals in quasar memory maps

### DIFF
--- a/ttexalens/hardware/quasar/functional_neo_block.py
+++ b/ttexalens/hardware/quasar/functional_neo_block.py
@@ -192,10 +192,10 @@ class QuasarFunctionalNeoBlock:
         )
 
         self.noc_memory_list: list[MemoryMapBlockInfo] = [
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc0.data_private_memory", self.trisc0.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc1.data_private_memory", self.trisc1.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc2.data_private_memory", self.trisc2.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc3.data_private_memory", self.trisc3.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc0.data_private_memory", self.trisc0.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[union-attr]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc1.data_private_memory", self.trisc1.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[union-attr]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc2.data_private_memory", self.trisc2.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[union-attr]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc3.data_private_memory", self.trisc3.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[union-attr]
             MemoryMapBlockInfo(f"neo{neo_id}.debug_regs", self.debug_regs.just_noc_address(), safe_to_write=True),
             MemoryMapBlockInfo(f"neo{neo_id}.pic_regs", self.pic_regs.just_noc_address()),
         ]

--- a/ttexalens/hardware/quasar/functional_neo_block.py
+++ b/ttexalens/hardware/quasar/functional_neo_block.py
@@ -192,12 +192,12 @@ class QuasarFunctionalNeoBlock:
         )
 
         self.noc_memory_list: list[MemoryMapBlockInfo] = [
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc0.data_private_memory", self.trisc0.data_private_memory, safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc1.data_private_memory", self.trisc1.data_private_memory, safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc2.data_private_memory", self.trisc2.data_private_memory, safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.trisc3.data_private_memory", self.trisc3.data_private_memory, safe_to_write=True),  # type: ignore[arg-type]
-            MemoryMapBlockInfo(f"neo{neo_id}.debug_regs", self.debug_regs, safe_to_write=True),
-            MemoryMapBlockInfo(f"neo{neo_id}.pic_regs", self.pic_regs),
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc0.data_private_memory", self.trisc0.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc1.data_private_memory", self.trisc1.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc2.data_private_memory", self.trisc2.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
+            MemoryMapBlockInfo(f"neo{neo_id}.trisc3.data_private_memory", self.trisc3.data_private_memory.just_noc_address(), safe_to_write=True),  # type: ignore[arg-type]
+            MemoryMapBlockInfo(f"neo{neo_id}.debug_regs", self.debug_regs.just_noc_address(), safe_to_write=True),
+            MemoryMapBlockInfo(f"neo{neo_id}.pic_regs", self.pic_regs.just_noc_address()),
         ]
 
     @cached_property


### PR DESCRIPTION
Recently we had a commit disallowing overlapping intervals in memory maps. This discovered problem with memory maps in quasar functional worker. We defined maps from perspective of neo block rather than NOC. This PR fixes that.