### PR TITLE
Avoid reading internal pipeline state in LLK math_reconfig.py test

### DIFF
--- a/ttexalens/hardware/blackhole/functional_worker_debug_bus_signals.py
+++ b/ttexalens/hardware/blackhole/functional_worker_debug_bus_signals.py
@@ -2125,6 +2125,6 @@ group_map: dict[str, tuple[int, int]] = {
 }
 
 tensix_debug_bus_description = TensixDebugBusDescription(
-    register_window_counter_groups=[group_name for group_name in group_map.keys() if group_name.startswith("rwc")],
-    address_counter_groups=[group_name for group_name in group_map.keys() if group_name.startswith("adc")],
+    register_window_counter_groups=["rwc_coordinates_a", "rwc_coordinates_b", "rwc_fidelity_phase"],
+    address_counter_groups=[group_name for group_name in group_map.keys() if group_name.startswith(("adcs0", "adcs2"))],
 )

--- a/ttexalens/hardware/wormhole/functional_worker_debug_bus_signals.py
+++ b/ttexalens/hardware/wormhole/functional_worker_debug_bus_signals.py
@@ -930,6 +930,6 @@ group_map = {
 }
 
 tensix_debug_bus_description = TensixDebugBusDescription(
-    register_window_counter_groups=[group_name for group_name in group_map if group_name.startswith("rwc")],
-    address_counter_groups=[group_name for group_name in group_map if group_name.startswith("adc")],
+    register_window_counter_groups=["rwc_coordinates_a", "rwc_coordinates_b", "rwc_fidelity_phase"],
+    address_counter_groups=[group_name for group_name in group_map if group_name.startswith(("adcs0", "adcs2"))],
 )


### PR DESCRIPTION
This LLK test reads back debug daisychain state before and after to verify that it is undisturbed. Some of the (daisy_sel, signal_sel) values it is reading are real (persistent) state of the ADCs and RWCs; others are internal, transient, undocumented RTL pipeline signals that do not reflect real state, and checking their equivalence before/after is not meaningful. Limit the reads to only the persistent ADC and RWC (including fidelity_phase) state.

Aside from being a general code hygiene improvement for silicon, this change also fixes these ~2400 tests on ttsim, which cannot return meaningful values for these daisy_sel/signal_sel pairs.