### PR TITLE
Use umd's telemetry tags instead of hardcoded list

### DIFF
--- a/ttexalens/hardware/arc_block.py
+++ b/ttexalens/hardware/arc_block.py
@@ -18,49 +18,8 @@ from ttexalens.util import FirmwareVersion
 
 CUTOFF_FIRMWARE_VERSION = FirmwareVersion(18, 4, 0)
 
-telemetry_tags_map: dict[str, int] = {
-    "BOARD_ID_HIGH": 1,
-    "BOARD_ID_LOW": 2,
-    "ASIC_ID": 3,
-    "HARVESTING_STATE": 4,
-    "UPDATE_TELEM_SPEED": 5,
-    "VCORE": 6,
-    "TDP": 7,
-    "TDC": 8,
-    "VDD_LIMITS": 9,
-    "THM_LIMITS": 10,
-    "ASIC_TEMPERATURE": 11,
-    "VREG_TEMPERATURE": 12,
-    "BOARD_TEMPERATURE": 13,
-    "AICLK": 14,
-    "AXICLK": 15,
-    "ARCCLK": 16,
-    "L2CPUCLK0": 17,
-    "L2CPUCLK1": 18,
-    "L2CPUCLK2": 19,
-    "L2CPUCLK3": 20,
-    "ETH_LIVE_STATUS": 21,
-    "DDR_STATUS": 22,
-    "DDR_SPEED": 23,
-    "ETH_FW_VERSION": 24,
-    "DDR_FW_VERSION": 25,
-    "BM_APP_FW_VERSION": 26,
-    "BM_BL_FW_VERSION": 27,
-    "FLASH_BUNDLE_VERSION": 28,
-    "CM_FW_VERSION": 29,
-    "L2CPU_FW_VERSION": 30,
-    "FAN_SPEED": 31,
-    "TIMER_HEARTBEAT": 32,
-    "TELEMETRY_ENUM_COUNT": 33,
-    "ENABLED_TENSIX_COL": 34,
-    "ENABLED_ETH": 35,
-    "ENABLED_GDDR": 36,
-    "ENABLED_L2CPU": 37,
-    "PCIE_USAGE": 38,
-    "NUMBER_OF_TAGS": 39,
-    "ASIC_LOCATION": 52,
-    "AICLK_LIMIT_MAX": 63,
-}
+# ARC telemetry tags are defined by UMD (tt::umd::TelemetryTag)
+telemetry_tags_map: dict[str, int] = {tag.name: tag.value for tag in tt_umd.TelemetryTag}
 
 
 class ArcBlock(NocBlock):
@@ -83,15 +42,13 @@ class ArcBlock(NocBlock):
             )
         return tag_id in self.telemetry_tag_ids
 
-    def get_telemetry_tag_id(self, tag_name) -> int | None:
+    def get_telemetry_tag_id(self, tag_name: str) -> int | None:
         """Returns the telemetry tag ID for a given tag name."""
         if self.telemetry_tags is None:
             raise TTException(
                 f"We no longer support ARC telemetry for firmware versions 18.3 and lower. This device is running firmware version {self.location.device.firmware_version}"
             )
-        if tag_name in self.telemetry_tags:
-            return self.telemetry_tags[tag_name]
-        return None
+        return self.telemetry_tags.get(tag_name)
 
     def run_arc_core(self, mask: int):
         """Runs the arc core specified by the mask.


### PR DESCRIPTION
In `arc_block` we hardcoded a list of telemetry tags, which since then changed and updated a couple times in umd. Now umd exposes that map so we should align.