### PR TITLE
Add named arguments for boolean parameters

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -85,6 +85,7 @@ jobs:
       - build
       - build-image
     strategy:
+      fail-fast: false
       matrix:
         runner-info: [
           {arch: "blackhole", board: "p150b", runs-on: "tt-ubuntu-2204-p150b-stable"},
@@ -98,6 +99,7 @@ jobs:
       VERBOSE: 5
       LOGGER_LEVEL: DEBUG
     runs-on: ${{ matrix.runner-info.runs-on }}
+    timeout-minutes: 60
     container:
       image: ${{ needs.build-image.outputs.docker-image }}
       options: --device /dev/tenstorrent/0
@@ -108,6 +110,14 @@ jobs:
         - /lib/modules:/lib/modules
     name: Run tests | ${{ matrix.runner-info.arch }} ${{ matrix.runner-info.board }}
     steps:
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          # Create unique identifier using run_id and matrix parameters
+          JOB_ID="${{ github.run_id }}_ubuntu_${{ inputs.ubuntu-version }}_${{ matrix.runner-info.arch }}_${{ matrix.runner-info.board }}"
+          echo "test_report_path=report_${JOB_ID}.xml" >> "$GITHUB_OUTPUT"
+
       - name: Git safe dir
         run: git config --global --add safe.directory '*'
 
@@ -116,17 +126,22 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: pyTooling/download-artifact@v4
+      - name: Download build artifact
+        id: download-build
+        continue-on-error: true
+        uses: pyTooling/download-artifact@v4
         with:
           name: ttexalens-build-ubuntu-${{ inputs.ubuntu-version }}
 
-      - name: Set reusable strings
-        id: strings
-        shell: bash
-        run: |
-          # Create unique identifier using run_id and matrix parameters
-          JOB_ID="${{ github.run_id }}_ubuntu_${{ inputs.ubuntu-version }}_${{ matrix.runner-info.arch }}_${{ matrix.runner-info.board }}"
-          echo "test_report_path=report_${JOB_ID}.xml" >> "$GITHUB_OUTPUT"
+      - name: Wait before retrying artifact download
+        if: steps.download-build.outcome == 'failure'
+        run: sleep 15
+
+      - name: Download build artifact (retry)
+        if: steps.download-build.outcome == 'failure'
+        uses: pyTooling/download-artifact@v4
+        with:
+          name: ttexalens-build-ubuntu-${{ inputs.ubuntu-version }}
 
       - name: Run tt-exalens in background
         shell: bash
@@ -146,6 +161,7 @@ jobs:
         with:
           name: test-reports-${{ inputs.ubuntu-version }}-${{ matrix.runner-info.arch }}-${{ matrix.runner-info.board }}
           path: ${{ steps.strings.outputs.test_report_path }}
+          if-no-files-found: ignore
 
       - name: Run Python tests for TTExaLens app (using NOC1)
         run: |

--- a/.github/workflows/build-ttexalens.yml
+++ b/.github/workflows/build-ttexalens.yml
@@ -64,6 +64,7 @@ jobs:
         uses: pyTooling/upload-artifact@v4
         with:
           name: ttexalens-build-${{ inputs.os }}
+          retention-days: 1
           path: |
             build
             build_riscv

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         ubuntu-version: [ "22.04", "24.04" ]
     uses: ./.github/workflows/build-and-test.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   build-and-test:
     strategy:
+      fail-fast: false
       matrix:
         ubuntu-version: [ "22.04", "24.04" ]
     uses: ./.github/workflows/build-and-test.yml

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -61,16 +61,16 @@ class TimeoutMemoryAccess(MemoryAccess):
     _coord = tt_umd.CoreCoord(0, 0, tt_umd.CoreType.TENSIX, tt_umd.CoordSystem.LOGICAL)
 
     def read(self, address: int, buffer: memoryview | bytearray) -> None:
-        raise TimeoutDeviceRegisterError(0, self._coord, address, len(buffer), True, None)
+        raise TimeoutDeviceRegisterError(0, self._coord, address, len(buffer), is_read=True, umd_error=None)
 
     def write(self, address: int, data: bytes | bytearray | memoryview) -> None:
-        raise TimeoutDeviceRegisterError(0, self._coord, address, len(data), False, None)
+        raise TimeoutDeviceRegisterError(0, self._coord, address, len(data), is_read=False, umd_error=None)
 
     def read_register(self, register_index: int) -> int:
-        raise TimeoutDeviceRegisterError(0, self._coord, register_index, 0, True, None)
+        raise TimeoutDeviceRegisterError(0, self._coord, register_index, 0, is_read=True, umd_error=None)
 
     def write_register(self, register_index: int, value: int) -> None:
-        raise TimeoutDeviceRegisterError(0, self._coord, register_index, 0, False, None)
+        raise TimeoutDeviceRegisterError(0, self._coord, register_index, 0, is_read=False, umd_error=None)
 
 
 class RiscHaltErrorMemoryAccess(MemoryAccess):

--- a/test/ttexalens/unit_tests/test_gdb_mem_access.py
+++ b/test/ttexalens/unit_tests/test_gdb_mem_access.py
@@ -26,7 +26,6 @@ from ttexalens.gdb.gdb_communication import (
 )
 from ttexalens.tt_exalens_lib import parse_elf, run_elf
 
-
 _MAINTENANCE_CASES: list[tuple[str, str, int | None, bool]] = [
     # Wormhole L1: [0x00000000, 0x0016E000)
     ("wormhole_inside", "wormhole", None, False),
@@ -337,7 +336,7 @@ class TestGdbMemAccessFromClient(unittest.TestCase):
             )
 
             # For this addr, all four packets (m/M/x/X) should either all succeed or all E04.
-            self._assert_packet_result(output, "m", addr_hex, length_hex, expect_e04)
-            self._assert_packet_result(output, "M", addr_hex, length_hex, expect_e04)
-            self._assert_packet_result(output, "x", addr_hex, length_hex, expect_e04)
-            self._assert_packet_result(output, "X", addr_hex, length_hex, expect_e04)
+            self._assert_packet_result(output, "m", addr_hex, length_hex, expect_e04=expect_e04)
+            self._assert_packet_result(output, "M", addr_hex, length_hex, expect_e04=expect_e04)
+            self._assert_packet_result(output, "x", addr_hex, length_hex, expect_e04=expect_e04)
+            self._assert_packet_result(output, "X", addr_hex, length_hex, expect_e04=expect_e04)

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -1369,7 +1369,9 @@ class TestARC(unittest.TestCase):
         timeout = timedelta(milliseconds=1000)
 
         # Ask for reply, check for reasonable TEST value
-        ret, return_3, _ = lib.arc_msg(self.device.id, msg_code, wait_for_done, args, timeout, context=self.context)
+        ret, return_3, _ = lib.arc_msg(
+            self.device.id, msg_code, wait_for_done=wait_for_done, args=args, timeout=timeout, context=self.context
+        )
 
         print(f"ARC message result={ret}, test={return_3}")
         self.assertEqual(ret, 0)
@@ -1547,7 +1549,7 @@ class TestCallStack(unittest.TestCase):
         parsed_elf.get_global("g_MAILBOX", mem_access)
 
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
         self.assertEqual(len(callstack), recursion_count + 3)
         self.assertEqual(callstack[0].function_name, "halt")
@@ -1571,7 +1573,9 @@ class TestCallStack(unittest.TestCase):
         parsed_elf = get_parsed_elf_file(elf_path)
         self.set_recursion_count(parsed_elf, recursion_count)
         self.loader.run_elf(parsed_elf)
-        callstack: list[CallstackEntry] = lib.callstack(self.location, elf_path, None, self.risc_name, None, 100, True)
+        callstack: list[CallstackEntry] = lib.callstack(
+            self.location, elf_path, None, self.risc_name, None, 100, stop_on_main=True
+        )
         self.assertEqual(len(callstack), recursion_count + 3)
         self.assertEqual(callstack[0].function_name, "halt")
         for i in range(1, recursion_count + 1):
@@ -1593,7 +1597,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
         self.assertEqual(len(callstack), 3)
         self.assertEqual(callstack[0].function_name, "halt")
@@ -1620,7 +1624,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFFA)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         # The inlined leaf chain (halt inlined into pc3/pc2/pc1) is reconstructed from the PC alone,
@@ -1655,7 +1659,14 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFFA)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True, expand_tail_call_inline_frames=True
+            self.location,
+            parsed_elf,
+            None,
+            self.risc_name,
+            None,
+            100,
+            stop_on_main=True,
+            expand_tail_call_inline_frames=True,
         )
 
         expected = [
@@ -1689,7 +1700,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFF9)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         # tc_a/tc_b/tc_c are not inlined, so the whole chain appears the same on every build: the
@@ -1734,7 +1745,7 @@ class TestCallStack(unittest.TestCase):
         self.l1_mem_access.write(self.get_mailbox_value_address(parsed_elf), struct.pack("<i", arg))
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         expected = [
@@ -1774,7 +1785,7 @@ class TestCallStack(unittest.TestCase):
         self.l1_mem_access.write(self.get_mailbox_value_address(parsed_elf), struct.pack("<i", arg))
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         expected = [
@@ -1855,7 +1866,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFFF)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
         self.assertEqual(len(callstack), 6)
         self.assertEqual(callstack[0].function_name, "halt")
@@ -1880,7 +1891,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFFE)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
         self.assertEqual(len(callstack), 5)
         self.assertEqual(callstack[0].function_name, "halt")
@@ -1969,7 +1980,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, mailbox)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         # The callstack is: halt, the value-test chain (one frame per type), an optional wrapper
@@ -1992,20 +2003,28 @@ class TestCallStack(unittest.TestCase):
             self.assertEqual(len(entry.arguments), 1, f"Unexpected arguments for {function_name}")
             self.assertEqual(len(entry.locals), 1, f"Unexpected locals for {function_name}")
             self.assert_variable(
-                entry.arguments[0], "arg", expected_arg, require_arguments, f"argument of {function_name}"
+                entry.arguments[0],
+                "arg",
+                expected_arg,
+                require_value=require_arguments,
+                message=f"argument of {function_name}",
             )
-            self.assert_variable(entry.locals[0], "local", expected_local, True, f"local of {function_name}")
+            self.assert_variable(
+                entry.locals[0], "local", expected_local, require_value=True, message=f"local of {function_name}"
+            )
 
     @parameterized.expand(CALLSTACK_ELFS)
     def test_callstack_argument_and_local_values(self, elf_name: str):
         require_arguments = "release" not in elf_name
         # 0xFFFFFFFD selects the value_test chain (separate frames, one per type) in callstack.cc.
-        self.check_chained_value_test(elf_name, 0xFFFFFFFD, "value_test", require_arguments)
+        self.check_chained_value_test(elf_name, 0xFFFFFFFD, "value_test", require_arguments=require_arguments)
 
     @parameterized.expand(CALLSTACK_ELFS)
     def test_callstack_inlined_argument_and_local_values(self, elf_name: str):
         # 0xFFFFFFFC selects the inline_value_test chain (inlined virtual frames) in callstack.cc.
-        self.check_chained_value_test(elf_name, 0xFFFFFFFC, "inline_value_test", True, wrapper="inline_value_test::run")
+        self.check_chained_value_test(
+            elf_name, 0xFFFFFFFC, "inline_value_test", require_arguments=True, wrapper="inline_value_test::run"
+        )
 
     @parameterized.expand(itertools.product(CALLSTACK_ELFS, range(len(VALUE_TEST_TYPES))))
     def test_callstack_single_frame_argument_and_local_values(self, elf_name: str, type_index: int):
@@ -2029,7 +2048,7 @@ class TestCallStack(unittest.TestCase):
         )
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         # The callstack is: value_test<T> (top frame), dispatch, main.
@@ -2038,8 +2057,12 @@ class TestCallStack(unittest.TestCase):
         self.assertEqual(len(top.arguments), 1)
         self.assertEqual(len(top.locals), 1)
         if struct_format.startswith("<"):
-            self.assert_variable(top.arguments[0], "arg", expected_arg, True, f"argument of {top.function_name}")
-            self.assert_variable(top.locals[0], "local", expected_local, True, f"local of {top.function_name}")
+            self.assert_variable(
+                top.arguments[0], "arg", expected_arg, require_value=True, message=f"argument of {top.function_name}"
+            )
+            self.assert_variable(
+                top.locals[0], "local", expected_local, require_value=True, message=f"local of {top.function_name}"
+            )
         else:
             # A const char* transferred through a register: verify it points at the test string.
             address = self.get_symbol_address(parsed_elf, struct_format)
@@ -2062,7 +2085,7 @@ class TestCallStack(unittest.TestCase):
         self.set_recursion_count(parsed_elf, 0xFFFFFFFB)
         self.loader.run_elf(parsed_elf)
         callstack: list[CallstackEntry] = lib.callstack(
-            self.location, parsed_elf, None, self.risc_name, None, 100, True
+            self.location, parsed_elf, None, self.risc_name, None, 100, stop_on_main=True
         )
 
         # The callstack is: halt, the callee_saved_test chain (one frame per type), then main.
@@ -2076,7 +2099,9 @@ class TestCallStack(unittest.TestCase):
             self.assertIn(frame.function_name, (function_name, function), f"Unexpected frame: {frame.function_name}")
             self.assertEqual(len(frame.locals), 1, f"Unexpected locals for {function_name}")
             if struct_format.startswith("<"):
-                self.assert_variable(frame.locals[0], "reg_value", value, True, f"reg_value of {function_name}")
+                self.assert_variable(
+                    frame.locals[0], "reg_value", value, require_value=True, message=f"reg_value of {function_name}"
+                )
             else:
                 # A const char* held in a callee-saved register: verify it points at the test string.
                 address = self.get_symbol_address(parsed_elf, struct_format)
@@ -2111,4 +2136,14 @@ class TestCallStack(unittest.TestCase):
 
         # Check for invalid location
         with self.assertRaises((TTException, ValueError, FileNotFoundError)):
-            lib.callstack(location, elf_paths, offsets, risc_name, None, max_depth, True, device_id, self.context)
+            lib.callstack(
+                location,
+                elf_paths,
+                offsets,
+                risc_name,
+                None,
+                max_depth,
+                stop_on_main=True,
+                device_id=device_id,
+                context=self.context,
+            )

--- a/ttexalens/cli.py
+++ b/ttexalens/cli.py
@@ -185,7 +185,9 @@ def redirect_command_output_to_file(file_output: str | None):
 
     file_output = file_output.strip()
     file_output = file_output.replace('"', "").replace("'", "")
-    return util.redirect_output_to_file_and_terminal(file_output, show_terminal_output, append)
+    return util.redirect_output_to_file_and_terminal(
+        file_output, show_terminal_output=show_terminal_output, append=append
+    )
 
 
 def main_loop(args, context: Context):

--- a/ttexalens/cli_commands/burst_read_xy.py
+++ b/ttexalens/cli_commands/burst_read_xy.py
@@ -156,7 +156,7 @@ def print_memory_block(header: str, start_addr: int, data: list[int], bytes_per_
     da.data = data
     if bytes_per_entry != 4:
         da.to_bytes_per_entry(bytes_per_entry)
-    print(f"{da.id}\n{util.dump_memory(start_addr, da.data, bytes_per_entry, 16, is_hex)}")
+    print(f"{da.id}\n{util.dump_memory(start_addr, da.data, bytes_per_entry, 16, in_hex=is_hex)}")
 
 
 def print_a_burst_read(

--- a/ttexalens/cli_commands/noc.py
+++ b/ttexalens/cli_commands/noc.py
@@ -217,7 +217,7 @@ def display_noc_status_registers(
     ]
 
     # Use the shared formatter API
-    display_grouped_data(noc_registers, grouping, simple_print)
+    display_grouped_data(noc_registers, grouping, simple_print=simple_print)
 
 
 def display_all_noc_registers(loc: OnChipCoordinate, device: Device, simple_print: bool = False) -> None:
@@ -237,7 +237,7 @@ def display_all_noc_registers(loc: OnChipCoordinate, device: Device, simple_prin
     grouping = [group_names]
 
     # Use the shared formatter API
-    display_grouped_data(noc_registers, grouping, simple_print)
+    display_grouped_data(noc_registers, grouping, simple_print=simple_print)
 
 
 def display_all_noc_status_registers(loc: OnChipCoordinate, device: Device, simple_print: bool = False) -> None:
@@ -249,8 +249,8 @@ def display_all_noc_status_registers(loc: OnChipCoordinate, device: Device, simp
         device: Device object
         simple_print: Whether to use simplified output format
     """
-    display_noc_status_registers(loc, device, NocId.NOC0, simple_print)
-    display_noc_status_registers(loc, device, NocId.NOC1, simple_print)
+    display_noc_status_registers(loc, device, NocId.NOC0, simple_print=simple_print)
+    display_noc_status_registers(loc, device, NocId.NOC1, simple_print=simple_print)
 
 
 def display_specific_noc_registers(
@@ -291,7 +291,7 @@ def display_specific_noc_registers(
     # Only display if we found at least one valid register
     if valid_registers:
         register_data = {f"{noc_id.name} Registers": get_noc_registers(device, loc, noc_id, valid_registers)}
-        display_grouped_data(register_data, [[f"{noc_id.name} Registers"]], simple_print)
+        display_grouped_data(register_data, [[f"{noc_id.name} Registers"]], simple_print=simple_print)
     elif not invalid_registers:
         # If no registers were found but none were invalid, it's likely an empty list
         util.ERROR(f"No register names provided for {noc_id.name}")

--- a/ttexalens/cli_commands/perf_counters.py
+++ b/ttexalens/cli_commands/perf_counters.py
@@ -64,7 +64,6 @@ from ttexalens.perf_counters import (
 from ttexalens.rich_formatters import formatter
 from ttexalens.uistate import UIState
 
-
 command_metadata = CommandMetadata(
     short_name="pcnt",
     long_name="perf-counters",
@@ -167,7 +166,7 @@ def _render_per_core(
     sample_key = next(iter(snap))
     did, coord = sample_key[0], sample_key[1]
     print(f"\n=== Perf Counter Read: chip={did} core={coord.to_user_str()} ===\n")
-    data = _build_render_data(snap, snap_prev, active_only, consolidated=False)
+    data = _build_render_data(snap, snap_prev, active_only=active_only, consolidated=False)
     if not data:
         print("  (no counters changed)")
         return
@@ -188,7 +187,7 @@ def _render_consolidated(
     active_only: bool,
 ) -> None:
     print("\n=== Perf Counter Read: multiple cores ===\n")
-    data = _build_render_data(snap, snap_prev, active_only, consolidated=True)
+    data = _build_render_data(snap, snap_prev, active_only=active_only, consolidated=True)
     if not data:
         print("  (no counters changed)")
         return
@@ -269,9 +268,9 @@ def _run_read(
 
     unique_locs = {(did, coord) for did, coord, *_ in snap.keys()}
     if len(unique_locs) > 1:
-        _render_consolidated(snap, snap_prev, active_only)
+        _render_consolidated(snap, snap_prev, active_only=active_only)
     else:
-        _render_per_core(snap, snap_prev, active_only)
+        _render_per_core(snap, snap_prev, active_only=active_only)
 
 
 def run(cmd_text: str, context: Context, ui_state: UIState):

--- a/ttexalens/cli_commands/search-memory.py
+++ b/ttexalens/cli_commands/search-memory.py
@@ -314,9 +314,9 @@ def run(cmd_text: str, context: Context, ui_state: UIState):
 
             try:
                 if risc_name:
-                    ranges = _get_risc_search_ranges(location, risc_name, start_addr, end_addr, unsafe)
+                    ranges = _get_risc_search_ranges(location, risc_name, start_addr, end_addr, unsafe=unsafe)
                 else:
-                    ranges = _get_noc_search_ranges(location, start_addr, end_addr, unsafe)
+                    ranges = _get_noc_search_ranges(location, start_addr, end_addr, unsafe=unsafe)
             except TTException as e:
                 util.ERROR(f"Device {device_id_str} | Location {location_str}: {e}")
                 continue
@@ -329,7 +329,15 @@ def run(cmd_text: str, context: Context, ui_state: UIState):
             for r_start, r_end, block_name in ranges:
                 remaining = None if max_results is None else max_results - len(all_matches)
                 block_matches = _search_in_range(
-                    location, r_start, r_end, block_name, pattern_bytes, unsafe, risc_name, read_size, remaining
+                    location,
+                    r_start,
+                    r_end,
+                    block_name,
+                    pattern_bytes,
+                    unsafe=unsafe,
+                    risc_name=risc_name,
+                    read_size=read_size,
+                    max_results=remaining,
                 )
                 all_matches.extend(block_matches)
                 if max_results is not None and len(all_matches) >= max_results:

--- a/ttexalens/coordinate.py
+++ b/ttexalens/coordinate.py
@@ -320,10 +320,10 @@ class OnChipCoordinate:
         dma_threshold: int | None = None,
         safe_mode: bool | None = None,
     ) -> None:
-        self.device.noc_read(self, address, buffer, noc_id, dma_threshold, safe_mode)
+        self.device.noc_read(self, address, buffer, noc_id, dma_threshold, safe_mode=safe_mode)
 
     def noc_read32(self, address: int, noc_id: NocId | None = None, safe_mode: bool | None = None) -> int:
-        return self.device.noc_read32(self, address, noc_id, safe_mode)
+        return self.device.noc_read32(self, address, noc_id, safe_mode=safe_mode)
 
     def noc_write(
         self,
@@ -333,7 +333,7 @@ class OnChipCoordinate:
         dma_threshold: int | None = None,
         safe_mode: bool | None = None,
     ):
-        self.device.noc_write(self, address, data, noc_id, dma_threshold, safe_mode)
+        self.device.noc_write(self, address, data, noc_id, dma_threshold, safe_mode=safe_mode)
 
     def noc_write32(self, address: int, data: int, noc_id: NocId | None = None, safe_mode: bool | None = None):
-        self.device.noc_write32(self, address, data, noc_id, safe_mode)
+        self.device.noc_write32(self, address, data, noc_id, safe_mode=safe_mode)

--- a/ttexalens/debug_tensix.py
+++ b/ttexalens/debug_tensix.py
@@ -265,7 +265,7 @@ class TensixDebug:
         return data
 
     def read_regfile(
-        self, regfile: int | str | REGFILE, num_tiles: int | None = None, signed=True
+        self, regfile: int | str | REGFILE, num_tiles: int | None = None, signed: bool = True
     ) -> Sequence[int | float | str]:
         """Dumps SRCA/DSTACC register file from the specified core, and parses the data into a list of values.
         Dumping DSTACC on Wormhole as FP32 clobbers the register.
@@ -310,9 +310,9 @@ class TensixDebug:
             data = self.read_regfile_data(regfile, df, num_tiles)
         try:
             return (
-                unpack_data_direct_access(data, df, signed)
+                unpack_data_direct_access(data, df, signed=signed)
                 if self._direct_dest_access_enabled(df, regfile)
-                else unpack_data(data, df, signed)
+                else unpack_data(data, df, signed=signed)
             )
         except ValueError as e:
             # If the data format is unsupported, return the raw data.

--- a/ttexalens/device.py
+++ b/ttexalens/device.py
@@ -246,13 +246,13 @@ class Device:
             curr_addr = addr + bytes_checked
             memory_block_info = noc_memory_map.find_by_noc_address(curr_addr)
             if not memory_block_info:
-                raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write)
+                raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write=is_write)
             assert (
                 memory_block_info.memory_block.address.noc_address is not None
             ), "Memory block found by NoC address must have a NoC address."
 
             if not memory_block_info.is_accessible:
-                raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write)
+                raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write=is_write)
 
             memory_block_end = memory_block_info.memory_block.address.noc_address + memory_block_info.memory_block.size
             assert memory_block_end > curr_addr, "Memory block end must be greater than current address."
@@ -271,11 +271,11 @@ class Device:
                         addr,
                         num_bytes,
                         curr_addr,
-                        is_write,
+                        is_write=is_write,
                         reason="Risc data private memory is marked unsafe due to potential blackhole hardware bug, see tt-exalens:#907/#908.",
                     )
                 else:
-                    raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write)
+                    raise UnsafeAccessException(location, addr, num_bytes, curr_addr, is_write=is_write)
 
             bytes_checked += access_size
 
@@ -360,7 +360,7 @@ class Device:
     ):
         if noc_id is None:
             noc_id = self.active_noc
-        return self._umd_device.arc_msg(noc_id, msg_code, wait_for_done, args, timeout)
+        return self._umd_device.arc_msg(noc_id, msg_code, wait_for_done=wait_for_done, args=args, timeout=timeout)
 
     def read_arc_telemetry_entry(self, noc_id: NocId | None, telemetry_tag: int) -> int:
         def noc_operation(noc_id: NocId) -> int:

--- a/ttexalens/hardware/baby_risc_debug.py
+++ b/ttexalens/hardware/baby_risc_debug.py
@@ -503,7 +503,7 @@ class BabyRiscDebug(RiscDebug):
         self.baby_risc_info = risc_info
         self.register_store = register_store
         self.debug_hardware = (
-            BabyRiscDebugHardware(register_store, risc_info, enable_asserts)
+            BabyRiscDebugHardware(register_store, risc_info, enable_asserts=enable_asserts)
             if risc_info.debug_hardware_present
             else None
         )

--- a/ttexalens/hardware/blackhole/baby_risc_debug.py
+++ b/ttexalens/hardware/blackhole/baby_risc_debug.py
@@ -9,7 +9,7 @@ from ttexalens.exceptions import TTException
 
 class BlackholeBabyRiscDebug(BabyRiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool | None = None):
-        super().__init__(risc_info, enable_asserts)
+        super().__init__(risc_info, enable_asserts=enable_asserts)
 
     def step(self):
         # There is a bug in hardware and for blackhole step should be executed twice

--- a/ttexalens/hardware/perf_counters.py
+++ b/ttexalens/hardware/perf_counters.py
@@ -170,7 +170,7 @@ class TensixPerfCounters:
         """
         block = self.get_block(block_name)
         counter_id = self._resolve_counter(block, counter)
-        return self._read_counter_id(block, counter_id, noc_id, safe_mode)
+        return self._read_counter_id(block, counter_id, noc_id, safe_mode=safe_mode)
 
     def _register_store(self, noc_id: NocId | None) -> RegisterStore:
         if noc_id is None:

--- a/ttexalens/hardware/quasar/baby_risc_debug.py
+++ b/ttexalens/hardware/quasar/baby_risc_debug.py
@@ -9,7 +9,7 @@ from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 class QuasarBabyRiscDebug(BabyRiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, neo_block, enable_asserts: bool | None = None):
         self.neo_block = neo_block
-        super().__init__(risc_info, enable_asserts)
+        super().__init__(risc_info, enable_asserts=enable_asserts)
 
     def invalidate_instruction_cache(self):
         pc = self.get_pc()

--- a/ttexalens/hardware/quasar/rocket_core_debug.py
+++ b/ttexalens/hardware/quasar/rocket_core_debug.py
@@ -53,7 +53,7 @@ SBCS_SBBUSYERROR = 1 << 22
 
 class QuasarRocketCoreDebug(RocketCoreDebug):
     def __init__(self, risc_info: BabyRiscInfo, register_store: RegisterStore, enable_asserts: bool = True):
-        super().__init__(risc_info, enable_asserts)
+        super().__init__(risc_info, enable_asserts=enable_asserts)
         self.register_store = register_store
 
     def is_in_reset(self) -> bool:
@@ -238,6 +238,7 @@ class QuasarRocketCoreDebug(RocketCoreDebug):
 
     def _write_gpr_via_debug_module(self, index: int, value: int) -> None:
         """Write a 64-bit general purpose register via the Access Register abstract command."""
+
         # Value to write: LSB -> DATA0, MSB -> DATA1
         def stage_value() -> None:
             self.register_store.write_register("TT_DEBUG_MODULE_APB_DATA0", value & 0xFFFFFFFF)

--- a/ttexalens/hardware/wormhole/baby_risc_debug.py
+++ b/ttexalens/hardware/wormhole/baby_risc_debug.py
@@ -8,7 +8,7 @@ from ttexalens.hardware.baby_risc_info import BabyRiscInfo
 
 class WormholeBabyRiscDebug(BabyRiscDebug):
     def __init__(self, risc_info: BabyRiscInfo, enable_asserts: bool | None = None):
-        super().__init__(risc_info, enable_asserts)
+        super().__init__(risc_info, enable_asserts=enable_asserts)
 
     def cont(self):
         # If this is functional worker core, we need to disable branch prediction as a hardware workaround

--- a/ttexalens/pack_unpack_regfile.py
+++ b/ttexalens/pack_unpack_regfile.py
@@ -198,7 +198,7 @@ def unpack_data_direct_access(data: list[int], df: int | TensixDataFormat, signe
     if isinstance(df, int):
         df = TensixDataFormat(df)
 
-    return [unpack_value_direct_access(value, df, signed) for value in data]
+    return [unpack_value_direct_access(value, df, signed=signed) for value in data]
 
 
 def pack_value_direct_access(value: int | float, df: TensixDataFormat) -> int:

--- a/ttexalens/rich_formatters.py
+++ b/ttexalens/rich_formatters.py
@@ -235,7 +235,9 @@ class RichFormatter:
             tables: list[Panel | Table] = []
             for group_name in group_row:
                 if group_name in data:
-                    tables.append(self.create_data_table(group_name, columns, data[group_name], simple_print))
+                    tables.append(
+                        self.create_data_table(group_name, columns, data[group_name], simple_print=simple_print)
+                    )
                 else:
                     tables.append(Panel(empty_text, title=group_name))
             console.print(Columns(tables, equal=True, expand=False))
@@ -270,7 +272,7 @@ class RichFormatter:
         if sort_by_height_desc:
             names.sort(key=lambda n: -len(data[n]))
         tables: list[Panel | Table] = [
-            self.create_data_table(name, columns, data[name], simple_print) for name in names
+            self.create_data_table(name, columns, data[name], simple_print=simple_print) for name in names
         ]
         console.print(Columns(tables, equal=False, expand=False, padding=(0, 1)))
         console.print()  # blank line

--- a/ttexalens/tt_exalens_init.py
+++ b/ttexalens/tt_exalens_init.py
@@ -43,7 +43,7 @@ def init_ttexalens(
     if simulation_directory is not None and noc_id == NocId.NOC1:
         noc_id = NocId.NOC0
 
-    umd_api = local_init(init_jtag, noc_id, simulation_directory)
+    umd_api = local_init(init_jtag=init_jtag, noc_id=noc_id, simulation_directory=simulation_directory)
 
     return load_context(umd_api, FileAccessApi(), noc_id, noc_failover=noc_failover, safe_mode=safe_mode)
 
@@ -68,7 +68,7 @@ def init_ttexalens_remote(
 
     umd_api, file_api = connect_to_server(ip_address, port)
     noc_id = umd_api.initialization_noc_id
-    return load_context(umd_api, file_api, noc_id, noc_failover, safe_mode)
+    return load_context(umd_api, file_api, noc_id, noc_failover=noc_failover, safe_mode=safe_mode)
 
 
 def load_context(

--- a/ttexalens/tt_exalens_lib.py
+++ b/ttexalens/tt_exalens_lib.py
@@ -52,7 +52,7 @@ def read_word_from_device(
     validate_addr(addr)
     noc_id = check_noc_id(noc_id, coordinate.context)
 
-    return coordinate.noc_read32(addr, noc_id, safe_mode)
+    return coordinate.noc_read32(addr, noc_id, safe_mode=safe_mode)
 
 
 @trace_api
@@ -158,7 +158,7 @@ def write_words_to_device(
     noc_id = check_noc_id(noc_id, coordinate.context)
 
     if isinstance(data, int):
-        coordinate.noc_write32(addr, data, noc_id, safe_mode)
+        coordinate.noc_write32(addr, data, noc_id, safe_mode=safe_mode)
     else:
         byte_data = b"".join(x.to_bytes(4, "little") for x in data)
         coordinate.noc_write(addr, byte_data, noc_id, safe_mode=safe_mode)
@@ -360,7 +360,7 @@ def arc_msg(
     if timeout < datetime.timedelta(0):
         raise TTException("Timeout must be greater than or equal to 0.")
 
-    return list(device.arc_msg(noc_id, msg_code, wait_for_done, args, timeout))
+    return list(device.arc_msg(noc_id, msg_code, wait_for_done=wait_for_done, args=args, timeout=timeout))
 
 
 @trace_api
@@ -580,7 +580,6 @@ def top_callstack(
     context: Context | None = None,
     extract_variables: bool = True,
 ) -> list[CallstackEntry]:
-
     """
     Retrieves the top frame of the callstack for the specified PC on the given ELF.
     There is no stack walking, so the function will return the function at the given PC and all inlined functions on the top frame (if there are any).
@@ -598,7 +597,7 @@ def top_callstack(
 
     context = check_context(context)
     elfs_loaded = parse_elfs(elfs, offsets, context)
-    return get_frame_callstack(elfs_loaded, pc, extract_variables)
+    return get_frame_callstack(elfs_loaded, pc, extract_variables=extract_variables)
 
 
 @trace_api
@@ -668,8 +667,8 @@ def callstack(
             mem_access,
             max_depth,
             "main" if stop_on_main else "",
-            extract_variables,
-            expand_tail_call_inline_frames,
+            extract_variables=extract_variables,
+            expand_tail_call_inline_frames=expand_tail_call_inline_frames,
         )
 
 
@@ -717,7 +716,6 @@ def read_riscv_memory(
     context: Context | None = None,
     safe_mode: bool | None = None,
 ) -> int:
-
     """
     Reads a 32-bit word from the specified RISC-V core's private memory.
 
@@ -874,8 +872,8 @@ def get_tensix_state(
     pack_counters = _read_register_group(tensix_reg_desc.pack_counters)
     pack_strides = _read_register_group(tensix_reg_desc.pack_strides)
     gpr = _read_register_group(tensix_reg_desc.general_purpose_registers)
-    group_reader = (
-        lambda signal_group: debug_bus.read_signal_group(signal_group, l1_address)
+    group_reader = lambda signal_group: (
+        debug_bus.read_signal_group(signal_group, l1_address)
         if l1_address is not None
         else debug_bus.read_signal_group_unsafe(signal_group)
     )

--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -253,7 +253,7 @@ def local_init(init_jtag=False, noc_id: NocId = NocId.NOC1, simulation_directory
         noc_id = (
             NocId.NOC0
         )  # Quasar is only available through simulation and does not have NOC1, so we switch to NOC0 as a workaround.
-    communicator = UmdApi(init_jtag, noc_id, simulation_directory)
+    communicator = UmdApi(init_jtag=init_jtag, noc_id=noc_id, simulation_directory=simulation_directory)
     if util.VERBOSE_ENABLED:
         util.VERBOSE("Device opened successfully.")
     return communicator

--- a/ttexalens/umd_device.py
+++ b/ttexalens/umd_device.py
@@ -160,7 +160,9 @@ class UmdDevice:
                         translated_coord = coord
 
                 # Translate the UMD error into a TimeoutDeviceRegisterError and raise it
-                raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, len(buffer), True, error)
+                raise TimeoutDeviceRegisterError(
+                    self.device_id, translated_coord, address, len(buffer), is_read=True, umd_error=error
+                )
 
     def __write_to_device_reg(
         self, coord: tt_umd.CoreCoord, address: int, data: bytes | bytearray | memoryview, dma_threshold: int
@@ -180,7 +182,9 @@ class UmdDevice:
                         translated_coord = self._soc_descriptor.translate_coord_to(coord, tt_umd.CoordSystem.NOC0)
                     except Exception:
                         translated_coord = coord
-                raise TimeoutDeviceRegisterError(self.device_id, translated_coord, address, len(data), False, error)
+                raise TimeoutDeviceRegisterError(
+                    self.device_id, translated_coord, address, len(data), is_read=False, umd_error=error
+                )
 
     def __read_from_device_reg_unaligned_helper(
         self,
@@ -422,12 +426,12 @@ class UmdDevice:
             """Send ARC message"""
             self.__select_noc_id(noc_id)
             timeout_ms = timeout.total_seconds() * 1000 if isinstance(timeout, datetime.timedelta) else timeout * 1000
-            return self.__device.arc_msg(msg_code, wait_for_done, args, int(timeout_ms))
+            return self.__device.arc_msg(msg_code, wait_for_done=wait_for_done, args=args, timeout_ms=int(timeout_ms))
         except tt_umd.SigbusError:
             if util.DEBUG_ENABLED:
                 util.DEBUG("Reset detected during arc_msg, reinitializing device and retrying...")
             self.__reinit_device_after_sigbus()
-            return self.arc_msg(noc_id, msg_code, wait_for_done, args, timeout)
+            return self.arc_msg(noc_id, msg_code, wait_for_done=wait_for_done, args=args, timeout=timeout)
 
     def read_arc_telemetry_entry(self, noc_id: tt_umd.NocId, telemetry_tag: int) -> int:
         """Read ARC telemetry entry"""


### PR DESCRIPTION
Refactor constructors and function calls to use named arguments for boolean parameters, enhancing code clarity and maintainability.