### PR TITLE
Reenabling few NOC1 tests

### DIFF
--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -835,10 +835,6 @@ class TestSafeAccess(unittest.TestCase):
                 block = device.get_block(location)
                 memory_map = block.noc_memory_map
 
-                if device.is_wormhole() and block.block_type == "dram" and self.context.use_noc1:
-                    # Skip DRAM tests on wormhole devices when using NOC1 due to bug #tt-umd:1823
-                    continue
-
                 # Get all blocks with NOC addresses
                 blocks_with_noc = [
                     (name, info)

--- a/test/ttexalens/unit_tests/test_noc.py
+++ b/test/ttexalens/unit_tests/test_noc.py
@@ -57,9 +57,6 @@ class TestNOCLocations(unittest.TestCase):
 
     def test_noc_locations(self):
         for device in self.context.devices.values():
-            # TODO (944): Remove this check once UMD bug is fixed.
-            if device.is_blackhole():
-                continue
             for block_type in device.block_types:
                 for block in device.get_blocks(block_type):
                     noc0_register_store = block.get_register_store(noc_id=0)

--- a/ttexalens/requirements.txt
+++ b/ttexalens/requirements.txt
@@ -1,4 +1,4 @@
-tt-umd==0.9.6
+tt-umd==0.9.7
 docopt==0.6.2
 fastnumbers==5.1.1
 prompt-toolkit==3.0.52


### PR DESCRIPTION
Removed skip of dram blocks on wormhole when using noc1 in `test_comprehensive_block_access`. It was failing due to https://github.com/tenstorrent/tt-umd/issues/1823 which is fixed allowing this test to pass. Ran 1000 times with 0 failures.

Also reenabled `TestNOCLocations` on blackhole. Closes #944.