### PR TITLE
Fix get_global/get_constant picking a shadowing type over the variable

### DIFF
--- a/riscv-src/globals_test.cc
+++ b/riscv-src/globals_test.cc
@@ -68,6 +68,10 @@ enum class EnumClass : uint32_t { VALUE_A = 0, VALUE_B = 1, VALUE_C = 2, VALUE_D
 
 enum EnumType : uint32_t { TYPE_X = 10, TYPE_Y = 20, TYPE_Z = 30 };
 
+enum shadowed_const : uint8_t { SHADOWED_A = 0, SHADOWED_B = 1, SHADOWED_C = 2 };
+[[gnu::used]] volatile enum shadowed_const g_shadowed_enum_user = SHADOWED_B;
+constexpr uint8_t shadowed_const = 42;
+
 struct InnerStruct {
     uint16_t x;
     uint16_t y;

--- a/riscv-src/globals_test.cc
+++ b/riscv-src/globals_test.cc
@@ -69,7 +69,7 @@ enum class EnumClass : uint32_t { VALUE_A = 0, VALUE_B = 1, VALUE_C = 2, VALUE_D
 enum EnumType : uint32_t { TYPE_X = 10, TYPE_Y = 20, TYPE_Z = 30 };
 
 enum shadowed_const : uint8_t { SHADOWED_A = 0, SHADOWED_B = 1, SHADOWED_C = 2 };
-[[gnu::used]] volatile enum shadowed_const g_shadowed_enum_user = SHADOWED_B;
+volatile enum shadowed_const g_shadowed_enum_user = SHADOWED_B;
 constexpr uint8_t shadowed_const = 42;
 
 struct InnerStruct {

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -10,7 +10,7 @@ from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from test.ttexalens.unit_tests.test_base import init_cached_test_context
 from ttexalens import OnChipCoordinate
 from ttexalens.context import Context
-from ttexalens.elf import DwarfDieTag, ElfFile, ElfVariable
+from ttexalens.elf import ElfFile, ElfVariable
 from ttexalens.exceptions import RiscHaltError
 from ttexalens.memory_access import MemoryAccess, create_memory_access
 from ttexalens.exceptions import RestrictedMemoryAccessError
@@ -392,10 +392,7 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(42, self.parsed_elf.get_global("shadowed_const", TestDebugSymbols.mem_access).read_value())
         self.assertEqual(42, self.parsed_elf.get_constant("shadowed_const"))
 
-        die = self.parsed_elf.find_die_by_name("shadowed_const")
-        assert die is not None
-        self.assertEqual(DwarfDieTag.enumeration_type, die.tag)
-
+        # Enumerator lookup by qualified name keeps working
         self.assertEqual(1, self.parsed_elf.get_enum_value("shadowed_const::SHADOWED_B"))
 
     def test_elf_variable_array_iteration(self):

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -10,7 +10,7 @@ from test.ttexalens.unit_tests.core_simulator import RiscvCoreSimulator
 from test.ttexalens.unit_tests.test_base import init_cached_test_context
 from ttexalens import OnChipCoordinate
 from ttexalens.context import Context
-from ttexalens.elf import ElfFile, ElfVariable
+from ttexalens.elf import DwarfDieTag, ElfFile, ElfVariable
 from ttexalens.exceptions import RiscHaltError
 from ttexalens.memory_access import MemoryAccess, create_memory_access
 from ttexalens.exceptions import RestrictedMemoryAccessError
@@ -385,6 +385,18 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(-12345, self.parsed_elf.get_constant("c_int16_t"))
         self.assertEqual(-1234567, self.parsed_elf.get_constant("c_int32_t"))
         self.assertEqual(-1234567890123456789, self.parsed_elf.get_constant("c_int64_t"))
+
+    def test_elf_enum_variable_name_collision(self):
+        # `enum shadowed_const` and `constexpr uint8_t shadowed_const` share a
+        # name (mirrors dev_msgs.h's `enum noc_mode` shadowing `noc_mode`).
+        self.assertEqual(42, self.parsed_elf.get_global("shadowed_const", TestDebugSymbols.mem_access).read_value())
+        self.assertEqual(42, self.parsed_elf.get_constant("shadowed_const"))
+
+        die = self.parsed_elf.find_die_by_name("shadowed_const")
+        assert die is not None
+        self.assertEqual(DwarfDieTag.enumeration_type, die.tag)
+
+        self.assertEqual(1, self.parsed_elf.get_enum_value("shadowed_const::SHADOWED_B"))
 
     def test_elf_variable_array_iteration(self):
         variable_die = self.parsed_elf.find_die_by_name("g_global_struct")

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -942,9 +942,11 @@ std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) co
     }
 
     // Compile-time constant (DW_AT_const_value).
-    if (auto bytes = serialize_constant_value(get_constant_value(), resolved->get_size().value_or(4))) {
-        auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
-        return ElfVariable(resolved, 0, std::move(cache));
+    if (auto size = resolved->get_size()) {
+        if (auto bytes = serialize_constant_value(get_constant_value(), *size)) {
+            auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
+            return ElfVariable(resolved, 0, std::move(cache));
+        }
     }
 
     // Static-storage variable (globals, file/function statics):
@@ -965,7 +967,11 @@ std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) co
     // Literal value (DW_OP_stack_value / register-direct / composite via
     // DW_OP_piece): synthesise a backing buffer holding the materialised
     // bytes and hand back a ElfVariable that reads from it.
-    const uint64_t size = resolved->get_size().value_or(4);
+    auto size_opt = resolved->get_size();
+    if (!size_opt) {
+        return std::nullopt;
+    }
+    const uint64_t size = *size_opt;
     std::vector<std::byte> bytes(size);
     if (!location->raw_bytes.empty()) {
         // Composite location already assembled the bytes in little-endian

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -641,9 +641,10 @@ const std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>>& DwarfDie::get_address_rang
     return ranges;
 }
 
-DwarfDiePtr DwarfDie::find_child_by_name(std::string_view target) const {
+DwarfDiePtr DwarfDie::find_child_by_name(std::string_view target,
+                                        const std::function<bool(const DwarfDiePtr&)>& filter) const {
     for (auto child = get_first_child(); child; child = child->get_next_sibling()) {
-        if (child->get_name() == target) {
+        if (child->get_name() == target && (!filter || filter(child))) {
             return child;
         }
     }
@@ -811,12 +812,9 @@ static std::optional<uint64_t> get_address_recursed(const DwarfDie& die, bool al
             return std::nullopt;
         }
         if (const auto* cv = die.get_attribute(DwarfAttributeTag::const_value)) {
-            // A const_value is only an *address* for the hard-coded-pointer
-            // pattern (`T* const g = (T*)0xADDR;`), where the constant IS the
-            // target address. For any non-pointer variable the const_value is
-            // the VALUE, not an address; treating it as one reads garbage from
-            // device memory (e.g. a folded `constexpr uint8_t x = 7` would read
-            // address 7). Such values are served via serialize_constant_value.
+            // A const_value is a target address only for hard-coded pointers
+            // (`T* const g = (T*)0xADDR;`). For a scalar it's the value, not an
+            // address, so don't hand it back as one.
             auto resolved = die.get_resolved_type();
             if (resolved && resolved->get_tag() == DwarfDieTag::pointer_type) {
                 return attr_as_uint(cv);

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -908,7 +908,7 @@ std::optional<DwarfFileLine> DwarfDie::get_call_file_info() const {
                              DwarfAttributeTag::call_column);
 }
 
-std::optional<std::vector<std::byte>> serialize_constant_value(const DwarfDie::ConstantValue& value, uint64_t size) {
+std::optional<std::vector<std::byte>> DwarfDie::serialize_constant_value(const ConstantValue& value, uint64_t size) {
     uint64_t uint_value = 0;
     if (const auto* b = std::get_if<bool>(&value)) {
         uint_value = *b ? 1 : 0;

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -811,7 +811,17 @@ static std::optional<uint64_t> get_address_recursed(const DwarfDie& die, bool al
             return std::nullopt;
         }
         if (const auto* cv = die.get_attribute(DwarfAttributeTag::const_value)) {
-            return attr_as_uint(cv);
+            // A const_value is only an *address* for the hard-coded-pointer
+            // pattern (`T* const g = (T*)0xADDR;`), where the constant IS the
+            // target address. For any non-pointer variable the const_value is
+            // the VALUE, not an address; treating it as one reads garbage from
+            // device memory (e.g. a folded `constexpr uint8_t x = 7` would read
+            // address 7). Such values are served via serialize_constant_value.
+            auto resolved = die.get_resolved_type();
+            if (resolved && resolved->get_tag() == DwarfDieTag::pointer_type) {
+                return attr_as_uint(cv);
+            }
+            return std::nullopt;
         }
         // .symtab address fallback runs in the public wrapper below — keeps
         // this free function from needing private access to DwarfDie.
@@ -900,6 +910,26 @@ std::optional<DwarfFileLine> DwarfDie::get_call_file_info() const {
                              DwarfAttributeTag::call_column);
 }
 
+std::optional<std::vector<std::byte>> serialize_constant_value(const DwarfDie::ConstantValue& value, uint64_t size) {
+    uint64_t uint_value = 0;
+    if (const auto* b = std::get_if<bool>(&value)) {
+        uint_value = *b ? 1 : 0;
+    } else if (const auto* s = std::get_if<int64_t>(&value)) {
+        uint_value = static_cast<uint64_t>(*s);
+    } else if (const auto* u = std::get_if<uint64_t>(&value)) {
+        uint_value = *u;
+    } else if (const auto* f = std::get_if<float>(&value)) {
+        uint_value = std::bit_cast<uint32_t>(*f);
+    } else if (const auto* d = std::get_if<double>(&value)) {
+        uint_value = std::bit_cast<uint64_t>(*d);
+    } else {
+        return std::nullopt;  // std::monostate — no constant value
+    }
+    std::vector<std::byte> bytes(size);
+    std::memcpy(bytes.data(), &uint_value, std::min(size, static_cast<uint64_t>(sizeof(uint_value))));
+    return bytes;
+}
+
 std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) const {
     // Reading value only makes sense for variables and parameters.
     const auto tag = get_tag();
@@ -914,26 +944,8 @@ std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) co
     }
 
     // Compile-time constant (DW_AT_const_value).
-    auto const_value = get_constant_value();
-    if (!std::holds_alternative<std::monostate>(const_value)) {
-        const uint64_t size = resolved->get_size().value_or(4);
-        uint64_t uint_value = 0;
-        if (const auto* b = std::get_if<bool>(&const_value)) {
-            uint_value = *b ? 1 : 0;
-        } else if (const auto* s = std::get_if<int64_t>(&const_value)) {
-            uint_value = static_cast<uint64_t>(*s);
-        } else if (const auto* u = std::get_if<uint64_t>(&const_value)) {
-            uint_value = *u;
-        } else if (const auto* f = std::get_if<float>(&const_value)) {
-            uint_value = std::bit_cast<uint32_t>(*f);
-        } else if (const auto* d = std::get_if<double>(&const_value)) {
-            uint_value = std::bit_cast<uint64_t>(*d);
-        } else {
-            return std::nullopt;
-        }
-        std::vector<std::byte> bytes(size);
-        std::memcpy(bytes.data(), &uint_value, std::min(size, static_cast<uint64_t>(sizeof(uint_value))));
-        auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(bytes), NoMemoryAccess::instance());
+    if (auto bytes = serialize_constant_value(get_constant_value(), resolved->get_size().value_or(4))) {
+        auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
         return ElfVariable(resolved, 0, std::move(cache));
     }
 

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -642,7 +642,7 @@ const std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>>& DwarfDie::get_address_rang
 }
 
 DwarfDiePtr DwarfDie::find_child_by_name(std::string_view target,
-                                        const std::function<bool(const DwarfDiePtr&)>& filter) const {
+                                         const std::function<bool(const DwarfDiePtr&)>& filter) const {
     for (auto child = get_first_child(); child; child = child->get_next_sibling()) {
         if (child->get_name() == target && (!filter || filter(child))) {
             return child;

--- a/ttexalens/cpp/elf/dwarf_die.hpp
+++ b/ttexalens/cpp/elf/dwarf_die.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -294,7 +295,9 @@ class DwarfDie : public std::enable_shared_from_this<DwarfDie> {
 
     // Walks the direct children of this DIE and returns the first whose
     // DW_AT_name matches `name`. nullptr on miss.
-    DwarfDiePtr find_child_by_name(std::string_view name) const;
+    // When `filter` is set, returns the first child that also satisfies it.
+    DwarfDiePtr find_child_by_name(std::string_view name,
+                                   const std::function<bool(const DwarfDiePtr&)>& filter = {}) const;
 
     // Resolves a DIE-valued attribute (e.g. DW_AT_abstract_origin,
     // DW_AT_specification) to the referenced DIE. nullptr when the attribute

--- a/ttexalens/cpp/elf/dwarf_die.hpp
+++ b/ttexalens/cpp/elf/dwarf_die.hpp
@@ -240,6 +240,11 @@ class DwarfDie : public std::enable_shared_from_this<DwarfDie> {
     using ConstantValue = std::variant<std::monostate, bool, int64_t, uint64_t, float, double>;
     ConstantValue get_constant_value() const;
 
+    // Serializes a DW_AT_const_value into `size` little-endian bytes suitable
+    // for backing a synthesized ElfVariable. Returns std::nullopt for
+    // std::monostate. Bools become 0/1; floats/doubles keep their IEEE-754 bits.
+    static std::optional<std::vector<std::byte>> serialize_constant_value(const ConstantValue& value, uint64_t size);
+
     // Peels typedef / const_type / volatile_type wrappers off a type, or
     // follows DW_AT_type from a non-type DIE (variable, member, …) to its
     // type and then peels. Also follows DW_AT_specification /
@@ -370,11 +375,5 @@ class DwarfDie : public std::enable_shared_from_this<DwarfDie> {
     mutable std::optional<std::vector<std::pair<Dwarf_Addr, Dwarf_Addr>>> address_ranges;
     mutable std::optional<std::weak_ptr<DwarfDie>> parent;
 };
-
-// Serializes a DW_AT_const_value into `size` little-endian bytes suitable for
-// backing a synthesized ElfVariable (see ElfVariable::from_constant). Returns
-// std::nullopt for std::monostate. Bools become 0/1; floats/doubles keep their
-// IEEE-754 bit pattern.
-std::optional<std::vector<std::byte>> serialize_constant_value(const DwarfDie::ConstantValue& value, uint64_t size);
 
 }  // namespace ttexalens::native_elf

--- a/ttexalens/cpp/elf/dwarf_die.hpp
+++ b/ttexalens/cpp/elf/dwarf_die.hpp
@@ -368,4 +368,10 @@ class DwarfDie : public std::enable_shared_from_this<DwarfDie> {
     mutable std::optional<std::weak_ptr<DwarfDie>> parent;
 };
 
+// Serializes a DW_AT_const_value into `size` little-endian bytes suitable for
+// backing a synthesized ElfVariable (see ElfVariable::from_constant). Returns
+// std::nullopt for std::monostate. Bools become 0/1; floats/doubles keep their
+// IEEE-754 bit pattern.
+std::optional<std::vector<std::byte>> serialize_constant_value(const DwarfDie::ConstantValue& value, uint64_t size);
+
 }  // namespace ttexalens::native_elf

--- a/ttexalens/cpp/elf/dwarf_info.cpp
+++ b/ttexalens/cpp/elf/dwarf_info.cpp
@@ -20,6 +20,7 @@
 #include "dwarf_cu.hpp"
 #include "dwarf_die.hpp"
 #include "dwarf_frame.hpp"
+#include "memory_access.hpp"
 #include "private/dwarf_info_impl.hpp"
 
 namespace ttexalens::native_elf {
@@ -129,7 +130,40 @@ DwarfDiePtr DwarfInfo::find_function_by_address(uint64_t address) const {
     return best;
 }
 
+namespace {
+
+// Finds `parent`'s child named `name`. When `want_variable` is set, a
+// DW_TAG_variable is preferred over a same-named non-variable (e.g. a
+// `constexpr uint8_t noc_mode` over an `enum noc_mode` that precedes it),
+// falling back to the first name-match if there is no variable.
+DwarfDiePtr find_named_child(const DwarfDiePtr& parent, std::string_view name, bool want_variable) {
+    if (!want_variable) {
+        return parent->find_child_by_name(name);
+    }
+    DwarfDiePtr fallback;
+    for (auto child = parent->get_first_child(); child; child = child->get_next_sibling()) {
+        if (child->get_name() != name) {
+            continue;
+        }
+        if (child->get_tag() == DwarfDieTag::variable) {
+            return child;
+        }
+        if (!fallback) {  // copy, not move: `child` still advances the loop
+            fallback = child;
+        }
+    }
+    return fallback;
+}
+
+}  // namespace
+
 DwarfDiePtr DwarfInfo::get_die_by_name(std::string_view name) const {
+    return resolve_die_by_name(name, DieNameFilter::Any);
+}
+
+DwarfDiePtr DwarfInfo::resolve_die_by_name(std::string_view name, DieNameFilter filter) const {
+    const bool prefer_variable = filter == DieNameFilter::Variable;
+
     // Split "Foo::Bar::baz" into ["Foo", "Bar", "baz"]. An empty input yields
     // one empty part and ends up finding nothing.
     std::vector<std::string_view> parts;
@@ -145,14 +179,16 @@ DwarfDiePtr DwarfInfo::get_die_by_name(std::string_view name) const {
     }
 
     DwarfDiePtr declaration_die;  // fallback if all matches are declarations
+    DwarfDiePtr non_variable_die;  // fallback if nothing resolves to a variable
 
     for (auto& cu : impl->get_cus()) {
         // First part is matched against the CU's root DIE; subsequent parts
-        // chain off the previous match.
-        auto current = cu.get_die()->find_child_by_name(parts[0]);
+        // chain off the previous match. Only the final part prefers a variable.
+        const auto want_variable = [&](size_t index) { return prefer_variable && index + 1 == parts.size(); };
+        auto current = find_named_child(cu.get_die(), parts[0], want_variable(0));
         bool matched_all = static_cast<bool>(current);
         for (size_t i = 1; matched_all && i < parts.size(); ++i) {
-            auto next = current->find_child_by_name(parts[i]);
+            auto next = find_named_child(current, parts[i], want_variable(i));
             if (!next) {
                 matched_all = false;
                 break;
@@ -185,9 +221,19 @@ DwarfDiePtr DwarfInfo::get_die_by_name(std::string_view name) const {
             continue;
         }
 
+        if (prefer_variable && current->get_tag() != DwarfDieTag::variable) {
+            if (!non_variable_die) {
+                non_variable_die = std::move(current);
+            }
+            continue;
+        }
+
         return current;
     }
 
+    if (non_variable_die) {
+        return non_variable_die;
+    }
     return declaration_die;
 }
 
@@ -227,7 +273,7 @@ std::optional<uint64_t> DwarfInfo::get_enum_value(std::string_view name) const {
 }
 
 DwarfDie::ConstantValue DwarfInfo::get_constant(std::string_view name) const {
-    auto die = get_die_by_name(name);
+    auto die = resolve_die_by_name(name, DieNameFilter::Variable);
     if (!die) {
         throw SymbolNotFoundException(std::string(name));
     }
@@ -243,30 +289,44 @@ DwarfDie::ConstantValue DwarfInfo::get_constant(std::string_view name) const {
 }
 
 ElfVariable DwarfInfo::get_global(std::string_view name, std::shared_ptr<MemoryAccess> memory_access) const {
-    auto die = get_die_by_name(name);
+    auto die = resolve_die_by_name(name, DieNameFilter::Variable);
     if (!die) {
         throw SymbolNotFoundException(std::string(name));
     }
-    auto address = die->get_address();
-    if (!address) {
-        throw SymbolNotFoundException(std::string(name));
+    // If the name only resolves to a type (no variable exists), it's not a
+    // readable global — say so instead of reading a type DIE as memory.
+    if (die->is_type()) {
+        throw SymbolNotFoundException(std::string(name) + " (resolves to a type, not a variable)");
     }
     auto resolved_type = die->get_resolved_type();
 
-    // Hard-coded-pointer pattern: `T* const g = (T*)0xADDR;` — the DIE's
-    // resolved type is pointer_type AND it carries a constant value. Treat
-    // the constant as the target address and return a variable of the
-    // pointee type.
-    if (resolved_type && resolved_type->get_tag() == DwarfDieTag::pointer_type) {
-        auto cv = die->get_constant_value();
-        if (!std::holds_alternative<std::monostate>(cv)) {
-            auto pointee = resolved_type->get_dereference_type();
-            if (pointee) {
-                return ElfVariable(std::move(pointee), *address, std::move(memory_access));
+    if (auto address = die->get_address()) {
+        // Hard-coded-pointer pattern: `T* const g = (T*)0xADDR;` — the DIE's
+        // resolved type is pointer_type AND it carries a constant value (which
+        // get_address() surfaces as the target address). Return a variable of
+        // the pointee type.
+        if (resolved_type && resolved_type->get_tag() == DwarfDieTag::pointer_type) {
+            auto cv = die->get_constant_value();
+            if (!std::holds_alternative<std::monostate>(cv)) {
+                auto pointee = resolved_type->get_dereference_type();
+                if (pointee) {
+                    return ElfVariable(std::move(pointee), *address, std::move(memory_access));
+                }
             }
         }
+        return ElfVariable(std::move(resolved_type), *address, std::move(memory_access));
     }
-    return ElfVariable(std::move(resolved_type), *address, std::move(memory_access));
+
+    // No runtime storage (folded constexpr): mask the difference by serving
+    // the compile-time DW_AT_const_value from a synthesized buffer. Read-only
+    // (writes raise via NoMemoryAccess), since there is nothing on device.
+    if (resolved_type) {
+        if (auto bytes = serialize_constant_value(die->get_constant_value(), resolved_type->get_size().value_or(4))) {
+            auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
+            return ElfVariable(std::move(resolved_type), 0, std::move(cache));
+        }
+    }
+    throw SymbolNotFoundException(std::string(name));
 }
 
 ElfVariable DwarfInfo::read_global(std::string_view name, std::shared_ptr<MemoryAccess> memory_access) const {

--- a/ttexalens/cpp/elf/dwarf_info.cpp
+++ b/ttexalens/cpp/elf/dwarf_info.cpp
@@ -130,40 +130,8 @@ DwarfDiePtr DwarfInfo::find_function_by_address(uint64_t address) const {
     return best;
 }
 
-namespace {
-
-// Finds `parent`'s child named `name`. When `want_variable` is set, a
-// DW_TAG_variable is preferred over a same-named non-variable (e.g. a
-// `constexpr uint8_t noc_mode` over an `enum noc_mode` that precedes it),
-// falling back to the first name-match if there is no variable.
-DwarfDiePtr find_named_child(const DwarfDiePtr& parent, std::string_view name, bool want_variable) {
-    if (!want_variable) {
-        return parent->find_child_by_name(name);
-    }
-    DwarfDiePtr fallback;
-    for (auto child = parent->get_first_child(); child; child = child->get_next_sibling()) {
-        if (child->get_name() != name) {
-            continue;
-        }
-        if (child->get_tag() == DwarfDieTag::variable) {
-            return child;
-        }
-        if (!fallback) {  // copy, not move: `child` still advances the loop
-            fallback = child;
-        }
-    }
-    return fallback;
-}
-
-}  // namespace
-
-DwarfDiePtr DwarfInfo::get_die_by_name(std::string_view name) const {
-    return resolve_die_by_name(name, DieNameFilter::Any);
-}
-
-DwarfDiePtr DwarfInfo::resolve_die_by_name(std::string_view name, DieNameFilter filter) const {
-    const bool prefer_variable = filter == DieNameFilter::Variable;
-
+DwarfDiePtr DwarfInfo::get_die_by_name(std::string_view name,
+                                       const std::function<bool(const DwarfDiePtr&)>& filter) const {
     // Split "Foo::Bar::baz" into ["Foo", "Bar", "baz"]. An empty input yields
     // one empty part and ends up finding nothing.
     std::vector<std::string_view> parts;
@@ -178,17 +146,22 @@ DwarfDiePtr DwarfInfo::resolve_die_by_name(std::string_view name, DieNameFilter 
         start = pos + 2;
     }
 
-    DwarfDiePtr declaration_die;   // fallback if all matches are declarations
-    DwarfDiePtr non_variable_die;  // fallback if nothing resolves to a variable
+    // The filter constrains only the final component; intermediate scopes are
+    // matched by name alone.
+    const std::function<bool(const DwarfDiePtr&)> no_filter;
+    const auto& filter_for = [&](size_t index) -> const std::function<bool(const DwarfDiePtr&)>& {
+        return index + 1 == parts.size() ? filter : no_filter;
+    };
+
+    DwarfDiePtr declaration_die;  // fallback if all matches are declarations
 
     for (auto& cu : impl->get_cus()) {
         // First part is matched against the CU's root DIE; subsequent parts
-        // chain off the previous match. Only the final part prefers a variable.
-        const auto want_variable = [&](size_t index) { return prefer_variable && index + 1 == parts.size(); };
-        auto current = find_named_child(cu.get_die(), parts[0], want_variable(0));
+        // chain off the previous match.
+        auto current = cu.get_die()->find_child_by_name(parts[0], filter_for(0));
         bool matched_all = static_cast<bool>(current);
         for (size_t i = 1; matched_all && i < parts.size(); ++i) {
-            auto next = find_named_child(current, parts[i], want_variable(i));
+            auto next = current->find_child_by_name(parts[i], filter_for(i));
             if (!next) {
                 matched_all = false;
                 break;
@@ -221,19 +194,9 @@ DwarfDiePtr DwarfInfo::resolve_die_by_name(std::string_view name, DieNameFilter 
             continue;
         }
 
-        if (prefer_variable && current->get_tag() != DwarfDieTag::variable) {
-            if (!non_variable_die) {
-                non_variable_die = std::move(current);
-            }
-            continue;
-        }
-
         return current;
     }
 
-    if (non_variable_die) {
-        return non_variable_die;
-    }
     return declaration_die;
 }
 
@@ -273,7 +236,7 @@ std::optional<uint64_t> DwarfInfo::get_enum_value(std::string_view name) const {
 }
 
 DwarfDie::ConstantValue DwarfInfo::get_constant(std::string_view name) const {
-    auto die = resolve_die_by_name(name, DieNameFilter::Variable);
+    auto die = get_die_by_name(name, [](const DwarfDiePtr& d) { return d->get_tag() == DwarfDieTag::variable; });
     if (!die) {
         throw SymbolNotFoundException(std::string(name));
     }
@@ -289,14 +252,12 @@ DwarfDie::ConstantValue DwarfInfo::get_constant(std::string_view name) const {
 }
 
 ElfVariable DwarfInfo::get_global(std::string_view name, std::shared_ptr<MemoryAccess> memory_access) const {
-    auto die = resolve_die_by_name(name, DieNameFilter::Variable);
+    auto die = get_die_by_name(name, [](const DwarfDiePtr& d) { return d->get_tag() == DwarfDieTag::variable; });
     if (!die) {
+        if (auto other = get_die_by_name(name); other && other->is_type()) {
+            throw SymbolNotFoundException(std::string(name) + " (resolves to a type, not a variable)");
+        }
         throw SymbolNotFoundException(std::string(name));
-    }
-    // If the name only resolves to a type (no variable exists), it's not a
-    // readable global — say so instead of reading a type DIE as memory.
-    if (die->is_type()) {
-        throw SymbolNotFoundException(std::string(name) + " (resolves to a type, not a variable)");
     }
     auto resolved_type = die->get_resolved_type();
 
@@ -317,13 +278,14 @@ ElfVariable DwarfInfo::get_global(std::string_view name, std::shared_ptr<MemoryA
         return ElfVariable(std::move(resolved_type), *address, std::move(memory_access));
     }
 
-    // No runtime storage (folded constexpr): mask the difference by serving
-    // the compile-time DW_AT_const_value from a synthesized buffer. Read-only
-    // (writes raise via NoMemoryAccess), since there is nothing on device.
+    // No runtime storage (folded constexpr): serve the compile-time value from a
+    // synthesized read-only buffer (writes raise via NoMemoryAccess).
     if (resolved_type) {
-        if (auto bytes = serialize_constant_value(die->get_constant_value(), resolved_type->get_size().value_or(4))) {
-            auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
-            return ElfVariable(std::move(resolved_type), 0, std::move(cache));
+        if (auto size = resolved_type->get_size()) {
+            if (auto bytes = serialize_constant_value(die->get_constant_value(), *size)) {
+                auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
+                return ElfVariable(std::move(resolved_type), 0, std::move(cache));
+            }
         }
     }
     throw SymbolNotFoundException(std::string(name));

--- a/ttexalens/cpp/elf/dwarf_info.cpp
+++ b/ttexalens/cpp/elf/dwarf_info.cpp
@@ -178,7 +178,7 @@ DwarfDiePtr DwarfInfo::resolve_die_by_name(std::string_view name, DieNameFilter 
         start = pos + 2;
     }
 
-    DwarfDiePtr declaration_die;  // fallback if all matches are declarations
+    DwarfDiePtr declaration_die;   // fallback if all matches are declarations
     DwarfDiePtr non_variable_die;  // fallback if nothing resolves to a variable
 
     for (auto& cu : impl->get_cus()) {

--- a/ttexalens/cpp/elf/dwarf_info.cpp
+++ b/ttexalens/cpp/elf/dwarf_info.cpp
@@ -282,7 +282,7 @@ ElfVariable DwarfInfo::get_global(std::string_view name, std::shared_ptr<MemoryA
     // synthesized read-only buffer (writes raise via NoMemoryAccess).
     if (resolved_type) {
         if (auto size = resolved_type->get_size()) {
-            if (auto bytes = serialize_constant_value(die->get_constant_value(), *size)) {
+            if (auto bytes = DwarfDie::serialize_constant_value(die->get_constant_value(), *size)) {
                 auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(*bytes), NoMemoryAccess::instance());
                 return ElfVariable(std::move(resolved_type), 0, std::move(cache));
             }

--- a/ttexalens/cpp/elf/dwarf_info.hpp
+++ b/ttexalens/cpp/elf/dwarf_info.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -19,13 +20,6 @@ namespace details {
 class ElfFileImpl;
 class DwarfInfoImpl;
 }  // namespace details
-
-// Preference for the final component of a name when several DIEs share it
-// (e.g. an `enum noc_mode` type shadowing a `constexpr uint8_t noc_mode`).
-enum class DieNameFilter {
-    Any,       // first name match, tag-agnostic (generic find-any-DIE lookups)
-    Variable,  // prefer a DW_TAG_variable (value lookups: get_global/get_constant)
-};
 
 class DwarfInfo {
    public:
@@ -43,8 +37,12 @@ class DwarfInfo {
 
     // Resolves a "Foo::Bar::baz" path against every CU's DIE tree and returns
     // the first non-declaration match (or a declaration as fallback). Follows
-    // DW_AT_abstract_origin / DW_AT_specification one hop when present.
-    DwarfDiePtr get_die_by_name(std::string_view name) const;
+    // DW_AT_abstract_origin / DW_AT_specification one hop when present. When
+    // `filter` is set, it constrains the last component so a value lookup
+    // can require a variable and skip a same-named type (e.g.
+    // `constexpr uint8_t noc_mode` over `enum noc_mode`).
+    DwarfDiePtr get_die_by_name(std::string_view name,
+                                const std::function<bool(const DwarfDiePtr&)>& filter = {}) const;
 
     // Walks every CU and recursively drills into children to find the DIE
     // whose address range contains `address`. When multiple CUs match (e.g.
@@ -83,13 +81,6 @@ class DwarfInfo {
     ElfVariable read_global(std::string_view name, std::shared_ptr<MemoryAccess> memory_access) const;
 
    private:
-    // Core name resolver for "Foo::Bar::baz" paths. With DieNameFilter::Variable
-    // the final component prefers a DW_TAG_variable over a same-named type
-    // (e.g. `constexpr uint8_t noc_mode` over `enum noc_mode`), scanning other
-    // CUs before settling for a non-variable. Falls back to the first name
-    // match, then to a declaration. get_die_by_name() passes DieNameFilter::Any.
-    DwarfDiePtr resolve_die_by_name(std::string_view name, DieNameFilter filter) const;
-
     std::shared_ptr<details::DwarfInfoImpl> impl;
 };
 

--- a/ttexalens/cpp/elf/dwarf_info.hpp
+++ b/ttexalens/cpp/elf/dwarf_info.hpp
@@ -20,6 +20,13 @@ class ElfFileImpl;
 class DwarfInfoImpl;
 }  // namespace details
 
+// Preference for the final component of a name when several DIEs share it
+// (e.g. an `enum noc_mode` type shadowing a `constexpr uint8_t noc_mode`).
+enum class DieNameFilter {
+    Any,       // first name match, tag-agnostic (generic find-any-DIE lookups)
+    Variable,  // prefer a DW_TAG_variable (value lookups: get_global/get_constant)
+};
+
 class DwarfInfo {
    public:
     DwarfInfo(std::weak_ptr<details::ElfFileImpl> elf_impl);
@@ -76,6 +83,13 @@ class DwarfInfo {
     ElfVariable read_global(std::string_view name, std::shared_ptr<MemoryAccess> memory_access) const;
 
    private:
+    // Core name resolver for "Foo::Bar::baz" paths. With DieNameFilter::Variable
+    // the final component prefers a DW_TAG_variable over a same-named type
+    // (e.g. `constexpr uint8_t noc_mode` over `enum noc_mode`), scanning other
+    // CUs before settling for a non-variable. Falls back to the first name
+    // match, then to a declaration. get_die_by_name() passes DieNameFilter::Any.
+    DwarfDiePtr resolve_die_by_name(std::string_view name, DieNameFilter filter) const;
+
     std::shared_ptr<details::DwarfInfoImpl> impl;
 };
 

--- a/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
@@ -238,12 +238,14 @@ void bind_dwarf_die(nb::module_& m) {
              nb::sig("def get_array_element_type(self) -> DwarfDie | None"))
         .def(
             "find_child_by_name",
-            [](const DwarfDie& self, std::string_view name, std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
+            [](const DwarfDie& self, std::string_view name,
+               std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
                 return self.find_child_by_name(name, filter ? *filter : std::function<bool(const DwarfDiePtr&)>{});
             },
             nb::arg("name"), nb::arg("filter") = nb::none(), nb::rv_policy::reference_internal,
-            nb::sig("def find_child_by_name(self, name: str, filter: collections.abc.Callable[[DwarfDie], bool] | None = "
-                    "None) -> DwarfDie | None"))
+            nb::sig(
+                "def find_child_by_name(self, name: str, filter: collections.abc.Callable[[DwarfDie], bool] | None = "
+                "None) -> DwarfDie | None"))
         .def("get_die_from_attribute", &DwarfDie::get_die_from_attribute, nb::arg("attribute_tag"),
              nb::rv_policy::reference_internal,
              nb::sig("def get_die_from_attribute(self, attribute_tag: DwarfAttributeTag) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
@@ -235,8 +235,9 @@ void bind_dwarf_die(nb::module_& m) {
              nb::sig("def get_dereference_type(self) -> DwarfDie | None"))
         .def("get_array_element_type", &DwarfDie::get_array_element_type, nb::rv_policy::reference_internal,
              nb::sig("def get_array_element_type(self) -> DwarfDie | None"))
-        .def("find_child_by_name", &DwarfDie::find_child_by_name, nb::arg("name"), nb::rv_policy::reference_internal,
-             nb::sig("def find_child_by_name(self, name: str) -> DwarfDie | None"))
+        .def("find_child_by_name",
+             [](const DwarfDie& self, std::string_view name) { return self.find_child_by_name(name); }, nb::arg("name"),
+             nb::rv_policy::reference_internal, nb::sig("def find_child_by_name(self, name: str) -> DwarfDie | None"))
         .def("get_die_from_attribute", &DwarfDie::get_die_from_attribute, nb::arg("attribute_tag"),
              nb::rv_policy::reference_internal,
              nb::sig("def get_die_from_attribute(self, attribute_tag: DwarfAttributeTag) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
@@ -235,9 +235,10 @@ void bind_dwarf_die(nb::module_& m) {
              nb::sig("def get_dereference_type(self) -> DwarfDie | None"))
         .def("get_array_element_type", &DwarfDie::get_array_element_type, nb::rv_policy::reference_internal,
              nb::sig("def get_array_element_type(self) -> DwarfDie | None"))
-        .def("find_child_by_name",
-             [](const DwarfDie& self, std::string_view name) { return self.find_child_by_name(name); }, nb::arg("name"),
-             nb::rv_policy::reference_internal, nb::sig("def find_child_by_name(self, name: str) -> DwarfDie | None"))
+        .def(
+            "find_child_by_name",
+            [](const DwarfDie& self, std::string_view name) { return self.find_child_by_name(name); }, nb::arg("name"),
+            nb::rv_policy::reference_internal, nb::sig("def find_child_by_name(self, name: str) -> DwarfDie | None"))
         .def("get_die_from_attribute", &DwarfDie::get_die_from_attribute, nb::arg("attribute_tag"),
              nb::rv_policy::reference_internal,
              nb::sig("def get_die_from_attribute(self, attribute_tag: DwarfAttributeTag) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_die.cpp
@@ -3,6 +3,7 @@
 
 #include <nanobind/make_iterator.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string.h>
@@ -237,8 +238,12 @@ void bind_dwarf_die(nb::module_& m) {
              nb::sig("def get_array_element_type(self) -> DwarfDie | None"))
         .def(
             "find_child_by_name",
-            [](const DwarfDie& self, std::string_view name) { return self.find_child_by_name(name); }, nb::arg("name"),
-            nb::rv_policy::reference_internal, nb::sig("def find_child_by_name(self, name: str) -> DwarfDie | None"))
+            [](const DwarfDie& self, std::string_view name, std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
+                return self.find_child_by_name(name, filter ? *filter : std::function<bool(const DwarfDiePtr&)>{});
+            },
+            nb::arg("name"), nb::arg("filter") = nb::none(), nb::rv_policy::reference_internal,
+            nb::sig("def find_child_by_name(self, name: str, filter: collections.abc.Callable[[DwarfDie], bool] | None = "
+                    "None) -> DwarfDie | None"))
         .def("get_die_from_attribute", &DwarfDie::get_die_from_attribute, nb::arg("attribute_tag"),
              nb::rv_policy::reference_internal,
              nb::sig("def get_die_from_attribute(self, attribute_tag: DwarfAttributeTag) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/function.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/shared_ptr.h>
 #include <nanobind/stl/string_view.h>
@@ -21,9 +22,13 @@ void bind_dwarf_info(nb::module_& m) {
     nb::class_<DwarfInfo>(m, "DwarfInfo")
         .def("find_file_line_by_address", &DwarfInfo::find_file_line_by_address, nb::arg("address"))
         .def(
-            "get_die_by_name", [](const DwarfInfo& self, std::string_view name) { return self.get_die_by_name(name); },
-            nb::arg("name"), nb::rv_policy::reference_internal,
-            nb::sig("def get_die_by_name(self, name: str) -> DwarfDie | None"))
+            "get_die_by_name",
+            [](const DwarfInfo& self, std::string_view name, std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
+                return self.get_die_by_name(name, filter ? *filter : std::function<bool(const DwarfDiePtr&)>{});
+            },
+            nb::arg("name"), nb::arg("filter") = nb::none(), nb::rv_policy::reference_internal,
+            nb::sig("def get_die_by_name(self, name: str, filter: collections.abc.Callable[[DwarfDie], bool] | None = "
+                    "None) -> DwarfDie | None"))
         .def("find_function_by_address", &DwarfInfo::find_function_by_address, nb::arg("address"),
              nb::rv_policy::reference_internal,
              nb::sig("def find_function_by_address(self, address: int) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
@@ -23,7 +23,8 @@ void bind_dwarf_info(nb::module_& m) {
         .def("find_file_line_by_address", &DwarfInfo::find_file_line_by_address, nb::arg("address"))
         .def(
             "get_die_by_name",
-            [](const DwarfInfo& self, std::string_view name, std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
+            [](const DwarfInfo& self, std::string_view name,
+               std::optional<std::function<bool(const DwarfDiePtr&)>> filter) {
                 return self.get_die_by_name(name, filter ? *filter : std::function<bool(const DwarfDiePtr&)>{});
             },
             nb::arg("name"), nb::arg("filter") = nb::none(), nb::rv_policy::reference_internal,

--- a/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
@@ -20,9 +20,10 @@ namespace ttexalens::native_elf::bindings {
 void bind_dwarf_info(nb::module_& m) {
     nb::class_<DwarfInfo>(m, "DwarfInfo")
         .def("find_file_line_by_address", &DwarfInfo::find_file_line_by_address, nb::arg("address"))
-        .def("get_die_by_name",
-             [](const DwarfInfo& self, std::string_view name) { return self.get_die_by_name(name); }, nb::arg("name"),
-             nb::rv_policy::reference_internal, nb::sig("def get_die_by_name(self, name: str) -> DwarfDie | None"))
+        .def(
+            "get_die_by_name", [](const DwarfInfo& self, std::string_view name) { return self.get_die_by_name(name); },
+            nb::arg("name"), nb::rv_policy::reference_internal,
+            nb::sig("def get_die_by_name(self, name: str) -> DwarfDie | None"))
         .def("find_function_by_address", &DwarfInfo::find_function_by_address, nb::arg("address"),
              nb::rv_policy::reference_internal,
              nb::sig("def find_function_by_address(self, address: int) -> DwarfDie | None"))

--- a/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
+++ b/ttexalens/cpp/nanobind/bind_dwarf_info.cpp
@@ -20,8 +20,9 @@ namespace ttexalens::native_elf::bindings {
 void bind_dwarf_info(nb::module_& m) {
     nb::class_<DwarfInfo>(m, "DwarfInfo")
         .def("find_file_line_by_address", &DwarfInfo::find_file_line_by_address, nb::arg("address"))
-        .def("get_die_by_name", &DwarfInfo::get_die_by_name, nb::arg("name"), nb::rv_policy::reference_internal,
-             nb::sig("def get_die_by_name(self, name: str) -> DwarfDie | None"))
+        .def("get_die_by_name",
+             [](const DwarfInfo& self, std::string_view name) { return self.get_die_by_name(name); }, nb::arg("name"),
+             nb::rv_policy::reference_internal, nb::sig("def get_die_by_name(self, name: str) -> DwarfDie | None"))
         .def("find_function_by_address", &DwarfInfo::find_function_by_address, nb::arg("address"),
              nb::rv_policy::reference_internal,
              nb::sig("def find_function_by_address(self, address: int) -> DwarfDie | None"))


### PR DESCRIPTION
## Problem
When a global shares its name with a type (e.g. `enum noc_mode` shadowing
`constexpr uint8_t noc_mode`), name resolution returned the type DIE (`DW_TAG_enumeration_type` instead of `DW_TAG_variable`), so
`get_global`/`get_constant` threw (`std::bad_cast`) or — for a folded
`constexpr` — read garbage (the const value was used as an address). This broke
tt-metal triage's `noc_mode` reads.

## Solution
- Resolve `get_global`/`get_constant` names to the variable, not a same-named type (across CUs).
- Only treat `DW_AT_const_value` as an address for pointers (not scalars).
- `get_global` now serves a folded constexpr's compile-time value (read-only) instead of reading device memory.

## Tests
Added an enum/variable name-collision fixture + regression test.