### PR TITLE
Keep QSR cores in reset during simulator init

### DIFF
--- a/ttexalens/umd_api.py
+++ b/ttexalens/umd_api.py
@@ -110,13 +110,11 @@ class UmdApi:
             # and take all cores out of reset. Downstream test harnesses then re-assert specific
             # cores, load their ELFs, and re-deassert. This keeps cores from executing garbage
             # between tt-exalens init and the harness taking over.
-            for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
-                core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
-                if tt_device.get_arch() == tt_umd.ARCH.BLACKHOLE:
+            if tt_device.get_arch() == tt_umd.ARCH.BLACKHOLE:
+                for core in soc_descriptor.get_cores(tt_umd.CoreType.TENSIX):
+                    core_noc0 = soc_descriptor.translate_coord_to(core, tt_umd.CoordSystem.NOC0)
                     tt_device.noc_write32(core_noc0.x, core_noc0.y, 0, 0x6F)
                     tt_device.deassert_risc_reset(tt_umd.tt_xy_pair(core.x, core.y), tt_umd.RiscType.BRISC)
-                elif tt_device.get_arch() == tt_umd.ARCH.QUASAR:
-                    tt_device.deassert_risc_reset(tt_umd.tt_xy_pair(core.x, core.y), tt_umd.RiscType.ALL)
             cluster_descriptor_content = create_simulation_cluster_descriptor(tt_device.get_arch())
             self.cluster_descriptor = tt_umd.ClusterDescriptor.create_from_yaml_content(cluster_descriptor_content)
             self.devices[0] = UmdDevice(


### PR DESCRIPTION
Revert the QSR branch added to tt-exalens simulator initialization. That branch deasserted RiscType.ALL for every QSR Tensix core during generic context setup, but no reset-vector stub or DM/RV64 ELF is loaded at that point. On QSR this can wake DM/RV64 cores and start them from junk reset contents before the LLK harness has installed code, which is unsafe and causes simulator instruction decode failures. Keep the existing Blackhole workaround, where a BRISC infinite-loop stub is written before release, and leave QSR cores in reset until a caller explicitly loads and starts the specific cores it needs.