### PR TITLE
cmake: pin ELFIO to a post-fix commit, not the stale Release_3.12 tag

### DIFF
--- a/cmake/native_elf.cmake
+++ b/cmake/native_elf.cmake
@@ -37,11 +37,18 @@ endif()
 
 # ELFIO — header-only C++ ELF reader (section list + symbol table; libdwarf v2.x
 # doesn't expose those publicly). DOWNLOAD_ONLY: we only want the headers.
+#
+# Pinned to a commit rather than a release tag: elf_types.hpp is missing
+# `#include <cstdint>` as of Release_3.12 (the latest tag, from 2023), which
+# fails to compile under GCC 15+/newer libstdc++ headers that no longer leak
+# <cstdint> in transitively. Fixed upstream on main but no release has been
+# cut since Release_3.12 (2023). Safe to move to a tagged release once one
+# exists.
 if(NOT TARGET elfio)
     CPMAddPackage(
         NAME ELFIO
         GITHUB_REPOSITORY serge1/ELFIO
-        GIT_TAG Release_3.12
+        GIT_TAG 6c77f9b01e8cf11cc1ac7f7aa7f3b288f23371ae
         EXCLUDE_FROM_ALL YES
         DOWNLOAD_ONLY YES
     )

--- a/ttexalens/cpp/elf/private/elf_file_impl.hpp
+++ b/ttexalens/cpp/elf/private/elf_file_impl.hpp
@@ -3,6 +3,9 @@
 
 #pragma once
 
+// elf_types.hpp (pulled in by elfio.hpp) uses uint16_t and friends but is
+// missing <cstdint> as of Release_3.12; include it first so those names exist.
+#include <cstdint>
 #include <elfio/elfio.hpp>
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
## Summary
- `elfio/elf_types.hpp` is missing `#include <cstdint>` as of `Release_3.12` (the newest available tag, cut 2023-08-28). Under GCC 15+/newer libstdc++ headers that no longer leak `<cstdint>` in transitively, this fails with `error: unknown type name 'uint16_t'` and similar, building `ttexalens_elf`.
- The include was added upstream on `serge1/ELFIO`'s `main` branch (commit `34d2c6423`, "Add missing #include <stdint.h> for gcc 15") but no release has followed `Release_3.12` since.
- This bumps `GIT_TAG` in `cmake/native_elf.cmake` to a specific commit past that fix (`6c77f9b0`). Safe to move back to a tagged release once upstream cuts one.

## Test plan
- [x] Confirmed the pinned commit's `elf_types.hpp` contains `#include <cstdint>` via the GitHub API
- [x] Verified this unblocks a full `tt-metal` build on aarch64/GCC 16 that was previously failing with `unknown type name 'uint16_t'` in `ttexalens_elf`