### PR TITLE
Elf variable reference fixes

### DIFF
--- a/riscv-src/callstack.cc
+++ b/riscv-src/callstack.cc
@@ -277,6 +277,11 @@ __attribute__((noinline)) void dispatch(uint32_t type_index) {
     register type reg_value asm("s2") = host_value<type>((slot) * 8); \
     asm volatile("" : "+r"(reg_value))
 
+// As above, but binds a reference to that slot, so s2 holds the referent's address.
+#define DECLARE_CALLEE_SAVED_REFERENCE(type, slot)                                                      \
+    register type& reg_value asm("s2") = *reinterpret_cast<type*>(mailbox_value_buffer() + (slot) * 8); \
+    asm volatile("" : : "r"(&reg_value))
+
 // Keeps reg_value live past the nested call so it is preserved in - or spilled from - s2.
 #define USE_CALLEE_SAVED_VALUE() asm volatile("" : : "r"(reg_value))
 
@@ -361,7 +366,19 @@ __attribute__((noinline, noclone)) void value_test_charptr() {
 }
 }  // namespace callee_saved_test
 
+namespace reference_test {
+// Like callee_saved_test, but s2 holds a reference. Its register-direct DWARF
+// location makes it materialised, so following it has to reach live memory.
+
+__attribute__((noinline, noclone)) void run() {
+    DECLARE_CALLEE_SAVED_REFERENCE(volatile uint32_t, 0);
+    halt();
+    USE_CALLEE_SAVED_VALUE();
+}
+}  // namespace reference_test
+
 #undef DECLARE_CALLEE_SAVED_VALUE
+#undef DECLARE_CALLEE_SAVED_REFERENCE
 #undef USE_CALLEE_SAVED_VALUE
 
 namespace tail_call_test {
@@ -522,7 +539,8 @@ __attribute__((noinline)) int run(int a) {
 int main() {
     if (*g_MAILBOX != 0xFFFFFFFF && *g_MAILBOX != 0xFFFFFFFE && *g_MAILBOX != 0xFFFFFFFD && *g_MAILBOX != 0xFFFFFFFC &&
         *g_MAILBOX != 0xFFFFFFFB && *g_MAILBOX != 0xFFFFFFFA && *g_MAILBOX != 0xFFFFFFF9 && *g_MAILBOX != 0xFFFFFFF8 &&
-        *g_MAILBOX != 0xFFFFFFF7 && (*g_MAILBOX & 0xFFFFFF00) != 0xFFFFFE00 && (*g_MAILBOX < 0 || *g_MAILBOX > 1000)) {
+        *g_MAILBOX != 0xFFFFFFF7 && *g_MAILBOX != 0xFFFFFFF6 && (*g_MAILBOX & 0xFFFFFF00) != 0xFFFFFE00 &&
+        (*g_MAILBOX < 0 || *g_MAILBOX > 1000)) {
         *g_MAILBOX = 10;
     }
 
@@ -548,6 +566,8 @@ int main() {
         tail_branch_test::run(host_value<int>(0));
     } else if (*g_MAILBOX == 0xFFFFFFF7) {
         tail_multi_test::run(host_value<int>(0));
+    } else if (*g_MAILBOX == 0xFFFFFFF6) {
+        reference_test::run();
     } else {
         int sum = recurse(*g_MAILBOX);
         *g_MAILBOX = sum;

--- a/riscv-src/callstack.cc
+++ b/riscv-src/callstack.cc
@@ -536,11 +536,16 @@ __attribute__((noinline)) int run(int a) {
 }
 }  // namespace tail_multi_test
 
+// Scenario selectors occupy the top of the range plus the 0xFFFFFE00 block; any
+// other value is a recursion count. Lower the bound when adding a scenario.
+constexpr uint32_t kLowestScenarioSelector = 0xFFFFFFF6;
+
+static bool is_scenario_selector(uint32_t mailbox) {
+    return mailbox >= kLowestScenarioSelector || (mailbox & 0xFFFFFF00) == 0xFFFFFE00;
+}
+
 int main() {
-    if (*g_MAILBOX != 0xFFFFFFFF && *g_MAILBOX != 0xFFFFFFFE && *g_MAILBOX != 0xFFFFFFFD && *g_MAILBOX != 0xFFFFFFFC &&
-        *g_MAILBOX != 0xFFFFFFFB && *g_MAILBOX != 0xFFFFFFFA && *g_MAILBOX != 0xFFFFFFF9 && *g_MAILBOX != 0xFFFFFFF8 &&
-        *g_MAILBOX != 0xFFFFFFF7 && *g_MAILBOX != 0xFFFFFFF6 && (*g_MAILBOX & 0xFFFFFF00) != 0xFFFFFE00 &&
-        (*g_MAILBOX < 0 || *g_MAILBOX > 1000)) {
+    if (!is_scenario_selector(*g_MAILBOX) && *g_MAILBOX > 1000) {
         *g_MAILBOX = 10;
     }
 

--- a/riscv-src/globals_test.cc
+++ b/riscv-src/globals_test.cc
@@ -152,6 +152,25 @@ GlobalStruct g_global_struct;
 GlobalStruct* const g_global_const_struct_ptr = (GlobalStruct*)(0x30000);
 thread_local GlobalStruct g_global_tls_struct;
 
+[[gnu::used]] GlobalStruct& g_global_struct_ref = g_global_struct;
+[[gnu::used]] uint32_t&& g_uint_rvalue_ref = 0x5A5A1234;
+
+struct RefStruct {
+    uint32_t& a_ref;
+    InnerStruct& inner_ref;
+    uint32_t (&array_ref)[4];
+    const char*& string_pointer_ref;
+    char (&string_buffer_ref)[32];
+};
+
+[[gnu::used]] RefStruct g_ref_struct = {
+    g_global_struct.a,
+    g_global_struct.d[2],
+    g_global_struct.uint_array,
+    g_global_struct.string_pointer,
+    g_global_struct.string_buffer,
+};
+
 void halt() {
     // Halt core with ebrake instruction
     asm volatile("ebreak");

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -13,7 +13,7 @@ from ttexalens.context import Context
 from ttexalens.elf import ElfFile, ElfVariable
 from ttexalens.exceptions import RiscHaltError
 from ttexalens.memory_access import MemoryAccess, create_memory_access
-from ttexalens.exceptions import RestrictedMemoryAccessError
+from ttexalens.exceptions import DataLossError, RestrictedMemoryAccessError, SymbolNotFoundError, TypeMismatchError
 from ttexalens.umd_device import TimeoutDeviceRegisterError
 
 from parameterized import parameterized
@@ -312,6 +312,35 @@ class TestDebugSymbols(unittest.TestCase):
         self.verify_global_struct(g_global_struct)
         self.assertEqual(self.mem_access.read_count, 1)
 
+    def test_elf_reference_global_variable(self):
+        # A reference has no value of its own - every operation resolves the referent.
+        g_global_struct = self.parsed_elf.get_global("g_global_struct_ref", TestDebugSymbols.mem_access)
+        self.verify_global_struct(g_global_struct)
+        self.assertEqual(0x11223344, g_global_struct.dereference().a)
+
+        # An rvalue reference resolves the same way.
+        self.assertEqual(0x5A5A1234, self.parsed_elf.get_global("g_uint_rvalue_ref", TestDebugSymbols.mem_access))
+
+    def test_elf_reference_struct_members(self):
+        # Reference members mirror GlobalStruct's pointer members: reaching one
+        # walks the struct offset first, then resolves through the reference.
+        g_ref_struct = self.parsed_elf.get_global("g_ref_struct", TestDebugSymbols.mem_access)
+        self.assertEqual(0x11223344, g_ref_struct.a_ref)
+        self.assertEqual(2 * 2, g_ref_struct.inner_ref.x)
+        self.assertEqual(2 * 2 + 1, g_ref_struct.inner_ref.y)
+        self.assertEqual(4, len(g_ref_struct.array_ref))
+        self.assertEqual([0x11111111, 0x22222222, 0x33333333, 0x44444444], g_ref_struct.array_ref.as_value_list())
+        # A reference to a char array, and a reference to a char pointer.
+        self.assertEqual("Hello, struct!", g_ref_struct.string_buffer_ref)
+        self.assertEqual("pointer to string", g_ref_struct.string_pointer_ref)
+
+    def test_read_elf_reference_global_variable(self):
+        self.mem_access.reset_stats()
+        g_global_struct = self.parsed_elf.read_global("g_global_struct_ref", TestDebugSymbols.mem_access)
+        self.verify_global_struct(g_global_struct)
+        # Two reads: the reference slot, then the referent snapshot.
+        self.assertEqual(self.mem_access.read_count, 2)
+
     def test_symtab_fallback_address(self):
         """Variables declared `extern` (no DW_AT_location on the DIE) need
         the .symtab fallback in DwarfDie::get_address. Anchored by
@@ -593,6 +622,12 @@ class TestDebugSymbols(unittest.TestCase):
         g_global_struct.string_buffer.write_value("Hello, struct!")  # Restore original value
         self.assertEqual("Hello, struct!", g_global_struct.string_buffer)
 
+        # A write through a reference lands on the referent.
+        a_ref = self.parsed_elf.get_global("g_ref_struct", TestDebugSymbols.mem_access).a_ref
+        a_ref.write_value(0xDEADBEEF)
+        self.assertEqual(0xDEADBEEF, g_global_struct.a)
+        a_ref.write_value(0x11223344)  # Restore original value
+
     def test_elf_variable_string(self):
         """C-style strings (char array and char pointer) are read as their text via read_value."""
         g_global_struct = self.parsed_elf.get_global("g_global_struct", TestDebugSymbols.mem_access)
@@ -608,6 +643,18 @@ class TestDebugSymbols(unittest.TestCase):
 
         # A non-char array (uint8_t[16]) is not a string - it is still read as numbers.
         self.assertEqual(list(range(16)), g_global_struct.c.as_value_list())
+
+    def test_elf_variable_exception_translation(self):
+        # Without nanobind's std::string/std::optional casters the native layer's
+        # exceptions all degrade to `RuntimeError: std::bad_cast`, so pin the mapping.
+        g_global_struct = self.parsed_elf.get_global("g_global_struct", TestDebugSymbols.mem_access)
+        self.assertRaises(
+            SymbolNotFoundError, self.parsed_elf.get_global, "no_such_global", TestDebugSymbols.mem_access
+        )
+        self.assertRaises(SymbolNotFoundError, lambda: g_global_struct.no_such_field.read_value())
+        self.assertRaises(TypeMismatchError, lambda: g_global_struct.a.dereference())
+        self.assertRaises(TypeMismatchError, lambda: g_global_struct.read_value())
+        self.assertRaises(DataLossError, lambda: g_global_struct.a.write_value(2.5))
 
     @parameterized.expand(
         [

--- a/test/ttexalens/unit_tests/test_debug_symbols.py
+++ b/test/ttexalens/unit_tests/test_debug_symbols.py
@@ -570,6 +570,23 @@ class TestDebugSymbols(unittest.TestCase):
         self.assertEqual(self.mem_access.read_count, 0)
         self.assertEqual(self.mem_access.total_bytes_read, 0)
 
+        # Test references
+        g_ref_struct = self.parsed_elf.get_global("g_ref_struct", TestDebugSymbols.mem_access)
+        a_ref = g_ref_struct.a_ref
+        self.assertTrue(a_ref == 0x11223344)
+        self.assertTrue(a_ref != 0x12345678)
+        self.assertTrue(a_ref < g_global_struct.b)
+        self.assertTrue(a_ref >= 0x11223344)
+        self.assertEqual(a_ref * g_global_struct.c[2], 0x11223344 * 2)
+        self.assertEqual(a_ref + 1, 0x11223345)
+        self.assertEqual(0x100000000 - a_ref, 0x100000000 - 0x11223344)
+        self.assertEqual(a_ref & 0xFF, 0x44)
+        self.assertEqual(a_ref >> 16, 0x1122)
+        self.assertEqual(-a_ref, -0x11223344)
+        self.assertEqual(str(a_ref), str(0x11223344))
+        self.assertEqual(format(a_ref, "08x"), format(0x11223344, "08x"))
+        self.assertEqual([0, 1, 2, 3, 4][g_ref_struct.inner_ref.x], 4)
+
     def test_elf_variable_hash(self):
         g_global_struct1 = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_access)
         g_global_struct2 = self.parsed_elf.read_global("g_global_struct", TestDebugSymbols.mem_access)

--- a/test/ttexalens/unit_tests/test_lib.py
+++ b/test/ttexalens/unit_tests/test_lib.py
@@ -2082,6 +2082,32 @@ class TestCallStack(unittest.TestCase):
                 address = self.get_symbol_address(parsed_elf, struct_format)
                 self.assert_string_pointer(frame.locals[0], "reg_value", address, f"reg_value of {function_name}")
 
+    @parameterized.expand(CALLSTACK_ELFS)
+    def test_callstack_register_reference_value(self, elf_name: str):
+        if self.device.is_blackhole() and self.risc_name == "trisc2":
+            self.skipTest("This test doesn't work as expected due to blackhole trisc2 hardware bug, tt-exalens:#528")
+
+        elf_path = self.get_elf_path(elf_name)
+        parsed_elf = get_parsed_elf_file(elf_path)
+        # reg_value references slot 0 of the value buffer.
+        self.l1_mem_access.write(self.get_mailbox_value_address(parsed_elf), struct.pack("<I", 0x5A5A1234))
+        # 0xFFFFFFF6 selects reference_test::run.
+        self.set_recursion_count(parsed_elf, 0xFFFFFFF6)
+        self.loader.run_elf(parsed_elf)
+        callstack: list[CallstackEntry] = lib.callstack(
+            self.location, parsed_elf, None, self.risc_name, None, 100, True
+        )
+
+        # The callstack is: halt, reference_test::run, main.
+        frame = callstack[1]
+        self.assertIn(frame.function_name, ("reference_test::run", "run"))
+        self.assertEqual(len(frame.locals), 1)
+        reg_value = frame.locals[0]
+        self.assertEqual(reg_value.name, "reg_value")
+        assert reg_value.value is not None
+        # The reference is materialised in the register, so following it reads live memory.
+        self.assertEqual(0x5A5A1234, reg_value.value.dereference().read_value())
+
     @parameterized.expand(
         [
             ("abcd", "build/riscv-src/blackhole/callstack.debug.brisc.elf"),  # Invalid location string

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -392,7 +392,7 @@ DwarfDiePtr DwarfDie::get_resolved_type() const {
 
 DwarfDiePtr DwarfDie::get_dereference_type() const {
     const DwarfDieTag tag = get_tag();
-    if (tag != DwarfDieTag::pointer_type && tag != DwarfDieTag::reference_type) {
+    if (tag != DwarfDieTag::pointer_type && !is_reference_tag(tag)) {
         return nullptr;
     }
     auto pointee = get_die_from_attribute(DwarfAttributeTag::type);

--- a/ttexalens/cpp/elf/dwarf_die.cpp
+++ b/ttexalens/cpp/elf/dwarf_die.cpp
@@ -966,7 +966,9 @@ std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) co
     }
     // Literal value (DW_OP_stack_value / register-direct / composite via
     // DW_OP_piece): synthesise a backing buffer holding the materialised
-    // bytes and hand back a ElfVariable that reads from it.
+    // bytes and hand back a ElfVariable that reads from it. The frame's
+    // memory access stays the cache's base so that a materialised pointer or
+    // reference can still be dereferenced into live memory.
     auto size_opt = resolved->get_size();
     if (!size_opt) {
         return std::nullopt;
@@ -982,7 +984,7 @@ std::optional<ElfVariable> DwarfDie::read_value(const FrameInspection& frame) co
         uint64_t raw = *location->value;
         std::memcpy(bytes.data(), &raw, std::min(size, static_cast<uint64_t>(sizeof(raw))));
     }
-    auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(bytes), NoMemoryAccess::instance());
+    auto cache = std::make_shared<CachedReadMemoryAccess>(0, std::move(bytes), frame.get_memory_access());
     return ElfVariable(resolved, 0, std::move(cache));
 }
 

--- a/ttexalens/cpp/elf/dwarf_die.hpp
+++ b/ttexalens/cpp/elf/dwarf_die.hpp
@@ -154,6 +154,11 @@ enum class DwarfDieTag : Dwarf_Half {
     with_stmt = DW_TAG_with_stmt,
 };
 
+// Lvalue and rvalue references.
+constexpr bool is_reference_tag(DwarfDieTag tag) {
+    return tag == DwarfDieTag::reference_type || tag == DwarfDieTag::rvalue_reference_type;
+}
+
 // Source location for a particular program counter — returned by
 // DwarfInfo::find_file_line_by_address.
 struct DwarfFileLine {

--- a/ttexalens/cpp/elf/variable.cpp
+++ b/ttexalens/cpp/elf/variable.cpp
@@ -156,7 +156,8 @@ uint64_t ElfVariable::get_size() const {
 }
 
 ElfVariable ElfVariable::get_member(std::string_view member_name) const {
-    if (type_die->get_tag() == DwarfDieTag::pointer_type) {
+    const DwarfDieTag member_tag = type_die->get_tag();
+    if (member_tag == DwarfDieTag::pointer_type || member_tag == DwarfDieTag::reference_type) {
         return dereference().get_member(member_name);
     }
 
@@ -194,7 +195,8 @@ ElfVariable ElfVariable::get_member(std::string_view member_name) const {
 }
 
 ElfVariable ElfVariable::dereference() const {
-    if (type_die->get_tag() != DwarfDieTag::pointer_type) {
+    const DwarfDieTag tag = type_die->get_tag();
+    if (tag != DwarfDieTag::pointer_type && tag != DwarfDieTag::reference_type) {
         throw TypeMismatchException("dereference", type_die->get_path());
     }
     auto ptr_size = type_die->get_size();

--- a/ttexalens/cpp/elf/variable.cpp
+++ b/ttexalens/cpp/elf/variable.cpp
@@ -157,7 +157,7 @@ uint64_t ElfVariable::get_size() const {
 
 ElfVariable ElfVariable::get_member(std::string_view member_name) const {
     const DwarfDieTag member_tag = type_die->get_tag();
-    if (member_tag == DwarfDieTag::pointer_type || member_tag == DwarfDieTag::reference_type) {
+    if (member_tag == DwarfDieTag::pointer_type || is_reference_tag(member_tag)) {
         return dereference().get_member(member_name);
     }
 
@@ -196,7 +196,7 @@ ElfVariable ElfVariable::get_member(std::string_view member_name) const {
 
 ElfVariable ElfVariable::dereference() const {
     const DwarfDieTag tag = type_die->get_tag();
-    if (tag != DwarfDieTag::pointer_type && tag != DwarfDieTag::reference_type) {
+    if (tag != DwarfDieTag::pointer_type && !is_reference_tag(tag)) {
         throw TypeMismatchException("dereference", type_die->get_path());
     }
     auto ptr_size = type_die->get_size();
@@ -215,6 +215,9 @@ ElfVariable ElfVariable::dereference() const {
 
 ElfVariable ElfVariable::get_index(int64_t i) const {
     const auto tag = type_die->get_tag();
+    if (is_reference_tag(tag)) {
+        return dereference().get_index(i);
+    }
     if (tag != DwarfDieTag::array_type && tag != DwarfDieTag::pointer_type) {
         throw TypeMismatchException("index", type_die->get_path());
     }
@@ -239,7 +242,11 @@ ElfVariable ElfVariable::get_index(int64_t i) const {
 }
 
 uint64_t ElfVariable::get_length() const {
-    if (type_die->get_tag() != DwarfDieTag::array_type) {
+    const auto tag = type_die->get_tag();
+    if (is_reference_tag(tag)) {
+        return dereference().get_length();
+    }
+    if (tag != DwarfDieTag::array_type) {
         throw TypeMismatchException("len", type_die->get_path());
     }
     for (auto child = type_die->get_first_child(); child; child = child->get_next_sibling()) {
@@ -278,6 +285,10 @@ std::vector<std::byte> ElfVariable::read_bytes() const {
 ElfVariable::Value ElfVariable::read_value() const {
     auto type = type_die;
     const auto tag = type->get_tag();
+
+    if (is_reference_tag(tag)) {
+        return dereference().read_value();
+    }
 
     // C strings: char[] and char* are returned as Python str.
     if (type->is_string_type()) {
@@ -352,6 +363,12 @@ ElfVariable::Value ElfVariable::read_value() const {
 void ElfVariable::write_value(Value value, bool check_data_loss) {
     auto type = type_die;
     const auto tag = type->get_tag();
+
+    if (is_reference_tag(tag)) {
+        ElfVariable target = dereference();
+        target.write_value(std::move(value), check_data_loss);
+        return;
+    }
 
     // C string write: only `char[]` is accepted (char* would have to allocate,
     // which we don't model). The supplied string + NUL must fit the array.
@@ -498,7 +515,8 @@ void ElfVariable::write_value(Value value, bool check_data_loss) {
 }
 
 ElfVariable ElfVariable::read() const {
-    if (type_die->get_tag() == DwarfDieTag::pointer_type) {
+    const DwarfDieTag tag = type_die->get_tag();
+    if (tag == DwarfDieTag::pointer_type || is_reference_tag(tag)) {
         return dereference().read();
     }
     auto data = read_bytes();

--- a/ttexalens/cpp/nanobind/bindings.cpp
+++ b/ttexalens/cpp/nanobind/bindings.cpp
@@ -5,6 +5,8 @@
 
 #include <libdwarf.h>
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/string.h>
 
 #include <exception>
 
@@ -16,6 +18,19 @@ namespace ttexalens::native_elf::bindings {
 
 namespace {
 
+// Raises ttexalens.exceptions.<class_name>(args...). If building it fails the
+// failure must not escape, or it gets reported instead of the error being
+// translated (e.g. SymbolNotFoundError surfacing as "RuntimeError: std::bad_cast").
+template <typename... Args>
+void raise_mapped(const std::exception& source, const char* class_name, Args&&... args) {
+    try {
+        auto exc = nb::module_::import_("ttexalens.exceptions").attr(class_name)(std::forward<Args>(args)...);
+        PyErr_SetObject(PyExceptionInstance_Class(exc.ptr()), exc.ptr());
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, source.what());
+    }
+}
+
 // Translates the C++ ELF-variable exceptions into the existing Python
 // exception classes so test code that does `except SymbolNotFoundError:`
 // (etc.) keeps working unchanged when the throws originate in C++.
@@ -24,20 +39,13 @@ void register_exception_translators() {
         try {
             std::rethrow_exception(p);
         } catch (const SymbolNotFoundException& e) {
-            auto exc = nb::module_::import_("ttexalens.exceptions").attr("SymbolNotFoundError")(e.member_path());
-            PyErr_SetObject(PyExceptionInstance_Class(exc.ptr()), exc.ptr());
+            raise_mapped(e, "SymbolNotFoundError", e.member_path());
         } catch (const TypeMismatchException& e) {
-            auto exc =
-                nb::module_::import_("ttexalens.exceptions").attr("TypeMismatchError")(e.operation(), e.actual_type());
-            PyErr_SetObject(PyExceptionInstance_Class(exc.ptr()), exc.ptr());
+            raise_mapped(e, "TypeMismatchError", e.operation(), e.actual_type());
         } catch (const InvalidArrayAccessException& e) {
-            auto length = e.length().has_value() ? nb::cast(*e.length()) : nb::cast(nb::none());
-            auto exc = nb::module_::import_("ttexalens.exceptions").attr("InvalidArrayAccessError")(e.index(), length);
-            PyErr_SetObject(PyExceptionInstance_Class(exc.ptr()), exc.ptr());
+            raise_mapped(e, "InvalidArrayAccessError", e.index(), e.length());
         } catch (const DataLossException& e) {
-            auto exc =
-                nb::module_::import_("ttexalens.exceptions").attr("DataLossError")(e.value_repr(), e.type_name());
-            PyErr_SetObject(PyExceptionInstance_Class(exc.ptr()), exc.ptr());
+            raise_mapped(e, "DataLossError", e.value_repr(), e.type_name());
         }
     });
 }


### PR DESCRIPTION
- References are now walked like the object they name (read/write/dereference/etc).
- A pointer/reference held in a register (DW_OP_reg*) now falls back to the frame's memory access instead of NoMemoryAccess, so it can actually be followed.
- Fixes exception translation: `bindings.cpp` was missing nanobind's std::string/std::optional casters, so every native error surfaced as `RuntimeError: std::bad_cast` instead of `SymbolNotFoundError`/`TypeMismatchError`/`DataLossError`/etc.