### PR TITLE
Skipping is_ebreak_hit in callstack for rocket cores

### DIFF
--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -650,10 +650,12 @@ def callstack(
         # Reading the program counter from risc register
         pc = risc_debug.read_gpr(32)
 
-        # If ebreak was hit, pc will point to the instruction after it
-        if risc_debug.is_ebreak_hit():
-            # Rewind pc to unwind callstack from the ebreak instruction
-            pc -= 4
+        # TODO: #1071
+        if not "rocket" in risc_name.lower():
+            # If ebreak was hit, pc will point to the instruction after it
+            if risc_debug.is_ebreak_hit():
+                # Rewind pc to unwind callstack from the ebreak instruction
+                pc -= 4
 
         mem_access = create_memory_access(risc_debug)
 

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -20,6 +20,7 @@ from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.context import Context, NocId
 from ttexalens.elf import read_elf, CallstackEntry, ElfFile, ElfVariable, get_callstack, get_frame_callstack
 from ttexalens.exceptions import TTException
+from ttexalens.hardware.rocket_core_debug import RocketCoreDebug
 from ttexalens.memory_access import create_memory_access
 
 
@@ -651,7 +652,7 @@ def callstack(
         pc = risc_debug.read_gpr(32)
 
         # TODO: #1071
-        if not "rocket" in risc_name.lower():
+        if not isinstance(risc_debug, RocketCoreDebug):
             # If ebreak was hit, pc will point to the instruction after it
             if risc_debug.is_ebreak_hit():
                 # Rewind pc to unwind callstack from the ebreak instruction


### PR DESCRIPTION
Closes #1062 

Until #1071 is resolved we should skip this check. When we have more information about `ebreak` behavior on Rocket cores we can decide if this check is needed for them. 